### PR TITLE
Updates: Mythical Stat Bonuses

### DIFF
--- a/GameServer/GlobalConstants.cs
+++ b/GameServer/GlobalConstants.cs
@@ -794,7 +794,18 @@ namespace DOL.GS
         MythicalSafeFall = 233,
         MythicalDiscumbering = 234,
         MythicalCoin = 235,
-		// 236 - 246 Available
+        // 236 - 246 used for Mythical Stat Cap
+        MythicalStatCapBonus_First = 236,
+        MythicalStrCapBonus = 236,
+        MythicalDexCapBonus = 237,
+        MythicalConCapBonus = 238,
+        MythicalQuiCapBonus = 239,
+        MythicalIntCapBonus = 240,
+        MythicalPieCapBonus = 241,
+        MythicalEmpCapBonus = 242,
+        MythicalChaCapBonus = 243,
+        MythicalAcuCapBonus = 244,
+        MythicalStatCapBonus_Last = 244,
 
 		BountyPoints = 247,
 		XpPoints = 248,

--- a/GameServer/gameutils/SkillBase.cs
+++ b/GameServer/gameutils/SkillBase.cs
@@ -1966,7 +1966,19 @@ namespace DOL.GS
 			m_propertyNames.Add(eProperty.CriticalMeleeHitChance, LanguageMgr.GetTranslation(ServerProperties.Properties.DB_LANGUAGE, "SkillBase.RegisterPropertyNames.CriticalMeleeHit"));
 			m_propertyNames.Add(eProperty.CriticalSpellHitChance, LanguageMgr.GetTranslation(ServerProperties.Properties.DB_LANGUAGE, "SkillBase.RegisterPropertyNames.CriticalSpellHit"));
 			m_propertyNames.Add(eProperty.CriticalHealHitChance, LanguageMgr.GetTranslation(ServerProperties.Properties.DB_LANGUAGE, "SkillBase.RegisterPropertyNames.CriticalHealHit"));
-			#endregion
+			
+            //Forsaken Worlds: Mythical Stat Cap
+            m_propertyNames.Add(eProperty.MythicalStrCapBonus, "Mythical Stat Cap (Strength)");
+			m_propertyNames.Add(eProperty.MythicalDexCapBonus, "Mythical Stat Cap (Dexterity)");
+			m_propertyNames.Add(eProperty.MythicalConCapBonus, "Mythical Stat Cap (Constitution)");
+			m_propertyNames.Add(eProperty.MythicalQuiCapBonus, "Mythical Stat Cap (Quickness)");
+			m_propertyNames.Add(eProperty.MythicalIntCapBonus, "Mythical Stat Cap (Intelligence)");
+			m_propertyNames.Add(eProperty.MythicalPieCapBonus, "Mythical Stat Cap (Piety)");
+			m_propertyNames.Add(eProperty.MythicalChaCapBonus, "Mythical Stat Cap (Charisma)");
+			m_propertyNames.Add(eProperty.MythicalEmpCapBonus, "Mythical Stat Cap (Empathy)");
+			m_propertyNames.Add(eProperty.MythicalAcuCapBonus, "Mythical Stat Cap (Acuity)");
+
+            #endregion
 		}
 
 		#endregion

--- a/GameServer/propertycalc/StatCalculator.cs
+++ b/GameServer/propertycalc/StatCalculator.cs
@@ -149,6 +149,7 @@ namespace DOL.GS.PropertyCalc
             int itemBonus = living.ItemBonus[(int)property];
             int itemBonusCap = GetItemBonusCap(living, property);
 
+
             if (living is GamePlayer)
             {
 				GamePlayer player = living as GamePlayer;
@@ -163,7 +164,8 @@ namespace DOL.GS.PropertyCalc
             }
 
             int itemBonusCapIncrease = GetItemBonusCapIncrease(living, property);
-            return Math.Min(itemBonus, itemBonusCap + itemBonusCapIncrease);
+            int mythicalitemBonusCapIncrease = GetMythicalItemBonusCapIncrease(living, property);
+            return Math.Min(itemBonus, itemBonusCap + itemBonusCapIncrease + mythicalitemBonusCapIncrease);
         }
 
         /// <summary>
@@ -205,6 +207,35 @@ namespace DOL.GS.PropertyCalc
             return Math.Min(itemBonusCapIncrease, itemBonusCapIncreaseCap);
         }
 
+
+        //Forsaken Mythical Cap Increase
+        public static int GetMythicalItemBonusCapIncrease(GameLiving living, eProperty property)
+        {
+            if (living == null) return 0;
+            int MythicalitemBonusCapIncreaseCap = GetMythicalItemBonusCapIncreaseCap(living);
+            int MythicalitemBonusCapIncrease = living.ItemBonus[(int)(eProperty.MythicalStatCapBonus_First - eProperty.Stat_First + property)];
+            int itemBonusCapIncrease = GetItemBonusCapIncrease(living, property);
+            if (living is GamePlayer)
+            {
+                GamePlayer player = living as GamePlayer;
+
+                if (property == (eProperty)player.CharacterClass.ManaStat)
+                {
+                    if (player.CharacterClass.ID != (int)eCharacterClass.Scout && player.CharacterClass.ID != (int)eCharacterClass.Hunter && player.CharacterClass.ID != (int)eCharacterClass.Ranger)
+                    {
+                        MythicalitemBonusCapIncrease += living.ItemBonus[(int)eProperty.MythicalAcuCapBonus];
+                    }
+                }
+            }
+            if (MythicalitemBonusCapIncrease + itemBonusCapIncrease > 52)
+            {
+                MythicalitemBonusCapIncrease = 52 - itemBonusCapIncrease;
+            }
+
+            return Math.Min(MythicalitemBonusCapIncrease, MythicalitemBonusCapIncreaseCap);
+        }
+
+
         /// <summary>
         /// Returns the cap for stat cap increases.
         /// </summary>
@@ -214,6 +245,13 @@ namespace DOL.GS.PropertyCalc
         {
             if (living == null) return 0;
             return living.Level / 2 + 1;
+        }
+
+        //Forsaken Worlds Mythical Cap Cap
+        public static int GetMythicalItemBonusCapIncreaseCap(GameLiving living)
+        {
+            if (living == null) return 0;
+            return 52;
         }
 	}
 }


### PR DESCRIPTION
1: Adds Mythical Stat Cap bonuses to GlobalConstants
2: Adds references in SkillBase to show properly on item info
3: Formula additions/changes to StatCalculator to be properly affected by the new mythicals to live-like standards

Signed-off-by: Mannik/Dargon <zbowen1994@gmail.com>