### PR TITLE
Server prop for Alb weapon dual spec

### DIFF
--- a/GameServer/gameobjects/GameLiving.cs
+++ b/GameServer/gameobjects/GameLiving.cs
@@ -1745,24 +1745,23 @@ namespace DOL.GS
 					weaponTypeToUse.Object_Type = weapon.Object_Type;
 					weaponTypeToUse.SlotPosition = weapon.SlotPosition;
 
-					if ((this is GamePlayer) && Realm == eRealm.Albion && ServerProperties.Properties.ENABLE_ALB_WEAPON_DUAL_SPEC)
+					if ((this is GamePlayer) 
+						&& (GameServer.ServerRules.IsObjectTypesEqual((eObjectType)weapon.Object_Type, eObjectType.TwoHandedWeapon) 
+						|| GameServer.ServerRules.IsObjectTypesEqual((eObjectType)weapon.Object_Type, eObjectType.PolearmWeapon))
+						&& ServerProperties.Properties.ENABLE_ALB_WEAPON_DUAL_SPEC)
 					{
 						// Albion dual spec penalty, which sets minimum damage to the base damage spec
-
-						if (GameServer.ServerRules.IsObjectTypesEqual((eObjectType)weapon.Object_Type, eObjectType.TwoHandedWeapon) || GameServer.ServerRules.IsObjectTypesEqual((eObjectType)weapon.Object_Type, eObjectType.PolearmWeapon))
+						if (weapon.Type_Damage == (int)eDamageType.Crush)
 						{
-							if (weapon.Type_Damage == (int)eDamageType.Crush)
-							{
-								weaponTypeToUse.Object_Type = (int)eObjectType.CrushingWeapon;
-							}
-							else if (weapon.Type_Damage == (int)eDamageType.Slash)
-							{
-								weaponTypeToUse.Object_Type = (int)eObjectType.SlashingWeapon;
-							}
-							else
-							{
-								weaponTypeToUse.Object_Type = (int)eObjectType.ThrustWeapon;
-							}
+							weaponTypeToUse.Object_Type = (int)eObjectType.CrushingWeapon;
+						}
+						else if (weapon.Type_Damage == (int)eDamageType.Slash)
+						{
+							weaponTypeToUse.Object_Type = (int)eObjectType.SlashingWeapon;
+						}
+						else
+						{
+							weaponTypeToUse.Object_Type = (int)eObjectType.ThrustWeapon;
 						}
 					}
 				}

--- a/GameServer/gameobjects/GameLiving.cs
+++ b/GameServer/gameobjects/GameLiving.cs
@@ -1748,7 +1748,7 @@ namespace DOL.GS
 					if ((this is GamePlayer) && Realm == eRealm.Albion
 						&& (GameServer.ServerRules.IsObjectTypesEqual((eObjectType)weapon.Object_Type, eObjectType.TwoHandedWeapon) 
 						|| GameServer.ServerRules.IsObjectTypesEqual((eObjectType)weapon.Object_Type, eObjectType.PolearmWeapon))
-						&& ServerProperties.Properties.ENABLE_ALB_WEAPON_DUAL_SPEC)
+						&& ServerProperties.Properties.ENABLE_ALBION_ADVANCED_WEAPON_SPEC)
 					{
 						// Albion dual spec penalty, which sets minimum damage to the base damage spec
 						if (weapon.Type_Damage == (int)eDamageType.Crush)

--- a/GameServer/gameobjects/GameLiving.cs
+++ b/GameServer/gameobjects/GameLiving.cs
@@ -1745,7 +1745,7 @@ namespace DOL.GS
 					weaponTypeToUse.Object_Type = weapon.Object_Type;
 					weaponTypeToUse.SlotPosition = weapon.SlotPosition;
 
-					if ((this is GamePlayer) && Realm == eRealm.Albion)
+					if ((this is GamePlayer) && Realm == eRealm.Albion && ServerProperties.Properties.ENABLE_ALB_WEAPON_DUAL_SPEC)
 					{
 						// Albion dual spec penalty, which sets minimum damage to the base damage spec
 

--- a/GameServer/gameobjects/GameLiving.cs
+++ b/GameServer/gameobjects/GameLiving.cs
@@ -1745,7 +1745,7 @@ namespace DOL.GS
 					weaponTypeToUse.Object_Type = weapon.Object_Type;
 					weaponTypeToUse.SlotPosition = weapon.SlotPosition;
 
-					if ((this is GamePlayer) 
+					if ((this is GamePlayer) && Realm == eRealm.Albion
 						&& (GameServer.ServerRules.IsObjectTypesEqual((eObjectType)weapon.Object_Type, eObjectType.TwoHandedWeapon) 
 						|| GameServer.ServerRules.IsObjectTypesEqual((eObjectType)weapon.Object_Type, eObjectType.PolearmWeapon))
 						&& ServerProperties.Properties.ENABLE_ALB_WEAPON_DUAL_SPEC)

--- a/GameServer/serverproperty/ServerProperties.cs
+++ b/GameServer/serverproperty/ServerProperties.cs
@@ -550,8 +550,8 @@ namespace DOL.GS.ServerProperties
 		/// <summary>
 		/// Property to enable crush/slash/thrust determining damage variance for polearms and 2H weapons
 		/// </summary>
-		[ServerProperty("server", "enable_alb_weapon_dual_spec", "Base weapon damage variance for polearms and 2H weapons on crush/slash/thrust spec?", true)]
-		public static bool ENABLE_ALB_WEAPON_DUAL_SPEC;
+		[ServerProperty("server", "enable_albion_advanced_weapon_spec", "Set to true to determine damage variance for polearms and 2H weapons on 1H crush/slash/thrust spec.", true)]
+		public static bool ENABLE_ALBION_ADVANCED_WEAPON_SPEC;
 		#endregion
 
 		#region WORLD

--- a/GameServer/serverproperty/ServerProperties.cs
+++ b/GameServer/serverproperty/ServerProperties.cs
@@ -547,6 +547,11 @@ namespace DOL.GS.ServerProperties
 		[ServerProperty("server", "use_new_tooltip_forcedupdate", "Set to true if you wish to enable the new 1.110+ Tooltip Forced update each time the server send a skill to a new client.", true)]
 		public static bool USE_NEW_TOOLTIP_FORCEDUPDATE;
 
+		/// <summary>
+		/// Property to enable crush/slash/thrust determining damage variance for polearms and 2H weapons
+		/// </summary>
+		[ServerProperty("server", "enable_alb_weapon_dual_spec", "Base weapon damage variance for polearms and 2H weapons on crush/slash/thrust spec?", true)]
+		public static bool ENABLE_ALB_WEAPON_DUAL_SPEC;
 		#endregion
 
 		#region WORLD


### PR DESCRIPTION
This is an old and controversial issue.

At release, Mythic said that Alb weapons did more damage than other realms, at the cost of having to spend more spec points to get there, but tests on live disproves that.  I remember Hib tanks being pissed because once they maxed out parry and spear, they had wasted spec points, while Alb tanks still had useful things to spend points on.  There's still people trying to get Broadsword to change it on live.

Since live still dual specs, the responsible option is a server prop set to dual spec by default.  Let people decide for themselves if they want dual speccing or not.