### PR TITLE
Lord calls for help

### DIFF
--- a/GameServer/ai/brain/Guards/Lord.cs
+++ b/GameServer/ai/brain/Guards/Lord.cs
@@ -41,8 +41,10 @@ namespace DOL.AI.Brain
 		/// <param name="attackData">The data associated with the puller's attack.</param>
 		protected override void BringFriends(AttackData ad)
 		{
+						if (m_nextCallForHelpTime < currenttime && lord != null)
+
 			long currenttime = DateTime.UtcNow.Ticks;
-			if (m_nextCallForHelpTime < currenttime && Body is GuardLord lord)
+			if (m_nextCallForHelpTime < currenttime && lord != null)
 			{
 				// Don't call for help more than once every minute
 				m_nextCallForHelpTime = currenttime + TimeSpan.TicksPerMinute;

--- a/GameServer/ai/brain/Guards/Lord.cs
+++ b/GameServer/ai/brain/Guards/Lord.cs
@@ -53,7 +53,6 @@ namespace DOL.AI.Brain
 					m_nextCallForHelpTime = currenttime + TimeSpan.TicksPerMinute;
 
 					int iGuardsResponding = 0;
-					FrontierHastener hastener = guard as FrontierHastener;
 					foreach (GameKeepGuard guard in lord.Component.Keep.Guards.Values)
 						if (guard != null && guard.IsAlive && guard.IsAvailable && !(guard is FrontierHastener))
 						{

--- a/GameServer/ai/brain/Guards/Lord.cs
+++ b/GameServer/ai/brain/Guards/Lord.cs
@@ -1,5 +1,6 @@
 using DOL.GS;
 using DOL.GS.Keeps;
+using System;
 
 namespace DOL.AI.Brain
 {
@@ -41,30 +42,35 @@ namespace DOL.AI.Brain
 		/// <param name="attackData">The data associated with the puller's attack.</param>
 		protected override void BringFriends(AttackData ad)
 		{
-			GuardLord lord = Body as GuardLord;
-			long currenttime = DateTime.UtcNow.Ticks;
-			if (m_nextCallForHelpTime < currenttime && lord != null)
+			if (GameServer.Instance.Configuration.ServerType == eGameServerType.GST_PvE)
 			{
-				// Don't call for help more than once every minute
-				m_nextCallForHelpTime = currenttime + TimeSpan.TicksPerMinute;
+				GuardLord lord = Body as GuardLord;
+				long currenttime = DateTime.UtcNow.Ticks;
 
-				int iGuardsResponding = 0;
-				foreach (GameKeepGuard guard in lord.Component.Keep.Guards.Values)
-					if (guard != null && guard.IsAlive && guard.IsAvailable && !(guard is FrontierHastener))
-					{
-						iGuardsResponding++;
-						guard.Follow(ad.Target, GameNPC.STICKMINIMUMRANGE, int.MaxValue);
-					}
+				if (m_nextCallForHelpTime < currenttime && lord != null)
+				{
+					// Don't call for help more than once every minute
+					m_nextCallForHelpTime = currenttime + TimeSpan.TicksPerMinute;
 
-				string sMessage = $"{lord.Name} bellows for assistance ";
-				if (iGuardsResponding == 0)
-					sMessage += "but no guards respond!";
-				else
-					sMessage += $"and {iGuardsResponding} guards respond!";
+					int iGuardsResponding = 0;
+					FrontierHastener hastener = guard as FrontierHastener;
+					foreach (GameKeepGuard guard in lord.Component.Keep.Guards.Values)
+						if (guard != null && guard.IsAlive && guard.IsAvailable && !(guard is FrontierHastener))
+						{
+							iGuardsResponding++;
+							guard.Follow(ad.Target, GameNPC.STICKMINIMUMRANGE, int.MaxValue);
+						}
 
-				foreach (GamePlayer player in lord.GetPlayersInRadius(WorldMgr.VISIBILITY_DISTANCE, true))
-					if (player != null)
-						ChatUtil.SendErrorMessage(player, sMessage);
+					string sMessage = $"{lord.Name} bellows for assistance ";
+					if (iGuardsResponding == 0)
+						sMessage += "but no guards respond!";
+					else
+						sMessage += $"and {iGuardsResponding} guards respond!";
+
+					foreach (GamePlayer player in lord.GetPlayersInRadius(WorldMgr.VISIBILITY_DISTANCE, true))
+						if (player != null)
+							ChatUtil.SendErrorMessage(player, sMessage);
+				}
 			}
 		}
 	}// LordBrain

--- a/GameServer/ai/brain/Guards/Lord.cs
+++ b/GameServer/ai/brain/Guards/Lord.cs
@@ -41,8 +41,7 @@ namespace DOL.AI.Brain
 		/// <param name="attackData">The data associated with the puller's attack.</param>
 		protected override void BringFriends(AttackData ad)
 		{
-						if (m_nextCallForHelpTime < currenttime && lord != null)
-
+			GuardLord lord = Body as GuardLord;
 			long currenttime = DateTime.UtcNow.Ticks;
 			if (m_nextCallForHelpTime < currenttime && lord != null)
 			{

--- a/GameServer/ai/brain/Guards/Lord.cs
+++ b/GameServer/ai/brain/Guards/Lord.cs
@@ -41,8 +41,8 @@ namespace DOL.AI.Brain
 		/// <param name="attackData">The data associated with the puller's attack.</param>
 		protected override void BringFriends(AttackData ad)
 		{
-			long currenttime = DateTime.Now.Ticks;
-			if (Body is GuardLord lord && m_nextCallForHelpTime < currenttime)
+			long currenttime = DateTime.UtcNow.Ticks;
+			if (m_nextCallForHelpTime < currenttime && Body is GuardLord lord)
 			{
 				// Don't call for help more than once every minute
 				m_nextCallForHelpTime = currenttime + TimeSpan.TicksPerMinute;

--- a/GameServer/ai/brain/Guards/Lord.cs
+++ b/GameServer/ai/brain/Guards/Lord.cs
@@ -8,6 +8,8 @@ namespace DOL.AI.Brain
 	/// </summary>
 	public class LordBrain : KeepGuardBrain
 	{
+		private long m_nextCallForHelpTime = 0; // Used to limit how often keep lords call for help
+	
 		public LordBrain() : base()
 		{
 		}
@@ -32,5 +34,37 @@ namespace DOL.AI.Brain
 			}
 			base.Think();
 		}
-	}
+
+		/// <summary>
+		/// Bring all alive keep guards to defend the lord
+		/// </summary>
+		/// <param name="attackData">The data associated with the puller's attack.</param>
+		protected override void BringFriends(AttackData ad)
+		{
+			long currenttime = DateTime.Now.Ticks;
+			if (Body is GuardLord lord && m_nextCallForHelpTime < currenttime)
+			{
+				// Don't call for help more than once every minute
+				m_nextCallForHelpTime = currenttime + TimeSpan.TicksPerMinute;
+
+				int iGuardsResponding = 0;
+				foreach (GameKeepGuard guard in lord.Component.Keep.Guards.Values)
+					if (guard != null && guard.IsAlive && guard.IsAvailable && !(guard is FrontierHastener))
+					{
+						iGuardsResponding++;
+						guard.Follow(ad.Target, GameNPC.STICKMINIMUMRANGE, int.MaxValue);
+					}
+
+				string sMessage = $"{lord.Name} bellows for assistance ";
+				if (iGuardsResponding == 0)
+					sMessage += "but no guards respond!";
+				else
+					sMessage += $"and {iGuardsResponding} guards respond!";
+
+				foreach (GamePlayer player in lord.GetPlayersInRadius(WorldMgr.VISIBILITY_DISTANCE, true))
+					if (player != null)
+						ChatUtil.SendErrorMessage(player, sMessage);
+			}
+		}
+	}// LordBrain
 }

--- a/GameServer/gameobjects/GameNPC.cs
+++ b/GameServer/gameobjects/GameNPC.cs
@@ -945,15 +945,15 @@ namespace DOL.GS
 		/// <summary>
 		/// Property entry on follow timer, wether the follow target is in range
 		/// </summary>
-		protected static readonly string FOLLOW_TARGET_IN_RANGE = "FollowTargetInRange";
+		protected const string FOLLOW_TARGET_IN_RANGE = "FollowTargetInRange";
 		/// <summary>
 		/// Minimum allowed attacker follow distance to avoid issues with client / server resolution (herky jerky motion)
 		/// </summary>
-		protected static readonly int MIN_ALLOWED_FOLLOW_DISTANCE = 100;
+		protected const int MIN_ALLOWED_FOLLOW_DISTANCE = 100;
 		/// <summary>
 		/// Minimum allowed pet follow distance
 		/// </summary>
-		protected static readonly int MIN_ALLOWED_PET_FOLLOW_DISTANCE = 90;
+		protected const int MIN_ALLOWED_PET_FOLLOW_DISTANCE = 90;
 		/// <summary>
 		/// At what health percent will npc give up range attack and rush the attacker
 		/// </summary>
@@ -1451,8 +1451,8 @@ namespace DOL.GS
 			BroadcastUpdate();
 		}
 
-		private const int STICKMINIMUMRANGE = 100;
-		private const int STICKMAXIMUMRANGE = 5000;
+		public const int STICKMINIMUMRANGE = 100;
+		public const int STICKMAXIMUMRANGE = 5000;
 
 		/// <summary>
 		/// Follow given object


### PR DESCRIPTION
This causes keep lords to call for help when attacked, pulling every surviving guard in the keep to come help them without aggroing a specific target so they attack the first hostile they see.

Once we have pathing working, this will allow things like bottlenecking at stairwells, but for now guards just charge in from all directions so killing guards off before tagging the lord is a really good idea.

I know this is how Gaheris behaves, but I'm not sure about normal live.  Do keep lords exhibit the same behaviour on normal live servers?