### PR TITLE
Serverlistupdate from DB issue

### DIFF
--- a/GameServerScripts/web/OnlineStatusUpdate.cs
+++ b/GameServerScripts/web/OnlineStatusUpdate.cs
@@ -95,8 +95,11 @@ namespace DOL.GS.GameEvents
 		[ScriptLoadedEvent]
 		public static void OnScriptCompiled(DOLEvent e, object sender, EventArgs args)
 		{
-			Init();
-		}
+		    if (ServerProperties.Properties.USE_SERVER_LIST_UPDATE_INTEGRATED.Equals(true))
+		    {
+		        Init();
+		    }
+        }
 		
 		/// <summary>
 		/// This method is called when the scripts are unloaded. 


### PR DESCRIPTION
`Enable in-built serverlistupdate script FALSE`
With serverlist_update set to False, the console still shows the below.

`[16:09:48,656] Login/URL Error: Validating Arguments Failed! The server's player count will not be added/updated on the list!
[16:09:48,660] Login/URL Error: The arguments that failed validation are:
[16:09:48,661] Username
[16:09:48,662] Password`

This is using the latest SVN with nothing custom. 
So I added a check.