### PR TITLE
Fixed dragon debuff damagetype

### DIFF
--- a/GameServer/gameobjects/Dragons/Cuuldurach.cs
+++ b/GameServer/gameobjects/Dragons/Cuuldurach.cs
@@ -229,7 +229,7 @@ namespace DOL.GS
 					spell.Value = 30;
 					spell.Duration = 30* DragonDifficulty /100;
 					spell.Damage = 0;
-					spell.DamageType = (int)eDamageType.Heat;
+					spell.DamageType = (int)eDamageType.Spirit;
 					spell.SpellID = 6023;
 					spell.Target = "Enemy";
 					spell.Type = "SpiritResistDebuff";
@@ -267,7 +267,7 @@ namespace DOL.GS
 					spell.Value = 50;
 					spell.Duration = 90* DragonDifficulty /100;
 					spell.Damage = 0;
-					spell.DamageType = (int)eDamageType.Heat;
+					spell.DamageType = (int)eDamageType.Spirit;
 					spell.SpellID = 6003;
 					spell.Target = "Enemy";
 					spell.Type = "FumbleChanceDebuff";
@@ -303,7 +303,7 @@ namespace DOL.GS
 					spell.Value = 100;
 					spell.Duration = 90* DragonDifficulty /100;
 					spell.Damage = 0;
-					spell.DamageType = (int)eDamageType.Heat;
+					spell.DamageType = (int)eDamageType.Spirit;
 					spell.SpellID = 6003;
 					spell.Target = "Enemy";
 					spell.Type = "Nearsight";

--- a/GameServer/gameobjects/Dragons/Cuuldurach.cs
+++ b/GameServer/gameobjects/Dragons/Cuuldurach.cs
@@ -21,7 +21,6 @@ using System.Collections.Generic;
 using System.Text;
 using DOL.Database;
 using DOL.Events;
-using log4net;
 using System.Reflection;
 using System.Collections;
 using DOL.AI.Brain;

--- a/GameServer/gameobjects/Dragons/Gjalpinulva.cs
+++ b/GameServer/gameobjects/Dragons/Gjalpinulva.cs
@@ -21,7 +21,6 @@ using System.Collections.Generic;
 using System.Text;
 using DOL.Database;
 using DOL.Events;
-using log4net;
 using System.Reflection;
 using System.Collections;
 using DOL.AI.Brain;

--- a/GameServer/gameobjects/Dragons/Gjalpinulva.cs
+++ b/GameServer/gameobjects/Dragons/Gjalpinulva.cs
@@ -233,7 +233,7 @@ namespace DOL.GS
 					spell.Value = 30;
 					spell.Duration = 30* DragonDifficulty /100;
 					spell.Damage = 0;
-					spell.DamageType = (int)eDamageType.Heat;
+					spell.DamageType = (int)eDamageType.Cold;
 					spell.SpellID = 6013;
 					spell.Target = "Enemy";
 					spell.Type = "ColdResistDebuff";
@@ -272,7 +272,7 @@ namespace DOL.GS
 					spell.Value = 50;
 					spell.Duration = 90* DragonDifficulty /100;
 					spell.Damage = 0;
-					spell.DamageType = (int)eDamageType.Heat;
+					spell.DamageType = (int)eDamageType.Cold;
 					spell.SpellID = 6003;
 					spell.Target = "Enemy";
 					spell.Type = "FumbleChanceDebuff";
@@ -309,7 +309,7 @@ namespace DOL.GS
 					spell.Value = 100;
 					spell.Duration = 90* DragonDifficulty /100;
 					spell.Damage = 0;
-					spell.DamageType = (int)eDamageType.Heat;
+					spell.DamageType = (int)eDamageType.Cold;
 					spell.SpellID = 6003;
 					spell.Target = "Enemy";
 					spell.Type = "Nearsight";


### PR DESCRIPTION
Cuul and Gjal were using heat for their debuff damagetype, likely due to be copy/pasted from Gole.  Changed to match their glare and breath damage types.