### PR TITLE
Creation Startup Equipment Active Weapon Slot Fix

### DIFF
--- a/GameServerScripts/startup/script/CreationStartupEquipment.cs
+++ b/GameServerScripts/startup/script/CreationStartupEquipment.cs
@@ -197,6 +197,10 @@ namespace DOL.GS.GameEvents
 											ch.ActiveWeaponSlot = (byte)GamePlayer.eActiveWeaponSlot.Distance;
 											break;
 									}
+									
+									// Save char to DB if Active Slot changed...
+									if (ch.ActiveWeaponSlot != 0)
+										GameServer.Database.SaveObject(ch);
 								}
 								
 								itemChoosen = true;


### PR DESCRIPTION
Save Character in Database when switching Active Weapon Slot on Startup Equipment Creation.

Allowing the player to load with the correct weapon slot when hitting start button, ready to use in combat !