### PR TITLE
Added Parameterised Database.SelectObject() methods

### DIFF
--- a/DOLDatabase/IObjectDatabase.cs
+++ b/DOLDatabase/IObjectDatabase.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * DAWN OF LIGHT - The first free open source DAoC server emulator
  * 
  * This program is free software; you can redistribute it and/or
@@ -92,6 +92,36 @@ namespace DOL.Database
 		#endregion
 
 		#region Select Where Clause With Parameters
+		/// <summary>
+ +		/// Retrieve a Single DataObject from the database based on the Where Expression and Parameters Collection
+ +		/// </summary>
+ +		/// <typeparam name="TObject"></typeparam>
+ +		/// <param name="whereExpression"></param>
+ +		/// <param name="parameters"></param>
+ +		/// <returns></returns>
+ +		TObject SelectObject<TObject>(string whereExpression, IEnumerable<IEnumerable<QueryParameter>> parameters)
+ +			where TObject : DataObject;
+ +
+ +		/// <summary>
+ +		/// Retrieve a Single DataObject from database based on Where Expression and Parameters
+ +		/// </summary>
+ +		/// <typeparam name="TObject"></typeparam>
+ +		/// <param name="whereExpression"></param>
+ +		/// <param name="parameter"></param>
+ +		/// <returns></returns>
+ +		TObject SelectObject<TObject>(string whereExpression, IEnumerable<QueryParameter> parameter)
+ +			where TObject : DataObject;
+ +
+ +		/// <summary>
+ +		/// Retrieve a Single DataObject from database based on Where Expression and Parameter
+ +		/// </summary>
+ +		/// <typeparam name="TObject"></typeparam>
+ +		/// <param name="whereExpression"></param>
+ +		/// <param name="param"></param>
+ +		/// <returns></returns>
+ +		TObject SelectObject<TObject>(string whereExpression, QueryParameter param)
+ +			where TObject : DataObject;
+
 		/// <summary>
 		/// Retrieve a Single DataObject from the database based on the Where Expression and Parameters Collection
 		/// </summary>

--- a/DOLDatabase/IObjectDatabase.cs
+++ b/DOLDatabase/IObjectDatabase.cs
@@ -90,8 +90,38 @@ namespace DOL.Database
 		IList<TObject> FindObjectsByKey<TObject>(IEnumerable<object> keys)
 			where TObject : DataObject;
 		#endregion
-		
+
 		#region Select Where Clause With Parameters
+		/// <summary>
+		/// Retrieve a Single DataObject from the database based on the Where Expression and Parameters Collection
+		/// </summary>
+		/// <typeparam name="TObject"></typeparam>
+		/// <param name="whereExpression"></param>
+		/// <param name="parameters"></param>
+		/// <returns></returns>
+		TObject SelectObject<TObject>(string whereExpression, IEnumerable<IEnumerable<QueryParameter>> parameters)
+			where TObject : DataObject;
+
+		/// <summary>
+		/// Retrieve a Single DataObject from database based on Where Expression and Parameters
+		/// </summary>
+		/// <typeparam name="TObject"></typeparam>
+		/// <param name="whereExpression"></param>
+		/// <param name="parameter"></param>
+		/// <returns></returns>
+		TObject SelectObject<TObject>(string whereExpression, IEnumerable<QueryParameter> parameter)
+			where TObject : DataObject;
+
+		/// <summary>
+		/// Retrieve a Single DataObject from database based on Where Expression and Parameter
+		/// </summary>
+		/// <typeparam name="TObject"></typeparam>
+		/// <param name="whereExpression"></param>
+		/// <param name="param"></param>
+		/// <returns></returns>
+		TObject SelectObject<TObject>(string whereExpression, QueryParameter param)
+			where TObject : DataObject;
+
 		/// <summary>
 		/// Retrieve a Collection of DataObjects from database based on the Where Expression and Parameters Collection
 		/// </summary>

--- a/DOLDatabase/ObjectDatabase.cs
+++ b/DOLDatabase/ObjectDatabase.cs
@@ -717,8 +717,50 @@ namespace DOL.Database
 		/// <returns>Collection of DataObject with primary key matching values</returns>
 		protected abstract IEnumerable<DataObject> FindObjectByKeyImpl(DataTableHandler tableHandler, IEnumerable<object> keys);
 		#endregion
-		
+
 		#region Public Object Select API With Parameters
+		/// <summary>
+		/// Retrieve a Single DataObject from the database based on the Where Expression and Parameters Collection
+		/// </summary>
+		/// <typeparam name="TObject"></typeparam>
+		/// <param name="whereExpression"></param>
+		/// <param name="parameters"></param>
+		/// <returns>DataObject or null</returns>
+		public TObject SelectObject<TObject>(string whereExpression, IEnumerable<IEnumerable<QueryParameter>> parameters)
+			where TObject : DataObject
+		{
+			IList<TObject> list = SelectObjects<TObject>(whereExpression, parameters).First();
+			if (list != null)
+				return list.First();
+			return null;
+		}
+
+		/// <summary>
+		/// Retrieve a Single DataObject from database based on Where Expression and Parameters
+		/// </summary>
+		/// <typeparam name="TObject"></typeparam>
+		/// <param name="whereExpression"></param>
+		/// <param name="parameter"></param>
+		/// <returns></returns>
+		public TObject SelectObject<TObject>(string whereExpression, IEnumerable<QueryParameter> parameter)
+			where TObject : DataObject
+		{
+			return SelectObjects<TObject>(whereExpression, parameter).First();
+		}
+
+		/// <summary>
+		/// Retrieve a Single DataObject from database based on Where Expression and Parameter
+		/// </summary>
+		/// <typeparam name="TObject"></typeparam>
+		/// <param name="whereExpression"></param>
+		/// <param name="param"></param>
+		/// <returns></returns>
+		public TObject SelectObject<TObject>(string whereExpression, QueryParameter param)
+			where TObject : DataObject
+		{
+			return SelectObjects<TObject>(whereExpression, param).First();
+		}
+
 		/// <summary>
 		/// Retrieve a Collection of DataObjects from database based on the Where Expression and Parameters Collection
 		/// </summary>

--- a/DOLDatabase/ObjectDatabase.cs
+++ b/DOLDatabase/ObjectDatabase.cs
@@ -720,6 +720,48 @@ namespace DOL.Database
 
 		#region Public Object Select API With Parameters
 		/// <summary>
+ +		/// Retrieve a Single DataObject from the database based on the Where Expression and Parameters Collection
+ +		/// </summary>
+ +		/// <typeparam name="TObject"></typeparam>
+ +		/// <param name="whereExpression"></param>
+ +		/// <param name="parameters"></param>
+ +		/// <returns>DataObject or null</returns>
+ +		public TObject SelectObject<TObject>(string whereExpression, IEnumerable<IEnumerable<QueryParameter>> parameters)
+ +			where TObject : DataObject
+ +		{
+ +			IList<TObject> list = SelectObjects<TObject>(whereExpression, parameters).First();
+ +			if (list != null)
+ +				return list.First();
+ +			return null;
+ +		}
+ +
+ +		/// <summary>
+ +		/// Retrieve a Single DataObject from database based on Where Expression and Parameters
+ +		/// </summary>
+ +		/// <typeparam name="TObject"></typeparam>
+ +		/// <param name="whereExpression"></param>
+ +		/// <param name="parameter"></param>
+ +		/// <returns></returns>
+ +		public TObject SelectObject<TObject>(string whereExpression, IEnumerable<QueryParameter> parameter)
+ +			where TObject : DataObject
+ +		{
+ +			return SelectObjects<TObject>(whereExpression, parameter).First();
+ +		}
+ +
+ +		/// <summary>
+ +		/// Retrieve a Single DataObject from database based on Where Expression and Parameter
+ +		/// </summary>
+ +		/// <typeparam name="TObject"></typeparam>
+ +		/// <param name="whereExpression"></param>
+ +		/// <param name="param"></param>
+ +		/// <returns></returns>
+ +		public TObject SelectObject<TObject>(string whereExpression, QueryParameter param)
+ +			where TObject : DataObject
+ +		{
+ +			return SelectObjects<TObject>(whereExpression, param).First();
+ +		}
+		
+		/// <summary>
 		/// Retrieve a Single DataObject from the database based on the Where Expression and Parameters Collection
 		/// </summary>
 		/// <typeparam name="TObject"></typeparam>


### PR DESCRIPTION
The current SelectObject() methods are flagged as obsolete, but no parameterized versions exist for them.  This uses the existing parameterized SelectObjects() methods to get lists, and then return the first object in them.