### PR TITLE
Database Patch Enabling Server Side MySQL Prepare

### DIFF
--- a/DOLDatabase/DatabaseParameter.cs
+++ b/DOLDatabase/DatabaseParameter.cs
@@ -24,7 +24,7 @@ namespace DOL.Database
 	/// <summary>
 	/// Parameter for Prepared Queries
 	/// </summary>
-	public sealed class QueryParameter : Tuple<string, object>
+	public sealed class QueryParameter : Tuple<string, object, Type>
 	{
 		/// <summary>
 		/// Parameter Name
@@ -37,12 +37,28 @@ namespace DOL.Database
 		public object Value { get { return Item2; } }
 		
 		/// <summary>
+		/// Parameter Value
+		/// </summary>
+		public Type ValueType { get { return Item3; } }
+		
+		/// <summary>
 		/// Create an instance of <see cref="QueryParameter"/>
 		/// </summary>
 		/// <param name="Name">Parameter Name</param>
 		/// <param name="Value">Parameter Value</param>
 		public QueryParameter(string Name, object Value)
-			: base(Name, Value)
+			: base(Name, Value, null)
+		{
+		}
+		
+		/// <summary>
+		/// Create a Typed instance of <see cref="QueryParameter"/>
+		/// </summary>
+		/// <param name="Name">Parameter Name</param>
+		/// <param name="Value">Parameter Value</param>
+		/// <param name="Type">Parameter Type</param>
+		public QueryParameter(string Name, object Value, Type Type)
+			: base(Name, Value, Type)
 		{
 		}
 		
@@ -50,7 +66,7 @@ namespace DOL.Database
 		/// Create a default instance of <see cref="QueryParameter"/>
 		/// </summary>
 		public QueryParameter()
-			: base(null, null)
+			: base(null, null, null)
 		{
 		}
 	}

--- a/DOLDatabase/Handlers/MySQLObjectDatabase.cs
+++ b/DOLDatabase/Handlers/MySQLObjectDatabase.cs
@@ -690,6 +690,11 @@ namespace DOL.Database.Handlers
 			return obj.ToArray();
 		}
 		#endregion
+		/// <summary>
+		/// Retrieve Query Parameter DB Type from Table Type or Runtime Type
+		/// </summary>
+		/// <param name="param">Query Parameter</param>
+		/// <returns>MySqlDbType for this Query Paramter, "Blob" as default.</returns>
 		protected static MySqlDbType GuessQueryParameterDbType(QueryParameter param)
 		{
 			var type = param.ValueType != null ? param.ValueType : param.Value != null ? param.Value.GetType() : null;

--- a/DOLDatabase/Handlers/SQLiteObjectDatabase.cs
+++ b/DOLDatabase/Handlers/SQLiteObjectDatabase.cs
@@ -808,12 +808,7 @@ namespace DOL.Database.Handlers
 						    				try
 						    				{
 							    				cmd.ExecuteNonQuery();
-							    				
-								    			using (var lastid = new SQLiteCommand("SELECT LAST_INSERT_ROWID()", conn))
-								    			{
-								    				var result = lastid.ExecuteScalar();
-								    				obj.Add(result);
-								    			}
+							    				obj.Add(conn.LastInsertRowId);
 						    				}
 								    		catch (SQLiteException sqle)
 								    		{

--- a/DOLDatabase/ObjectDatabase.cs
+++ b/DOLDatabase/ObjectDatabase.cs
@@ -637,7 +637,7 @@ namespace DOL.Database
 				
 				var whereClause = string.Format("`{0}` = @{0}", remoteBind.ColumnName);
 				
-				var parameters = objects.Select(obj => new [] { new QueryParameter(string.Format("@{0}", remoteBind.ColumnName), localBind.GetValue(obj)) });
+				var parameters = objects.Select(obj => new [] { new QueryParameter(string.Format("@{0}", remoteBind.ColumnName), localBind.GetValue(obj), localBind.ValueType) });
 				
 				objsResults = SelectObjectsImpl(remoteHandler, whereClause, parameters, Transaction.IsolationLevel.DEFAULT);
 			}

--- a/DOLDatabase/SQLObjectDatabase.cs
+++ b/DOLDatabase/SQLObjectDatabase.cs
@@ -148,7 +148,7 @@ namespace DOL.Database
 					obj.ObjectId = IDGenerator.GenerateID();
 				
 				// Build Parameters
-				var parameters = objs.Select(obj => columns.Select(col => new QueryParameter(col.ParamName, col.Binding.GetValue(obj))));
+				var parameters = objs.Select(obj => columns.Select(col => new QueryParameter(col.ParamName, col.Binding.GetValue(obj), col.Binding.ValueType)));
 				
 				// Primary Key Auto Inc Handler
 				if (usePrimaryAutoInc)
@@ -241,7 +241,7 @@ namespace DOL.Database
 				                            string.Join(" AND ", primary.Select(col => string.Format("{0} = {1}", col.ColumnName, col.ParamName))));
 				
 				var objs = dataObjects.ToArray();
-				var parameters = objs.Select(obj => columns.Concat(primary).Select(col => new QueryParameter(col.ParamName, col.Binding.GetValue(obj))));
+				var parameters = objs.Select(obj => columns.Concat(primary).Select(col => new QueryParameter(col.ParamName, col.Binding.GetValue(obj), col.Binding.ValueType)));
 				
 				var affected = ExecuteNonQueryImpl(command, parameters);
 				var resultByObjects = affected.Select((result, index) => new { Result = result, DataObject = objs[index] });
@@ -300,7 +300,7 @@ namespace DOL.Database
 	                        string.Join(" AND ", primary.Select(col => string.Format("`{0}` = @{0}", col.ColumnName))));
 				
 				var objs = dataObjects.ToArray();
-				var parameters = objs.Select(obj => primary.Select(pk => new QueryParameter(string.Format("@{0}", pk.ColumnName), pk.GetValue(obj))));
+				var parameters = objs.Select(obj => primary.Select(pk => new QueryParameter(string.Format("@{0}", pk.ColumnName), pk.GetValue(obj), pk.ValueType)));
 				
 				var affected = ExecuteNonQueryImpl(command, parameters);
 				var resultByObjects = affected.Select((result, index) => new { Result = result, DataObject = objs[index] });
@@ -342,7 +342,7 @@ namespace DOL.Database
 		{
 			// Primary Key
 			var primary = tableHandler.FieldElementBindings.Where(bind => bind.PrimaryKey != null)
-				.Select(bind => new { ColumnName = string.Format("`{0}`", bind.ColumnName), ParamName = string.Format("@{0}", bind.ColumnName) }).ToArray();
+				.Select(bind => new { ColumnName = string.Format("`{0}`", bind.ColumnName), ParamName = string.Format("@{0}", bind.ColumnName), ParamType = bind.ValueType }).ToArray();
 			
 			if (!primary.Any())
 				throw new DatabaseException(string.Format("Table {0} has no primary key for finding by key...", tableHandler.TableName));
@@ -351,7 +351,7 @@ namespace DOL.Database
 			                                string.Join(" AND ", primary.Select(col => string.Format("{0} = {1}", col.ColumnName, col.ParamName))));
 			
 			var keysArray = keys.ToArray();
-			var parameters = keysArray.Select(key => primary.Select(col => new QueryParameter(col.ParamName, key)));
+			var parameters = keysArray.Select(key => primary.Select(col => new QueryParameter(col.ParamName, key, col.ParamType)));
 			
 			var objs = SelectObjectsImpl(tableHandler, whereClause, parameters, Transaction.IsolationLevel.DEFAULT);
 			


### PR DESCRIPTION
From MySQL documentation the Prepare Statement is ignored by default in ADO.NET connector...

Enabling server-side Prepare needed some logic change in the Parameter Binding, leading to some update of the underlying API.

Server-side Prepare Statement should speed up Bulk Data Access and reduce network overhead when sending Data.