### PR TITLE
Pet cancel buffs

### DIFF
--- a/GameServer/gameobjects/Bonedancer/CommanderPet.cs
+++ b/GameServer/gameobjects/Bonedancer/CommanderPet.cs
@@ -323,6 +323,13 @@ namespace DOL.GS
 				//Found it, lets remove it
 				if (found)
 				{
+					if (controlledNpc.Body != null && controlledNpc.Body is GamePet)
+                    			{
+						GamePet minion = controlledNpc.Body as GamePet;
+						minion.StripOwnerBuffs(this); // Strip buffs off commander
+						minion.StripOwnerBuffs(Owner); // Strip buffs off player
+                    			}
+				
 					//First lets store the brain to kill it
 					IControlledBrain tempBrain = m_controlledBrain[i];
 					//Lets get rid of the brain asap

--- a/GameServer/gameobjects/CharacterClasses/CharacterClassBase.cs
+++ b/GameServer/gameobjects/CharacterClasses/CharacterClassBase.cs
@@ -350,6 +350,11 @@ namespace DOL.GS
 			GameNPC npc = controlledBrain.Body;
 			if (npc == null)
 				return;
+			else if (npc is GamePet)
+            		{
+				GamePet pet = npc as GamePet;
+				pet.StripOwnerBuffs(pet.Owner);
+            		}
 
 			Player.Notify(GameLivingEvent.PetReleased, npc);
 		}

--- a/GameServer/gameobjects/GamePet.cs
+++ b/GameServer/gameobjects/GamePet.cs
@@ -381,9 +381,34 @@ namespace DOL.GS
 
 		public override void Die(GameObject killer)
 		{
+			StripOwnerBuffs(Owner);
+		
 			GameEventMgr.Notify(GameLivingEvent.PetReleased, this);
 			base.Die(killer);
 			CurrentRegion = null;
+		}
+		
+		/// <summary>
+		/// Strips any buffs this pet cast on owner
+		/// </summary>
+		/// <param name="owner">
+		/// The target to strip buffs off of.
+		/// </param>
+		public virtual void StripOwnerBuffs(GameLiving owner)
+		{
+			if (owner != null & owner.EffectList != null)
+			{
+			   	foreach (IGameEffect effect in owner.EffectList)
+				{
+					if (effect != null && effect is GameSpellEffect)
+					{
+						GameSpellEffect spelleffect = effect as GameSpellEffect;
+						if (spelleffect.SpellHandler != null && spelleffect.SpellHandler.Caster != null
+							&& spelleffect.SpellHandler.Caster == this)
+								spelleffect.Cancel(false);
+					}
+				}
+			}
 		}
 		
 		/// <summary>

--- a/GameServer/gameobjects/GamePet.cs
+++ b/GameServer/gameobjects/GamePet.cs
@@ -19,6 +19,7 @@
 using System;
 using DOL.AI.Brain;
 using DOL.Database;
+using DOL.GS.Effects;
 using DOL.Events;
 using DOL.GS.ServerProperties;
 using DOL.GS.Spells;


### PR DESCRIPTION
This adds a new method, StripOwnerBuffs(), to GamePet, which is called when the pet dies and when a player releases it.

It will stop players from summoning one pet to get buffs, and then releasing it to summon something else while still keeping the buff.