### PR TITLE
autoselect caster for realm spells

### DIFF
--- a/GameServer/spells/SpellHandler.cs
+++ b/GameServer/spells/SpellHandler.cs
@@ -346,6 +346,19 @@ namespace DOL.GS.Spells
 		#endregion
 
 		/// <summary>
+		/// Sets the target of the spell to the caster for beneficial effects when not selecting a valid target
+		///		ie. You're in the middle of a fight with a mob and want to heal yourself.  Rather than having to switch
+		///		targets to yourself to healm and then back to the target, you can just heal yourself
+		/// </summary>
+		/// <param name="target">The current target of the spell, changed to the player if appropriate</param>
+		protected virtual void AutoSelectCaster(ref GameLiving target)
+		{
+			if (Spell.Target.ToUpper() == "REALM" && 
+				(target == null || !(target is GameNPC npc) || npc.Realm != Caster.Realm || (npc.Flags & GameNPC.eFlags.PEACE) != 0))
+				target = Caster;
+		}
+
+		/// <summary>
 		/// Cast a spell by using an item
 		/// </summary>
 		/// <param name="item"></param>
@@ -438,7 +451,9 @@ namespace DOL.GS.Spells
                 } // switch (m_spell.SpellType.ToString().ToLower())
             } // if (Caster is GamePet)
 
-            bool success = true;
+			bool success = true;
+
+			AutoSelectCaster(ref targetObject);
 
 			m_spellTarget = targetObject;
 
@@ -871,8 +886,8 @@ namespace DOL.GS.Spells
 						break;
 				}
 
-				//heals/buffs/rez need LOS only to start casting
-				if (!m_caster.TargetInView && m_spell.Target.ToLower() != "pet")
+				//heals/buffs/rez need LOS only to start casting, TargetInView only works if Caster.TargetObject == selectedTarget
+				if (selectedTarget == Caster.TargetObject && !m_caster.TargetInView && m_spell.Target.ToLower() != "pet")
 				{
 					if (!quiet) MessageToCaster("Your target is not in visible!", eChatType.CT_SpellResisted);
 					Caster.Notify(GameLivingEvent.CastFailed, new CastFailedEventArgs(this, CastFailedEventArgs.Reasons.TargetNotInView));

--- a/GameServer/spells/SpellHandler.cs
+++ b/GameServer/spells/SpellHandler.cs
@@ -353,8 +353,9 @@ namespace DOL.GS.Spells
 		/// <param name="target">The current target of the spell, changed to the player if appropriate</param>
 		protected virtual void AutoSelectCaster(ref GameLiving target)
 		{
-			if (Caster is GamePlayer && Spell.Target.ToUpper() == "REALM" && 
-				(target == null || !(target is GameNPC npc) || npc.Realm != Caster.Realm || (npc.Flags & GameNPC.eFlags.PEACE) != 0))
+			GameNPC npc = target as GameNPC;
+			if (Spell.Target.ToUpper() == "REALM" && Caster is GamePlayer &&
+				(npc == null || npc.Realm != Caster.Realm || (npc.Flags & GameNPC.eFlags.PEACE) != 0))
 				target = Caster;
 		}
 

--- a/GameServer/spells/SpellHandler.cs
+++ b/GameServer/spells/SpellHandler.cs
@@ -353,7 +353,7 @@ namespace DOL.GS.Spells
 		/// <param name="target">The current target of the spell, changed to the player if appropriate</param>
 		protected virtual void AutoSelectCaster(ref GameLiving target)
 		{
-			if (Spell.Target.ToUpper() == "REALM" && 
+			if (Caster is GamePlayer && Spell.Target.ToUpper() == "REALM" && 
 				(target == null || !(target is GameNPC npc) || npc.Realm != Caster.Realm || (npc.Flags & GameNPC.eFlags.PEACE) != 0))
 				target = Caster;
 		}


### PR DESCRIPTION
This adds caster autoselection for beneficial spells.  Let's say your valkyrie is soloing a mob, and you need to cast an insta-heal.  In live implementation, you have to target yourself, cast the heal, then target the mob.  With this change, the heal spell will automatically target the caster when the spell isn't appropriate for the current target, so you can just heal yourself without having to change targets.

While this isn't a live feature, it feels like a no brainer to me.  Other MMOs from the same generation included this as a feature, and it's ridiculous that live doesn't.  That said, it's really easy to add a server property to enable this if the community wishes.