### PR TITLE
Fixed issue with archer mobs at max range

### DIFF
--- a/GameServer/gameobjects/GameNPC.cs
+++ b/GameServer/gameobjects/GameNPC.cs
@@ -3888,7 +3888,7 @@ namespace DOL.GS
 				if (ActiveWeaponSlot == eActiveWeaponSlot.Distance)
 				{
 					// Archer mobs sometimes bug and keep trying to fire at max range unsuccessfully so force them to get just a tad closer.
-					Follow(target, AttackRange - 10, STICKMAXIMUMRANGE);
+					Follow(target, AttackRange - 30, STICKMAXIMUMRANGE);
 				}
 				else
 				{

--- a/GameServer/gameobjects/GameNPC.cs
+++ b/GameServer/gameobjects/GameNPC.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * DAWN OF LIGHT - The first free open source DAoC server emulator
  *
  * This program is free software; you can redistribute it and/or
@@ -3887,7 +3887,8 @@ namespace DOL.GS
 
 				if (ActiveWeaponSlot == eActiveWeaponSlot.Distance)
 				{
-					Follow(target, AttackRange, STICKMAXIMUMRANGE);
+					// Archer mobs sometimes bug and keep trying to fire at max range unsuccessfully so force them to get just a tad closer.
+					Follow(target, AttackRange - 10, STICKMAXIMUMRANGE);
 				}
 				else
 				{


### PR DESCRIPTION
Sometimes, mobs will try to fire arrows but due to some gimmick in the math somewhere be just a hair out of range.  This leads to them starting to fire over and over again without actually firing.  It appears to add multiple ranged fire timers, so the moment the target is in range, all the timers go off at once and do a ridiculous amount of burst damage.

By forcing mobs to move just a tiny bit closer before firing, this issue appears to be resolved.