### PR TITLE
Changed PacketProcessor (and Preprocessor) to have a non-static imple…

### DIFF
--- a/GameServer/packets/Client/168/PlayerHeadingUpdateHandler.cs
+++ b/GameServer/packets/Client/168/PlayerHeadingUpdateHandler.cs
@@ -55,7 +55,10 @@ namespace DOL.GS.PacketHandler.Client.v168
 			client.Player.TargetInView = ((flags & 0x10) != 0);
 
 			byte[] con = packet.ToArray();
-			if (!client.Player.IsAlive)
+            con[0] = (byte)(client.SessionID >> 8);
+            con[1] = (byte)(client.SessionID & 0xff);
+
+            if (!client.Player.IsAlive)
 			{
 				con[9] = 5; // set dead state
 			}

--- a/GameServer/packets/Client/168/PlayerPositionUpdateHandler.cs
+++ b/GameServer/packets/Client/168/PlayerPositionUpdateHandler.cs
@@ -620,8 +620,11 @@ namespace DOL.GS.PacketHandler.Client.v168
 			//**************//
 
 			byte[] con168 = packet.ToArray();
-			//Riding is set here!
-			if (client.Player.Steed != null && client.Player.Steed.ObjectState == GameObject.eObjectState.Active)
+            con168[0] = (byte)(client.SessionID >> 8);
+            con168[1] = (byte)(client.SessionID & 0xff);
+
+            //Riding is set here!
+            if (client.Player.Steed != null && client.Player.Steed.ObjectState == GameObject.eObjectState.Active)
 			{
 				client.Player.Heading = client.Player.Steed.Heading;
 

--- a/GameServer/packets/Server/PacketPreprocessing.cs
+++ b/GameServer/packets/Server/PacketPreprocessing.cs
@@ -44,17 +44,17 @@ namespace DOL.GS.PacketHandler
 	/// with it, and thus we pass it thru. (return true)
 	/// </para>
 	/// </remarks>
-	public static class PacketPreprocessing
+	public class PacketPreprocessing
 	{
 		/// <summary>
 		/// Defines a logger for this class.
 		/// </summary>
-		private static readonly ILog log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+		private readonly ILog log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 		
-		private static readonly Dictionary<int, int> _packetIdToPreprocessMap;
-		private static readonly Dictionary<int, Func<GameClient, GSPacketIn, bool>> _preprocessors;
+		private readonly Dictionary<int, int> _packetIdToPreprocessMap;
+		private readonly Dictionary<int, Func<GameClient, GSPacketIn, bool>> _preprocessors;
 
-		static PacketPreprocessing()
+		public PacketPreprocessing()
 		{
 			_packetIdToPreprocessMap = new Dictionary<int, int>();
 			_preprocessors = new Dictionary<int, Func<GameClient, GSPacketIn, bool>>();
@@ -68,7 +68,7 @@ namespace DOL.GS.PacketHandler
 		/// </summary>
 		/// <param name="packetId">the ID of the packet in question</param>
 		/// <param name="preprocessorId">the ID of the preprocessor for the given packet ID</param>
-		public static void RegisterPacketDefinition(int packetId, int preprocessorId)
+		public void RegisterPacketDefinition(int packetId, int preprocessorId)
 		{
 			// if they key doesn't exist, add it, and if it does, replace it
 			if (!_packetIdToPreprocessMap.ContainsKey(packetId))
@@ -87,7 +87,7 @@ namespace DOL.GS.PacketHandler
 		/// </summary>
 		/// <param name="preprocessorId">the ID for the preprocessor</param>
 		/// <param name="preprocessorFunc">the preprocessor delegate to use</param>
-		public static void RegisterPreprocessors(int preprocessorId, Func<GameClient, GSPacketIn, bool> preprocessorFunc)
+		public void RegisterPreprocessors(int preprocessorId, Func<GameClient, GSPacketIn, bool> preprocessorFunc)
 		{
 			_preprocessors.Add(preprocessorId, preprocessorFunc);
 		}
@@ -98,7 +98,7 @@ namespace DOL.GS.PacketHandler
 		/// <param name="client">the client that sent the packet</param>
 		/// <param name="packet">the packet in question</param>
 		/// <returns>true if the packet passes all preprocessor checks; false otherwise</returns>
-		public static bool CanProcessPacket(GameClient client, GSPacketIn packet)
+		public bool CanProcessPacket(GameClient client, GSPacketIn packet)
 		{
 			int preprocessorId;
 			if(!_packetIdToPreprocessMap.TryGetValue(packet.ID, out preprocessorId))


### PR DESCRIPTION
…mentation. This opens the way to having client specific Client->Server handlers. To speed up the implementation caching is used to save IPacketHandler lists for different versions - assemblies are only searched for the first login, thereafter the cache is used.

This would be a nice feature to work towards. For example, rather than having a single PlayerPositionUpdateHandler that has hard-coded logic to switch different client versions, we could have a separate v168.PlayerPositionUpdateHandler, v192.PlayerPositionUpdateHandler etc.