### PR TITLE
Remove Quit Timer

### DIFF
--- a/GameServer/gameobjects/GamePlayer.cs
+++ b/GameServer/gameobjects/GamePlayer.cs
@@ -671,12 +671,7 @@ namespace DOL.GS
 			if (Client.Account.PrivLevel > 1) // GMs can always insta quit
 				bInstaQuit = true;
 			else if (Client.Player.InCombat == false)  // Players can only insta quit if they aren't in combat
-			{
-				ServerProperty spInstaQuit = GameServer.Database.FindObjectByKey<ServerProperty>("remove quit timer");
-
-				if (spInstaQuit != null)
-					bInstaQuit = spInstaQuit.Value.ToLower() == "true";
-			}
+				bInstaQuit = ServerProperties.Properties.REMOVE_QUIT_TIMER;
 
 			if (bInstaQuit == false)
 			{

--- a/GameServer/gameobjects/GamePlayer.cs
+++ b/GameServer/gameobjects/GamePlayer.cs
@@ -666,8 +666,19 @@ namespace DOL.GS
 				return 0;
 			}
 
-			//Gms can quit instantly
-			if (Client.Account.PrivLevel == 1)
+			bool bInstaQuit = false;
+
+			if (Client.Account.PrivLevel > 1) // GMs can always insta quit
+				bInstaQuit = true;
+			else if (Client.Player.InCombat == false)  // Players can only insta quit if they aren't in combat
+			{
+				ServerProperty spInstaQuit = GameServer.Database.FindObjectByKey<ServerProperty>("remove quit timer");
+
+				if (spInstaQuit != null)
+					bInstaQuit = spInstaQuit.Value.ToLower() == "true";
+			}
+
+			if (bInstaQuit == false)
 			{
 				if (CraftTimer != null && CraftTimer.IsAlive)
 				{
@@ -2547,7 +2558,7 @@ namespace DOL.GS
 			 * Strength affects the amount of damage done by spells in all of the Vampiir's spell lines.
 			 * The amount of said affecting was recently increased slightly (fixing a bug), and that minor increase will go live in 1.74 next week.
 			 * 
-			 * Strength ALSO affects the size of the power pool for a Vampiir… sort of.
+			 * Strength ALSO affects the size of the power pool for a Vampiir sort of.
 			 * Your INNATE strength (the number of attribute points your character has for strength) has no effect at all.
 			 * Extra points added through ITEMS, however, does increase the size of your power pool.
 

--- a/GameServer/serverproperty/ServerProperties.cs
+++ b/GameServer/serverproperty/ServerProperties.cs
@@ -379,6 +379,12 @@ namespace DOL.GS.ServerProperties
 
 		#region SERVER
 
+		/// <summary>
+		/// Disable quit timers for players?
+		/// </summary>
+		[ServerProperty("server", "remove_quit_timer", "Allow players to log out without waiting?", false)]
+		public static bool REMOVE_QUIT_TIMER;
+
         /// <summary>
         /// Enable integrated serverlistupdate script?
         /// </summary>


### PR DESCRIPTION
I hate waiting to quit, so this change checks for ServerProperty "remove quit timer" and lets privlevel 1 accounts quit instantly so long as they aren't in combat.