### PR TITLE
Fix: Prevent Deadlock in WeatherManager when Stopping Weather Tasks.

### DIFF
--- a/GameServer/SimpleScheduler.cs
+++ b/GameServer/SimpleScheduler.cs
@@ -318,6 +318,7 @@ namespace DOL.GS.Scheduler
 		
 		/// <summary>
 		/// Stop and Unschedule Task
+		/// Lock and Wait for Task End if currently Running.
 		/// </summary>
 		public void Stop()
 		{


### PR DESCRIPTION
Stopping a Task on SimpleScheduler is Locking the Task waiting for thread to Complete.

This can Lead to deadlock in Weather Manager when accessing Region Dictionary.