### PR TITLE
Adds working resurrection sickness

### DIFF
--- a/GameServer/GlobalConstants.cs
+++ b/GameServer/GlobalConstants.cs
@@ -2458,10 +2458,10 @@ namespace DOL.GS
 		
 	}
 
-	public class GlobalSpells
+	public static class GlobalSpells
 	{
-		public const string PvERessurectionIllnessSpellType = "PveResurrectionIllness";
-		private static Spell m_PvERezIllness = null;
+		public const string PvEResurrectionIllnessSpellType = "PveResurrectionIllness";
+		private static Spell m_PvERezIllness;
 		public static Spell PvERezIllness
 		{
 			get
@@ -2476,12 +2476,42 @@ namespace DOL.GS
 					spell.SpellID = 2435;
 					spell.Name = LanguageMgr.GetTranslation(ServerProperties.Properties.DB_LANGUAGE, "GamePlayer.Spell.ResurrectionIllness");
 					spell.Range = 0;
+					spell.Duration = 300;
+					spell.Value = 30;
 					spell.Target = "Self";
-					spell.Type = PvERessurectionIllnessSpellType;
+					spell.Type = PvEResurrectionIllnessSpellType;
 					spell.Description = "The player's effectiveness is greatly reduced due to being recently resurrected.";
 					m_PvERezIllness = new Spell(spell, 50);
+					SkillBase.AddScriptedSpell(GlobalSpellsLines.Reserved_Spells, m_PvERezIllness);
 				}
 				return m_PvERezIllness;
+			}
+		}
+		public const string RvRResurrectionIllnessSpellType = "RvrResurrectionIllness";
+		private static Spell m_RvRRezIllness;
+		public static Spell RvRRezIllness
+		{
+			get
+			{
+				if (m_RvRRezIllness == null)
+				{
+					DBSpell spelltwo = new DBSpell();
+					spelltwo.AllowAdd = false;
+					spelltwo.CastTime = 0;
+					spelltwo.ClientEffect = 2435;
+					spelltwo.Icon = 2435;
+					spelltwo.SpellID = 8181;
+					spelltwo.Name = LanguageMgr.GetTranslation(ServerProperties.Properties.DB_LANGUAGE, "GamePlayer.Spell.RvrResurrectionIllness");
+					spelltwo.Range = 0;
+					spelltwo.Duration = 300;
+					spelltwo.Value = 50;
+					spelltwo.Target = "Self";
+					spelltwo.Type = RvRResurrectionIllnessSpellType;
+					spelltwo.Description = "The player's effectiveness is greatly reduced due to being recently resurrected.";
+					m_RvRRezIllness = new Spell(spelltwo, 50);
+					SkillBase.AddScriptedSpell(GlobalSpellsLines.Reserved_Spells, m_RvRRezIllness);
+				}
+				return m_RvRRezIllness;
 			}
 		}
 	}

--- a/GameServer/gameobjects/CustomNPC/Healer.cs
+++ b/GameServer/gameobjects/CustomNPC/Healer.cs
@@ -34,7 +34,7 @@ namespace DOL.GS
 	[NPCGuildScript("Healer")]
 	public class GameHealer : GameNPC
 	{
-		private const string CURED_SPELL_TYPE = GlobalSpells.PvERessurectionIllnessSpellType;
+		private const string CURED_SPELL_TYPE = GlobalSpells.PvEResurrectionIllnessSpellType;
 
 		private const string COST_BY_PTS = "cost";
 

--- a/GameServer/gameobjects/GamePlayer.cs
+++ b/GameServer/gameobjects/GamePlayer.cs
@@ -1753,24 +1753,59 @@ namespace DOL.GS
 		}
 		
 		/// <summary>
+		/// Death types ingame
+		/// </summary>
+		public enum eDeathType
+		{
+			PvE,
+			RvR,
+			PvP,
+			None,
+		}
+		
+		/// <summary>
+		/// The current death type
+		/// </summary>
+		protected eDeathType m_deathtype;
+
+		/// <summary>
+		/// Gets the player's current death type.
+		/// </summary>
+		public eDeathType DeathType
+		{
+			get { return m_deathtype; }
+			set { m_deathtype = value; }
+		}
+		/// <summary>
 		/// Called when player revive
 		/// </summary>
 		public virtual void OnRevive(DOLEvent e, object sender, EventArgs args)
 		{
 			GamePlayer player = (GamePlayer)sender;
-			
+						
 			if (player.IsUnderwater && player.CanBreathUnderWater == false)
 				player.Diving(waterBreath.Holding);
-			
+			//We need two different sickness spells because RvR sickness is not curable by Healer NPC -Unty
 			if (player.Level > 5)
+			switch (DeathType)
 			{
-				// get illness after level 5
-				SpellLine Line = SkillBase.GetSpellLine(GlobalSpellsLines.Reserved_Spells);
-				if (Line == null) return;
-				ISpellHandler spellHandler = ScriptMgr.CreateSpellHandler(player, GlobalSpells.PvERezIllness, Line);
-				spellHandler.StartSpell(player);
+				case eDeathType.RvR:
+					SpellLine rvrsick = SkillBase.GetSpellLine(GlobalSpellsLines.Reserved_Spells);
+					if (rvrsick == null) return;
+					Spell rvrillness = SkillBase.FindSpell(8181, rvrsick);
+					player.CastSpell(rvrillness, rvrsick);
+					break;
+				case eDeathType.PvP: //PvP sickness is the same as PvE sickness - Curable
+				case eDeathType.PvE:
+					SpellLine pvesick = SkillBase.GetSpellLine(GlobalSpellsLines.Reserved_Spells);
+					if (pvesick == null) return;
+					Spell pveillness = SkillBase.FindSpell(2435, pvesick);
+					player.CastSpell(pveillness, pvesick);
+					break;
 			}
+			
 			GameEventMgr.RemoveHandler(this, GamePlayerEvent.Revive, new DOLEventHandler(OnRevive));
+			m_deathtype = eDeathType.None;
 		}
 
 		/// <summary>
@@ -7581,10 +7616,29 @@ namespace DOL.GS
 					xpLossPercent = MaxLevel - 40;
 				}
 
-				if (realmDeath)
+				if (realmDeath) //Live PvP servers have 3 con loss on pvp death, can be turned off in server properties -Unty
 				{
-					Out.SendMessage(LanguageMgr.GetTranslation(Client.Account.Language, "GamePlayer.Die.DeadRVR"), eChatType.CT_YouDied, eChatLoc.CL_SystemWindow);
-					xpLossPercent = 0;
+					int conpenalty = 0;
+					switch (GameServer.Instance.Configuration.ServerType)
+					{
+						case eGameServerType.GST_Normal:
+								Out.SendMessage(LanguageMgr.GetTranslation(Client.Account.Language, "GamePlayer.Die.DeadRVR"), eChatType.CT_YouDied, eChatLoc.CL_SystemWindow);
+								xpLossPercent = 0;
+								m_deathtype = eDeathType.RvR;
+								break;
+								
+						case eGameServerType.GST_PvP:
+								Out.SendMessage(LanguageMgr.GetTranslation(Client.Account.Language, "GamePlayer.Die.DeadRVR"), eChatType.CT_YouDied, eChatLoc.CL_SystemWindow);
+								xpLossPercent = 0;
+								m_deathtype = eDeathType.PvP;
+								if (ServerProperties.Properties.PVP_DEATH_CON_LOSS)
+								{
+									conpenalty = 3;
+									TempProperties.setProperty(DEATH_CONSTITUTION_LOSS_PROPERTY, conpenalty);
+								}
+								break;
+				 	}
+					 
 				}
 				else if (Level > 5) // under level 5 there is no penalty
 				{
@@ -7603,7 +7657,7 @@ namespace DOL.GS
 					}
 
 					DeathCount++;
-
+					m_deathtype = eDeathType.PvE;
 					long xpLoss = (ExperienceForNextLevel - ExperienceForCurrentLevel) * xpLossPercent / 1000;
 					GainExperience(eXPSource.Other, -xpLoss, 0, 0, 0, false, true);
 					TempProperties.setProperty(DEATH_EXP_LOSS_PROPERTY, xpLoss);

--- a/GameServer/realmabilities/handlers/PerfectRecoveryAbility.cs
+++ b/GameServer/realmabilities/handlers/PerfectRecoveryAbility.cs
@@ -201,9 +201,12 @@ namespace DOL.GS.RealmAbilities
 			resurrectedPlayer.Out.SendPlayerRevive(resurrectedPlayer);
 			resurrectedPlayer.UpdatePlayerStatus();
 
-			GameSpellEffect effect = SpellHandler.FindEffectOnTarget(resurrectedPlayer, GlobalSpells.PvERessurectionIllnessSpellType);
+			GameSpellEffect effect = SpellHandler.FindEffectOnTarget(resurrectedPlayer, GlobalSpells.PvEResurrectionIllnessSpellType);
 			if (effect != null)
 				effect.Cancel(false);
+			GameSpellEffect effecttwo = SpellHandler.FindEffectOnTarget(resurrectedPlayer, GlobalSpells.RvRResurrectionIllnessSpellType);
+			if (effecttwo != null)
+				effecttwo.Cancel(false);
 			resurrectedPlayer.Out.SendMessage("You have been resurrected by " + rezzer.GetName(0, false) + "!", eChatType.CT_System, eChatLoc.CL_SystemWindow);
             //Lifeflight: this should make it so players who have been ressurected don't take damage for 5 seconds
             RezDmgImmunityEffect rezImmune = new RezDmgImmunityEffect();

--- a/GameServer/serverproperty/ServerProperties.cs
+++ b/GameServer/serverproperty/ServerProperties.cs
@@ -1204,6 +1204,12 @@ namespace DOL.GS.ServerProperties
 		/// </summary>
 		[ServerProperty("pvp", "enable_warmapmgr", "Shall we enable the WarMap manager ?", false)]
 		public static bool ENABLE_WARMAPMGR;
+		
+		/// <summary>
+		/// Toggle con loss on PvP server type
+		/// </summary>
+		[ServerProperty("pvp", "pvp_death_con_loss", "Loose con on pvp death on PvP servertype", true)]
+		public static bool PVP_DEATH_CON_LOSS;
 		#endregion
 
 		#region KEEPS

--- a/GameServer/spells/IllnessSpellHandler.cs
+++ b/GameServer/spells/IllnessSpellHandler.cs
@@ -27,7 +27,7 @@ namespace DOL.GS.Spells
 	/// <summary>
 	/// Pve Resurrection Illness
 	/// </summary>
-	[SpellHandler(GlobalSpells.PvERessurectionIllnessSpellType)]
+	[SpellHandler(GlobalSpells.PvEResurrectionIllnessSpellType)]
 	public class PveResurrectionIllness : AbstractIllnessSpellHandler
 	{
 		/// <summary>
@@ -153,4 +153,5 @@ namespace DOL.GS.Spells
 		public AbstractIllnessSpellHandler(GameLiving caster, Spell spell, SpellLine spellLine) : base(caster, spell, spellLine) {}
 	
 	}
+		
 }

--- a/GameServer/spells/ResurrectSpellHandler.cs
+++ b/GameServer/spells/ResurrectSpellHandler.cs
@@ -123,7 +123,7 @@ namespace DOL.GS.Spells
 					{
 						ResurrectLiving(player); //accepted
 						//VaNaTiC->
-						#warning VaNaTiC: add this in GamePlayer.OnRevive with my RevivedEventArgs
+						//#warning VaNaTiC: add this in GamePlayer.OnRevive with my RevivedEventArgs
 						// Patch 1.56: Resurrection sickness now goes from 100% to 50% when doing a "full rez" on another player. 
 						// We have do to this here, cause we dont have any other chance to get
 						// an object-relation between the casted spell of the rezzer (here) and
@@ -131,9 +131,12 @@ namespace DOL.GS.Spells
 						// -> any better solution -> post :)
 						if ( Spell.ResurrectHealth == 100 )
 						{
-							GameSpellEffect effect = FindEffectOnTarget(player, GlobalSpells.PvERessurectionIllnessSpellType);
+							GameSpellEffect effect = SpellHandler.FindEffectOnTarget(player, GlobalSpells.PvEResurrectionIllnessSpellType);
 				            if ( effect != null )
 				            	effect.Overwrite(new GameSpellEffect(effect.SpellHandler, effect.Duration / 2, effect.PulseFreq));
+							GameSpellEffect effecttwo = SpellHandler.FindEffectOnTarget(player, GlobalSpells.RvRResurrectionIllnessSpellType);
+				            if ( effecttwo != null )
+				            	effecttwo.Overwrite(new GameSpellEffect(effecttwo.SpellHandler, effecttwo.Duration / 2, effecttwo.PulseFreq));
 						}
 						//VaNaTiC<-
 					}

--- a/GameServer/spells/RvRSicknessSpellHandler.cs
+++ b/GameServer/spells/RvRSicknessSpellHandler.cs
@@ -1,0 +1,34 @@
+/*
+ * DAWN OF LIGHT - The first free open source DAoC server emulator
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ */
+using System;
+
+namespace DOL.GS.Spells
+{
+	/// <summary>
+	/// RvR Resurrection Illness Handler
+	/// </summary>
+	[SpellHandler(GlobalSpells.RvRResurrectionIllnessSpellType)]
+	public class RvrResurrectionIllness : PveResurrectionIllness
+	{
+		// constructor
+		public RvrResurrectionIllness(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line)
+		{
+		}
+	}
+}


### PR DESCRIPTION
Adds RvR, PvP, and PvE types of resurrection. RvR sickness is not curable except by Perfect recovery RA, and perfecter ML8 ability. PvP sickness player looses 3 con on death, curable. Con loss can be removed in server properties. PvE sickness removes con depending on number of death that level, curable.

