### PR TITLE
Fixed CastSpell() call

### DIFF
--- a/GameServer/gameobjects/Bonedancer/CommanderPet.cs
+++ b/GameServer/gameobjects/Bonedancer/CommanderPet.cs
@@ -175,7 +175,7 @@ namespace DOL.GS
 						{
 							if (spell.Name == LanguageMgr.GetTranslation(player.Client.Account.Language, "GameObjects.CommanderPet.WR.Spell.Empower"))
 							{
-								CastSpell(spell, m_mobSpellLine);
+								CastSpell(spell, SkillBase.GetSpellLine(GlobalSpellsLines.Mob_Spells));
 								break;
 							}
 						}

--- a/GameServer/gameobjects/Bonedancer/CommanderPet.cs
+++ b/GameServer/gameobjects/Bonedancer/CommanderPet.cs
@@ -175,7 +175,7 @@ namespace DOL.GS
 						{
 							if (spell.Name == LanguageMgr.GetTranslation(player.Client.Account.Language, "GameObjects.CommanderPet.WR.Spell.Empower"))
 							{
-								CastSpell(spell, null);
+								CastSpell(spell, m_mobSpellLine);
 								break;
 							}
 						}


### PR DESCRIPTION
Calling CastSpell() with NULL for line causes an exception.