### PR TITLE
Stop pets from getting aggro out of LOS

### DIFF
--- a/GameServer/ai/brain/StandardMobBrain.cs
+++ b/GameServer/ai/brain/StandardMobBrain.cs
@@ -248,7 +248,10 @@ namespace DOL.AI.Brain
 
 				if (CalculateAggroLevelToTarget(npc) > 0)
 				{
-					AddToAggroList(npc, (npc.Level + 1) << 1);
+					if (npc is GamePet) // Required to stop pets from being aggro'd without LOS
+						AddToAggroList(npc, (npc.Level + 1) << 1, true);
+					else
+						AddToAggroList(npc, (npc.Level + 1) << 1);
 				}
 			}
 		}


### PR DESCRIPTION
I reported this a while back, but it doesn't look like it was remedied: http://www.dolserver.net/viewtopic.php?f=5&t=23087&p=158981&hilit=pet+aggro+through+wall

This is a quick fix rather than resolving the underlying problem.  There may be other issues stemming from the underlying race condition Leo mentions, but fixing that is beyond my capabilities.