### PR TITLE
Scale bd minion effects by player spec

### DIFF
--- a/DOLDatabase/IObjectDatabase.cs
+++ b/DOLDatabase/IObjectDatabase.cs
@@ -93,6 +93,36 @@ namespace DOL.Database
 		
 		#region Select Where Clause With Parameters
 		/// <summary>
+ 		/// Retrieve a Single DataObject from the database based on the Where Expression and Parameters Collection
+ 		/// </summary>
+ 		/// <typeparam name="TObject"></typeparam>
+ 		/// <param name="whereExpression"></param>
+ 		/// <param name="parameters"></param>
+ 		/// <returns></returns>
+ 		TObject SelectObject<TObject>(string whereExpression, IEnumerable<IEnumerable<QueryParameter>> parameters)
+ 			where TObject : DataObject;
+ 
+ 		/// <summary>
+ 		/// Retrieve a Single DataObject from database based on Where Expression and Parameters
+ 		/// </summary>
+ 		/// <typeparam name="TObject"></typeparam>
+ 		/// <param name="whereExpression"></param>
+ 		/// <param name="parameter"></param>
+ 		/// <returns></returns>
+ 		TObject SelectObject<TObject>(string whereExpression, IEnumerable<QueryParameter> parameter)
+ 			where TObject : DataObject;
+ 
+ 		/// <summary>
+ 		/// Retrieve a Single DataObject from database based on Where Expression and Parameter
+ 		/// </summary>
+ 		/// <typeparam name="TObject"></typeparam>
+ 		/// <param name="whereExpression"></param>
+ 		/// <param name="param"></param>
+ 		/// <returns></returns>
+ 		TObject SelectObject<TObject>(string whereExpression, QueryParameter param)
+ 			where TObject : DataObject;
+
+		/// <summary>
 		/// Retrieve a Collection of DataObjects from database based on the Where Expression and Parameters Collection
 		/// </summary>
 		/// <param name="whereExpression">Parametrized Where Expression</param>

--- a/DOLDatabase/ObjectDatabase.cs
+++ b/DOLDatabase/ObjectDatabase.cs
@@ -720,6 +720,48 @@ namespace DOL.Database
 		
 		#region Public Object Select API With Parameters
 		/// <summary>
+		/// Retrieve a Single DataObject from the database based on the Where Expression and Parameters Collection
+		/// </summary>
+		/// <typeparam name="TObject"></typeparam>
+		/// <param name="whereExpression"></param>
+		/// <param name="parameters"></param>
+		/// <returns>DataObject or null</returns>
+		public TObject SelectObject<TObject>(string whereExpression, IEnumerable<IEnumerable<QueryParameter>> parameters)
+			where TObject : DataObject
+		{
+			IList<TObject> list = SelectObjects<TObject>(whereExpression, parameters).First();
+			if (list != null)
+				return list.First();
+			return null;
+		}
+
+		/// <summary>
+		/// Retrieve a Single DataObject from database based on Where Expression and Parameters
+		/// </summary>
+		/// <typeparam name="TObject"></typeparam>
+		/// <param name="whereExpression"></param>
+		/// <param name="parameter"></param>
+		/// <returns></returns>
+		public TObject SelectObject<TObject>(string whereExpression, IEnumerable<QueryParameter> parameter)
+			where TObject : DataObject
+		{
+			return SelectObjects<TObject>(whereExpression, parameter).First();
+		}
+
+		/// <summary>
+		/// Retrieve a Single DataObject from database based on Where Expression and Parameter
+		/// </summary>
+		/// <typeparam name="TObject"></typeparam>
+		/// <param name="whereExpression"></param>
+		/// <param name="param"></param>
+		/// <returns></returns>
+		public TObject SelectObject<TObject>(string whereExpression, QueryParameter param)
+			where TObject : DataObject
+		{
+			return SelectObjects<TObject>(whereExpression, param).First();
+		}
+
+		/// <summary>
 		/// Retrieve a Collection of DataObjects from database based on the Where Expression and Parameters Collection
 		/// </summary>
 		/// <param name="whereExpression">Parametrized Where Expression</param>

--- a/GameServer/gameobjects/Bonedancer/BDSubPet.cs
+++ b/GameServer/gameobjects/Bonedancer/BDSubPet.cs
@@ -48,6 +48,37 @@ namespace DOL.GS
 			Archer = 5
 		}
 
+		protected string m_PetSpecLine = null;
+		/// <summary>
+		/// Returns the spell line specialization this pet was summoned from
+		/// </summary>
+		public string PetSpecLine
+		{
+			get
+			{
+				// This is really inefficient, so only do it once, and only if we actually need it
+				if (m_PetSpecLine == null && Owner is CommanderPet commander && commander.Owner is GamePlayer player)
+				{
+					// Get the spell that summoned this pet
+					DBSpell dbSummoningSpell = GameServer.Database.SelectObject<DBSpell>("LifeDrainReturn=@TemplateId", new QueryParameter("@TemplateID", NPCTemplate.TemplateId));
+					if (dbSummoningSpell != null)
+					{
+						// Figure out which spell line the summoning spell is from
+						DBLineXSpell dbLineSpell = GameServer.Database.SelectObject<DBLineXSpell>("SpellID=@SpellID", new QueryParameter("@SpellID", dbSummoningSpell.SpellID));
+						if (dbLineSpell != null)
+						{
+							// Now figure out what the spec name is
+							SpellLine line = player.GetSpellLine(dbLineSpell.LineName);
+							if (line != null)
+								m_PetSpecLine = line.Spec;
+						}
+					}
+				}
+
+				return m_PetSpecLine;
+			}
+		}
+
 		/// <summary>
 		/// Create a commander.
 		/// </summary>

--- a/GameServer/spells/SpellHandler.cs
+++ b/GameServer/spells/SpellHandler.cs
@@ -382,6 +382,14 @@ namespace DOL.GS.Spells
             // Scale spells that are cast by pets
             if (Caster is GamePet && !(Caster is NecromancerPet) && ServerProperties.Properties.PET_SCALE_SPELL_MAX_LEVEL > 0)
             {
+				double CasterLevel;
+
+				// Cap the level we scale BD minions' spell effects to the player's modified spec for the spec line the pet is from
+				if (Caster is BDSubPet subpet && subpet.Owner is CommanderPet commander && commander.Owner is GamePlayer player)
+					CasterLevel = Math.Min(subpet.Level, player.GetModifiedSpecLevel(subpet.PetSpecLine));
+				else
+					CasterLevel = Caster.Level;
+					
                 switch (m_spell.SpellType.ToString().ToLower())
                 {
                     // Scale Damage
@@ -393,7 +401,7 @@ namespace DOL.GS.Spells
                     case "lifedrain":
                     case "damagespeeddecrease":
                     case "StyleBleeding": // Style Effect
-                        Spell.Damage = Spell.Damage * (double)(Caster.Level) / ServerProperties.Properties.PET_SCALE_SPELL_MAX_LEVEL;
+						Spell.Damage = Spell.Damage * CasterLevel / ServerProperties.Properties.PET_SCALE_SPELL_MAX_LEVEL;
                         break;
                     // Scale Value
                     case "enduranceregenbuff":
@@ -425,14 +433,14 @@ namespace DOL.GS.Spells
                     case "stylecombatspeeddebuff": // Style Effect
                     case "stylespeeddecrease": // Style Effect
                     //case "styletaunt":  Taunt styles already scale with damage, leave their values alone.
-                        Spell.Value = Spell.Value * (double)(Caster.Level) / ServerProperties.Properties.PET_SCALE_SPELL_MAX_LEVEL;
+						Spell.Value = Spell.Value * CasterLevel / ServerProperties.Properties.PET_SCALE_SPELL_MAX_LEVEL;
                         break;
                     // Scale Duration
                     case "disease":
                     case "stun":
                     case "Mesmerize":
                     case "stylestun": // Style Effect
-                        Spell.Duration = (int)Math.Round(Spell.Duration * (double)(Caster.Level) / ServerProperties.Properties.PET_SCALE_SPELL_MAX_LEVEL); ;
+						Spell.Duration = (int)Math.Round(Spell.Duration * CasterLevel / ServerProperties.Properties.PET_SCALE_SPELL_MAX_LEVEL);
                         break;
                     default: break; // Don't mess with types we don't know
                 } // switch (m_spell.SpellType.ToString().ToLower())


### PR DESCRIPTION
This change makes low spec BD pets useful without making them overpowered for the amount the player has invested in them.  It also provides more reason to branch out BD specs and to gear for +skill bonuses.

Currently, pet spell scaling is based entirely on pet level.  If you summon a bone guardian, it will cast the same quality of buffs if you only have 20 spec in suppression as if you spec'd all the way to 50.  That's just not right, and leads to dipping into a secondary spec being more powerful than it should be.  A good example would be a BA BD speccing to 15 in suppression to get the same full damage shield and attack speed buffs they'd get if they were specced to 50 in suppression.  There should be a consequence to that which also provides incentive to spec further into suppression and to gear +suppression skill items.

By capping the pet caster level when scaling to the player's modified spec, low level minions are still useful but not disproportionately so.  It also provides incentive to gear for secondary spec bonuses.  With full gear and RR bonuses at 20 spec, it almost reaches parity: 20 + 11 for gear + 10 for RR = level 41 when 42 is the max level for minions on live.

Even the melee pets are impacted by this as their style effects are scaled, so the bleed and melee speed reduction from pillager/plunderer will vary according to player spec.  The only subpet it won't impact is archers, and if archers are changed to use archery spells down the road they will be impacted as well.