### PR TITLE
Bugfix: Champion Level spell cast speed and effectiveness

### DIFF
--- a/GameServer/GlobalConstants.cs
+++ b/GameServer/GlobalConstants.cs
@@ -1033,7 +1033,7 @@ namespace DOL.GS
 		public const string Mob_Spells = "Mob Spells";
 		public const string Character_Abilities = "Character Abilities"; // dirty tricks, flurry ect...
 		public const string Item_Spells = "Item Spells";	// Combine scroll etc.
-		public const string Champion_Spells = "Champion Abilities";
+		public const string Champion_Lines_StartWith = "Champion ";
 	}
 
 	public static class GlobalConstants

--- a/GameServer/gameobjects/GameLiving.cs
+++ b/GameServer/gameobjects/GameLiving.cs
@@ -940,7 +940,7 @@ namespace DOL.GS
 
 			if (spell.InstrumentRequirement != 0 ||
 			    line.KeyName == GlobalSpellsLines.Item_Spells ||
-			    line.KeyName.StartsWith(GlobalSpellsLines.Champion_Spells))
+			    line.KeyName.StartsWith(GlobalSpellsLines.Champion_Lines_StartWith))
 			{
 				return ticks;
 			}

--- a/GameServer/gameobjects/GamePlayer.cs
+++ b/GameServer/gameobjects/GamePlayer.cs
@@ -3609,7 +3609,7 @@ namespace DOL.GS
 		/// <returns></returns>
 		public override int GetModifiedSpecLevel(string keyName)
 		{
-			if (keyName == GlobalSpellsLines.Champion_Spells)
+			if (keyName.StartsWith(GlobalSpellsLines.Champion_Lines_StartWith))
 				return 50;
 
 			Specialization spec = null;
@@ -8281,7 +8281,7 @@ namespace DOL.GS
 
 			if (spell.InstrumentRequirement != 0 ||
 			    line.KeyName == GlobalSpellsLines.Item_Spells ||
-			    line.KeyName.StartsWith(GlobalSpellsLines.Champion_Spells))
+			    line.KeyName.StartsWith(GlobalSpellsLines.Champion_Lines_StartWith))
 			{
 				return ticks;
 			}

--- a/GameServer/spells/SpellHandler.cs
+++ b/GameServer/spells/SpellHandler.cs
@@ -3619,7 +3619,7 @@ namespace DOL.GS.Spells
 				spellLevel += (int)effect.Spell.Value;
 			}
 
-			if (playerCaster != null && (m_spellLine.KeyName == GlobalSpellsLines.Combat_Styles_Effect || m_spellLine.KeyName.StartsWith(GlobalSpellsLines.Champion_Spells)))
+			if (playerCaster != null && (m_spellLine.KeyName == GlobalSpellsLines.Combat_Styles_Effect || m_spellLine.KeyName.StartsWith(GlobalSpellsLines.Champion_Lines_StartWith)))
 			{
 				spellLevel = Math.Min(playerCaster.MaxLevel, target.Level);
 			}


### PR DESCRIPTION
Fixed Champion Level spells cast speed.
Fixed Champion Level spells effectiveness:
CL specialization level will be returned as 50 again.
CL spell effective level should be calculated correctly again.

Due to changes to the naming of Champion lines the value provided by the global constant would never match. The constant's name has been changed, it's value set to match current CL line naming and an additional string.StartsWith() check has replaced a dysfunctional comparison.