### PR TITLE
Config option preventing GameServerScript compilation to plug a debugger

### DIFF
--- a/DOLConfig/serverconfig_extraproperties.xml
+++ b/DOLConfig/serverconfig_extraproperties.xml
@@ -64,6 +64,12 @@
     <description>List of Script assembies</description>
   </Server>
   <Server>
+    <property>EnableCompilation</property>
+    <type>bool</type>
+    <value></value>
+    <description>Enables or Disables Startup Game Server Scripts Compilation</description>
+  </Server>
+  <Server>
     <property>EnableUPnP</property>
     <type>boolean</type>
     <value>true</value>

--- a/GameServer/GameServerConfiguration.cs
+++ b/GameServer/GameServerConfiguration.cs
@@ -54,6 +54,11 @@ namespace DOL.GS
 		/// The assemblies to include when compiling the scripts
 		/// </summary>
 		protected string m_scriptAssemblies;
+		
+		/// <summary>
+		/// Enable/Disable Startup Script Compilation
+		/// </summary>
+		protected bool m_enableCompilation;
 
 		/// <summary>
 		/// True if the server shall automatically create accounts
@@ -148,6 +153,7 @@ namespace DOL.GS
 
 			m_scriptCompilationTarget = root["Server"]["ScriptCompilationTarget"].GetString(m_scriptCompilationTarget);
 			m_scriptAssemblies = root["Server"]["ScriptAssemblies"].GetString(m_scriptAssemblies);
+			m_enableCompilation = root["Server"]["EnableCompilation"].GetBoolean(true);
 			m_autoAccountCreation = root["Server"]["AutoAccountCreation"].GetBoolean(m_autoAccountCreation);
 
 			string serverType = root["Server"]["GameType"].GetString("Normal");
@@ -250,6 +256,7 @@ namespace DOL.GS
 
 			root["Server"]["ScriptCompilationTarget"].Set(m_scriptCompilationTarget);
 			root["Server"]["ScriptAssemblies"].Set(m_scriptAssemblies);
+			root["Server"]["EnableCompilation"].Set(m_enableCompilation);
 			root["Server"]["AutoAccountCreation"].Set(m_autoAccountCreation);
 
 			string serverType = "Normal";
@@ -417,10 +424,19 @@ namespace DOL.GS
 			get
 			{
 				return m_scriptAssemblies.Split(',')
-					.Union(new DirectoryInfo(string.Format("{0}{1}lib", RootDirectory, Path.DirectorySeparatorChar))
-					       .EnumerateFiles("*.dll", SearchOption.TopDirectoryOnly).Select(f => f.Name).Where(f => !f.ToLower().Equals(new FileInfo(ScriptCompilationTarget).Name.ToLower())))
+					.Union(new DirectoryInfo(Path.Combine(RootDirectory, "lib"))
+					       .EnumerateFiles("*.dll", SearchOption.TopDirectoryOnly).Select(f => f.Name).Where(f => !f.Equals(new FileInfo(ScriptCompilationTarget).Name, StringComparison.OrdinalIgnoreCase)))
 					.ToArray();
 			}
+		}
+		
+		/// <summary>
+		/// Get or Set the Compilation Flag
+		/// </summary>
+		public bool EnableCompilation
+		{
+			get { return m_enableCompilation; }
+			set { m_enableCompilation = value; }
 		}
 
 		/// <summary>

--- a/GameServer/GameServerConfiguration.cs
+++ b/GameServer/GameServerConfiguration.cs
@@ -339,25 +339,28 @@ namespace DOL.GS
 		{
 			m_ServerName = "Dawn Of Light";
 			m_ServerNameShort = "DOLSERVER";
-			if(Assembly.GetEntryAssembly()!=null)
+			
+			if (Assembly.GetEntryAssembly() != null)
 				m_rootDirectory = new FileInfo(Assembly.GetEntryAssembly().Location).DirectoryName;
 			else
 				m_rootDirectory = new FileInfo(Assembly.GetAssembly(typeof(GameServer)).Location).DirectoryName;
 
-			m_logConfigFile = "." + Path.DirectorySeparatorChar + "config" + Path.DirectorySeparatorChar + "logconfig.xml";
+			m_logConfigFile = Path.Combine(Path.Combine(".", "config"), "logconfig.xml");
 
-			m_scriptCompilationTarget = "."+Path.DirectorySeparatorChar+"lib"+Path.DirectorySeparatorChar+"GameServerScripts.dll";
+			m_scriptCompilationTarget = Path.Combine(Path.Combine(".", "lib"), "GameServerScripts.dll");
 			m_scriptAssemblies = "System.dll,System.Xml.dll";
+			m_enableCompilation = true;
 			m_autoAccountCreation = true;
 			m_serverType = eGameServerType.GST_Normal;
 
 			m_cheatLoggerName = "cheats";
 			m_gmActionsLoggerName = "gmactions";
 		    InventoryLoggerName = "inventories";
-			m_invalidNamesFile = "." + Path.DirectorySeparatorChar + "config" + Path.DirectorySeparatorChar + "invalidnames.txt";
+		    m_invalidNamesFile = Path.Combine(Path.Combine(".", "config"), "invalidnames.txt");
 
 			m_dbType = ConnectionType.DATABASE_SQLITE;
-			m_dbConnectionString = "Data Source="+m_rootDirectory+Path.DirectorySeparatorChar+"dol.sqlite3.db"+";Version=3;Pooling=False;Cache Size=1073741824;Journal Mode=Off;Synchronous=Off;Foreign Keys=True;Default Timeout=60";
+			m_dbConnectionString = string.Format("Data Source={0};Version=3;Pooling=False;Cache Size=1073741824;Journal Mode=Off;Synchronous=Off;Foreign Keys=True;Default Timeout=60",
+			                                     Path.Combine(m_rootDirectory, "dol.sqlite3.db"));
 			m_autoSave = true;
 			m_saveInterval = 10;
 			m_maxClientCount = 500;

--- a/GameServer/commands/gmcommands/Instance.cs
+++ b/GameServer/commands/gmcommands/Instance.cs
@@ -125,12 +125,8 @@ namespace DOL.GS.Commands
 								GameObject obj = null;
 
 								//Now we have the classtype to create, create it thus!
-								ArrayList asms = new ArrayList();
-								asms.Add(typeof(GameServer).Assembly);
-								asms.AddRange(ScriptMgr.Scripts);
-
 								//This is required to ensure we check scripts for the space aswell, such as quests!
-								foreach (Assembly asm in asms)
+								foreach (Assembly asm in ScriptMgr.GameServerScripts)
 								{
 									obj = (GameObject)(asm.CreateInstance(theType, false));
 									if (obj != null)

--- a/GameServer/commands/gmcommands/merchant.cs
+++ b/GameServer/commands/gmcommands/merchant.cs
@@ -77,9 +77,7 @@ namespace DOL.GS.Commands
 
 						//Create a new merchant
 						GameMerchant merchant = null;
-						ArrayList asms = new ArrayList(ScriptMgr.Scripts);
-						asms.Add(typeof(GameServer).Assembly);
-						foreach (Assembly script in asms)
+						foreach (Assembly script in ScriptMgr.GameServerScripts)
 						{
 							try
 							{
@@ -403,9 +401,7 @@ namespace DOL.GS.Commands
 
 						//Create a new merchant
 						GameMerchant merchant = null;
-						ArrayList asms = new ArrayList(ScriptMgr.Scripts);
-						asms.Add(typeof(GameServer).Assembly);
-						foreach (Assembly script in asms)
+						foreach (Assembly script in ScriptMgr.GameServerScripts)
 						{
 							try
 							{

--- a/GameServer/commands/gmcommands/mob.cs
+++ b/GameServer/commands/gmcommands/mob.cs
@@ -295,10 +295,8 @@ namespace DOL.GS.Commands
 
 			//Create a new mob
 			GameNPC mob = null;
-			ArrayList asms = new ArrayList(ScriptMgr.Scripts);
-			asms.Add(typeof(GameServer).Assembly);
 
-			foreach (Assembly script in asms)
+			foreach (Assembly script in ScriptMgr.GameServerScripts)
 			{
 				try
 				{
@@ -2454,10 +2452,7 @@ namespace DOL.GS.Commands
 					}
 					else
 					{
-						ArrayList asms = new ArrayList(ScriptMgr.Scripts);
-						asms.Add(typeof(GameServer).Assembly);
-
-						foreach (Assembly script in asms)
+						foreach (Assembly script in ScriptMgr.GameServerScripts)
 						{
 							try
 							{

--- a/GameServer/commands/gmcommands/object.cs
+++ b/GameServer/commands/gmcommands/object.cs
@@ -361,10 +361,8 @@ namespace DOL.GS.Commands
 		GameStaticItem CreateItemInstance(GameClient client, string itemClassName)
 		{
 			GameStaticItem obj = null;
-			ArrayList asms = new ArrayList(ScriptMgr.Scripts);
-			asms.Add(typeof(GameServer).Assembly);
 
-			foreach (Assembly script in asms)
+			foreach (Assembly script in ScriptMgr.GameServerScripts)
 			{
 				try
 				{

--- a/GameServer/gameobjects/GameLiving.cs
+++ b/GameServer/gameobjects/GameLiving.cs
@@ -6721,10 +6721,7 @@ namespace DOL.GS
 		{
 			try
 			{
-				ArrayList asms = new ArrayList();
-				asms.Add(typeof(GameServer).Assembly);
-				asms.AddRange(ScriptMgr.Scripts);
-				foreach (Assembly asm in asms)
+				foreach (Assembly asm in ScriptMgr.GameServerScripts)
 				{
 					foreach (Type t in asm.GetTypes())
 					{

--- a/GameServer/gameobjects/GameNPC.cs
+++ b/GameServer/gameobjects/GameNPC.cs
@@ -1973,11 +1973,8 @@ namespace DOL.GS
 			{
 				try
 				{
-					var asms = new List<Assembly>();
-					asms.Add(typeof(GameServer).Assembly);
-					asms.AddRange(ScriptMgr.Scripts);
 					ABrain brain = null;
-					foreach (Assembly asm in asms)
+					foreach (Assembly asm in ScriptMgr.GameServerScripts)
 					{
 						brain = (ABrain)asm.CreateInstance(dbMob.Brain, false);
 						if (brain != null)

--- a/GameServer/quests/QuestsMgr/QuestMgr.cs
+++ b/GameServer/quests/QuestsMgr/QuestMgr.cs
@@ -66,13 +66,10 @@ namespace DOL.GS.Quests
 
         public static bool Init()
         {
-            List<Assembly> assemblies = new List<Assembly>();
-            assemblies.Add(Assembly.GetAssembly(typeof(GameServer)));
-            assemblies.AddRange(ScriptMgr.Scripts);
             //We will search our assemblies for Quests by reflection so
             //it is not neccessary anymore to register new quests with the
             //server, it is done automatically!
-            foreach (Assembly assembly in assemblies)
+            foreach (Assembly assembly in ScriptMgr.GameServerScripts)
             {
                 // Walk through each type in the assembly
                 foreach (Type type in assembly.GetTypes())

--- a/GameServer/world/Instance/Instance.cs
+++ b/GameServer/world/Instance/Instance.cs
@@ -104,12 +104,8 @@ namespace DOL.GS
 				}
 
 				//Now we have the classtype to create, create it thus!
-				ArrayList asms = new ArrayList();
-				asms.Add(typeof(GameServer).Assembly);
-				asms.AddRange(ScriptMgr.Scripts);
-
 				//This is required to ensure we check scripts for the space aswell, such as quests!
-				foreach (Assembly asm in asms)
+				foreach (Assembly asm in ScriptMgr.GameServerScripts)
 				{
 					obj = (GameObject)(asm.CreateInstance(theType, false));
 					if (obj != null)


### PR DESCRIPTION
Update: Add a new Config for preventing Game Server Scripts Compilation (Allowing to plug a debugger)

Improve ScriptMgr Assemblies Accessors for Enumeration of Ordered Core/Script Assembly
Replacing most Assembly gathering from other classes to use these new accessors.