### PR TITLE
Removed Gateway location check for PvE servers

### DIFF
--- a/GameServer/spells/Teleport/GatewayPersonalBind.cs
+++ b/GameServer/spells/Teleport/GatewayPersonalBind.cs
@@ -54,7 +54,7 @@ namespace DOL.GS.Spells
 			if (player == null)
 				return false;
 
-			if (player.CurrentRegion.IsRvR || player.CurrentRegion.IsInstance)
+			if ((player.CurrentRegion.IsRvR || player.CurrentRegion.IsInstance) && GameServer.Instance.Configuration.ServerType != eGameServerType.GST_PvE)
 			{
 				// Actual live message is: You can't use that item!
 				player.Out.SendMessage("You can't use that here!", DOL.GS.PacketHandler.eChatType.CT_System, DOL.GS.PacketHandler.eChatLoc.CL_SystemWindow);


### PR DESCRIPTION
The RVR zone check doesn't make sense for PvE servers, and I don't see any reason for the instance check at all.  If there is a reason for the instance check that I'm not seeing, it's easy enough to change this to still do it.