### PR TITLE
Check on Runtime to deploy unix compatible logconfig.xml 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,5 @@ install:
  - travis_retry nuget install NUnit.Console -Version 3.2.1 -OutputDirectory test -ExcludeVersion
 script:
  - MONO_IOMAP=case xbuild /p:Configuration=$XBUILD_TARGET "Dawn of Light.sln"
- - mkdir -p ./build/UnitTests/$XBUILD_TARGET/config
- - sed -e 's/type\=\"log4net\.Appender\.ColoredConsoleAppender\"/type\=\"log4net\.Appender\.ConsoleAppender\"/' ./GameServer/config/logconfig.xml > ./build/UnitTests/$XBUILD_TARGET/config/logconfig.xml
  - LANG=en_US.CP1252 mono ./test/NUnit.ConsoleRunner/tools/nunit3-console.exe ./build/UnitTests/$XBUILD_TARGET/lib/UnitTests.dll
  - LANG=en_US.CP1252 mono ./test/NUnit.ConsoleRunner/tools/nunit3-console.exe ./build/DOLDatabaseTests/$XBUILD_TARGET/lib/DOLDatabaseTests.dll

--- a/GameServer/GameServer.cs
+++ b/GameServer/GameServer.cs
@@ -299,7 +299,10 @@ namespace DOL.GS
 			var logConfig = new FileInfo(config.LogConfigFile);
 			if (!logConfig.Exists)
 			{
-				ResourceUtil.ExtractResource(logConfig.Name, logConfig.FullName);
+			    if (Environment.OSVersion.Platform == PlatformID.Unix)
+				    ResourceUtil.ExtractResource("logconfig_unix.xml", logConfig.FullName);
+			    else
+                    ResourceUtil.ExtractResource("logconfig.xml", logConfig.FullName);
 			}
 
 			//Configure and watch the config file

--- a/GameServer/GameServer.csproj
+++ b/GameServer/GameServer.csproj
@@ -2605,6 +2605,7 @@
     <Compile Include="world\ZonePointEffects.cs" />
     <EmbeddedResource Include="config\logconfig.xml" />
     <EmbeddedResource Include="config\invalidnames.txt" />
+    <EmbeddedResource Include="config\logconfig_unix.xml" />
     <None Include="language\DE\AI.txt" />
     <None Include="language\DE\Atlantis.txt" />
     <None Include="language\DE\Behaviour.txt" />

--- a/GameServer/config/logconfig_unix.xml
+++ b/GameServer/config/logconfig_unix.xml
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- This section contains the log4net configuration settings -->
+<!-- For mor information please see the website http://logging.apache.org/log4net/ -->
+<log4net>
+	<!-- Setup the root category, add the appenders and set the default level -->
+	<root>
+		<level value="DEBUG" />
+		<appender-ref ref="ColoredConsoleAppender" />
+		<appender-ref ref="GameServerLogFile" />
+		<appender-ref ref="ErrorLogFile" />
+		<appender-ref ref="WarnLogFile" />
+	</root>
+
+	<!-- Define our console output -->
+	<appender name="ColoredConsoleAppender" type="log4net.Appender.ConsoleAppender">
+		<Threshold value="DEBUG" />
+		<Layout type="log4net.Layout.PatternLayout">
+			<param name="ConversionPattern" value="[%d{ABSOLUTE}] %m%n" />
+		</Layout>
+	</appender>
+
+	<!-- Define our file output -->
+	<appender name="GameServerLogFile" type="log4net.Appender.RollingFileAppender" >
+		<appendtofile value="true" />
+		<file value="./logs/GameServer.log" />
+		<maximumFileSize value="100MB" />
+		<datePattern value="yyyy-MM-dd" />
+		<immediateFlush value="false"/>
+		<Layout type="log4net.Layout.PatternLayout">
+			<param name="ConversionPattern" value="%d - [%t] - %-5p - %c - %m%n" />
+		</Layout>
+	</appender>
+	<!-- Define our ERROR Logger -->
+	<appender name="ErrorLogFile" type="log4net.Appender.RollingFileAppender" >
+		<file value="./logs/Error.log" />
+		<appendToFile value="false" />
+		<maxSizeRollBackups value="5" />
+		<maximumFileSize value="20MB" />
+		<staticLogFileName value="true" />
+		<Layout type="log4net.Layout.PatternLayout">
+			<param name="ConversionPattern" value="%date - [%thread] - %-5p - %c - %message%newline" />
+		</Layout>
+		<Threshold value="ERROR" />
+	</appender>
+
+	<!-- Define our WARN Logger -->
+	<appender name="WarnLogFile" type="log4net.Appender.RollingFileAppender" >
+		<file value="./logs/Warn.log" />
+			<appendToFile value="false" />
+			<maxSizeRollBackups value="5" />
+			<maximumFileSize value="20MB" />
+			<staticLogFileName value="true" />
+			<Layout type="log4net.Layout.PatternLayout">
+			<param name="ConversionPattern" value="%date - [%thread] - %-5p - %c - %message%newline" />
+			</Layout>
+			<filter type="log4net.Filter.LevelRangeFilter">
+			<param name="LevelMin" value="WARN"/>
+			<param name="LevelMax" value="WARN"/>
+			</filter>
+			<filter type="log4net.Filter.DenyAllFilter" />
+	</appender>
+
+	<!-- Define our GM Action Logger -->
+	<logger name="gmactions">
+		<additivity value="false" />
+		<level value="ALL" />
+		<appender-ref ref="GMActionFileAppender" />
+	</logger>
+	<!-- Define our file output -->
+	<appender name="GMActionFileAppender" type="log4net.Appender.RollingFileAppender" >
+		<appendtofile value="true" />
+		<file value="./logs/GMActions.log" />
+		<Layout type="log4net.Layout.PatternLayout">
+			<param name="ConversionPattern" value="%d - %m%n" />
+		</Layout>
+	</appender>
+
+	<!-- Define our Cheat Action Logger -->
+	<logger name="cheats">
+		<additivity value="false" />
+		<level value="ALL" />
+		<appender-ref ref="CheatFileAppender" />
+	</logger>
+	<!-- Define our file output -->
+	<appender name="CheatFileAppender" type="log4net.Appender.RollingFileAppender" >
+		<appendtofile value="true" />
+		<file value="./logs/Cheats.log" />
+		<Layout type="log4net.Layout.PatternLayout">
+			<param name="ConversionPattern" value="%d - %m%n" />
+		</Layout>
+	</appender>
+
+	<!-- Define our Inventories Action Logger -->
+	<logger name="inventories">
+		<additivity value="false" />
+		<level value="ALL" />
+		<appender-ref ref="InventoryFileAppender" />
+	</logger>
+	<!-- Define our file output -->
+	<appender name="InventoryFileAppender" type="log4net.Appender.RollingFileAppender" >
+		<appendtofile value="true" />
+		<file value="./logs/Inventories.log" />
+		<Layout type="log4net.Layout.PatternLayout">
+			<param name="ConversionPattern" value="%d - %m%n" />
+		</Layout>
+	</appender>
+
+	<!-- We set the log level for some lowlevel loggers so it won't clutter our output -->
+	<logger name="DOL.GS.PacketHandler.PacketProcessor">
+		<level value="INFO" />
+	</logger>
+	<logger name="DOL.Database.ObjectDatabase">
+		<level value="INFO" />
+	</logger>
+	<logger name="DOL.GS.GameObject">
+		<level value="INFO" />
+	</logger>
+	<logger name="DOL.Database.Handlers">
+		<level value="INFO" />
+	</logger>
+	<logger name="DOL.GS.Zone">
+		<level value="INFO" />
+	</logger>
+	<logger name="DOL.GS.GameTimer">
+		<level value="DEBUG" />
+	</logger>
+</log4net>


### PR DESCRIPTION
Check on Runtime to deploy unix compatible logconfig.xml  (without colored console appender).

Update: Travis configuration remove edition of logconfig prior to running tests.