### PR TITLE
Report keepitem duplicates & Optimization

### DIFF
--- a/GameServer/commands/gmcommands/keep.cs
+++ b/GameServer/commands/gmcommands/keep.cs
@@ -2166,7 +2166,7 @@ namespace DOL.GS.Commands
 
 							d.Component = new GameKeepComponent();
 							d.Component.AbstractKeep = k;
-							d.Component.AbstractKeep.Doors[d.DoorID] = this;
+							d.Component.AbstractKeep.Doors.Add(d.DoorID.ToString(), d);
 
 							d.Health = d.MaxHealth;
 							d.StartHealthRegeneration();

--- a/GameServer/gameobjects/GameNPC.cs
+++ b/GameServer/gameobjects/GameNPC.cs
@@ -945,15 +945,15 @@ namespace DOL.GS
 		/// <summary>
 		/// Property entry on follow timer, wether the follow target is in range
 		/// </summary>
-		protected const string FOLLOW_TARGET_IN_RANGE = "FollowTargetInRange";
+		protected static readonly string FOLLOW_TARGET_IN_RANGE = "FollowTargetInRange";
 		/// <summary>
 		/// Minimum allowed attacker follow distance to avoid issues with client / server resolution (herky jerky motion)
 		/// </summary>
-		protected const int MIN_ALLOWED_FOLLOW_DISTANCE = 100;
+		protected static readonly int MIN_ALLOWED_FOLLOW_DISTANCE = 100;
 		/// <summary>
 		/// Minimum allowed pet follow distance
 		/// </summary>
-		protected const int MIN_ALLOWED_PET_FOLLOW_DISTANCE = 90;
+		protected static readonly int MIN_ALLOWED_PET_FOLLOW_DISTANCE = 90;
 		/// <summary>
 		/// At what health percent will npc give up range attack and rush the attacker
 		/// </summary>
@@ -1451,8 +1451,8 @@ namespace DOL.GS
 			BroadcastUpdate();
 		}
 
-		public const int STICKMINIMUMRANGE = 100;
-		public const int STICKMAXIMUMRANGE = 5000;
+		private const int STICKMINIMUMRANGE = 100;
+		private const int STICKMAXIMUMRANGE = 5000;
 
 		/// <summary>
 		/// Follow given object

--- a/GameServer/gameobjects/GameNPC.cs
+++ b/GameServer/gameobjects/GameNPC.cs
@@ -945,15 +945,15 @@ namespace DOL.GS
 		/// <summary>
 		/// Property entry on follow timer, wether the follow target is in range
 		/// </summary>
-		protected static readonly string FOLLOW_TARGET_IN_RANGE = "FollowTargetInRange";
+		protected const string FOLLOW_TARGET_IN_RANGE = "FollowTargetInRange";
 		/// <summary>
 		/// Minimum allowed attacker follow distance to avoid issues with client / server resolution (herky jerky motion)
 		/// </summary>
-		protected static readonly int MIN_ALLOWED_FOLLOW_DISTANCE = 100;
+		protected const int MIN_ALLOWED_FOLLOW_DISTANCE = 100;
 		/// <summary>
 		/// Minimum allowed pet follow distance
 		/// </summary>
-		protected static readonly int MIN_ALLOWED_PET_FOLLOW_DISTANCE = 90;
+		protected const int MIN_ALLOWED_PET_FOLLOW_DISTANCE = 90;
 		/// <summary>
 		/// At what health percent will npc give up range attack and rush the attacker
 		/// </summary>
@@ -1451,8 +1451,8 @@ namespace DOL.GS
 			BroadcastUpdate();
 		}
 
-		private const int STICKMINIMUMRANGE = 100;
-		private const int STICKMAXIMUMRANGE = 5000;
+		public const int STICKMINIMUMRANGE = 100;
+		public const int STICKMAXIMUMRANGE = 5000;
 
 		/// <summary>
 		/// Follow given object

--- a/GameServer/keeps/AbstractGameKeep.cs
+++ b/GameServer/keeps/AbstractGameKeep.cs
@@ -40,7 +40,6 @@ namespace DOL.GS.Keeps
 		/// </summary>
 		private static readonly ILog log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
 
-		public bool HasChampion = false;
 		public bool HasCommander = false;
 		public bool HasHastener = false;
 		public bool HasLord = false;

--- a/GameServer/keeps/AbstractGameKeep.cs
+++ b/GameServer/keeps/AbstractGameKeep.cs
@@ -40,6 +40,22 @@ namespace DOL.GS.Keeps
 		/// </summary>
 		private static readonly ILog log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
 
+		public bool HasChampion = false;
+		public bool HasCommander = false;
+		public bool HasHastener = false;
+		public bool HasLord = false;
+
+		/// <summary>
+		/// Height of the keep
+		/// </summary>
+		public virtual int Height
+		{
+			get
+			{
+				return GameServer.KeepManager.GetHeightFromLevel(this.Level);
+			}
+		}
+
 		/// <summary>
 		/// The manager responsible for updating all guards appearance, realm, levles, stats
 		/// </summary>
@@ -184,13 +200,13 @@ namespace DOL.GS.Keeps
 		/// This hold list of all keep doors
 		/// </summary>
 		//protected ArrayList m_doors;
-		protected Hashtable m_doors;
+		protected Dictionary<string,GameKeepDoor> m_doors;
 
 		/// <summary>
 		/// keep doors
 		/// </summary>
 		//public ArrayList Doors
-		public Hashtable Doors
+		public Dictionary<string, GameKeepDoor> Doors
 		{
 			get	{ return m_doors; }
 			set { m_doors = value; }
@@ -213,12 +229,12 @@ namespace DOL.GS.Keeps
 		/// <summary>
 		/// This hold list of all guards of keep
 		/// </summary>
-		protected Hashtable m_guards;
+		protected Dictionary<string,GameKeepGuard> m_guards;
 
 		/// <summary>
 		/// List of all guards of keep
 		/// </summary>
-		public Hashtable Guards
+		public Dictionary<string, GameKeepGuard> Guards
 		{
 			get	{ return m_guards; }
 		}
@@ -226,22 +242,22 @@ namespace DOL.GS.Keeps
 		/// <summary>
 		/// List of all banners
 		/// </summary>
-		protected Hashtable m_banners;
+		protected Dictionary<string, GameKeepBanner> m_banners;
 
 		/// <summary>
 		/// List of all banners
 		/// </summary>
-		public Hashtable Banners
+		public Dictionary<string, GameKeepBanner> Banners
 		{
 			get	{ return m_banners; }
 			set	{ m_banners = value; }
 		}
 
-		protected Hashtable m_patrols;
+		protected Dictionary<string, Patrol> m_patrols;
 		/// <summary>
 		/// List of all patrols
 		/// </summary>
-		public Hashtable Patrols
+		public Dictionary<string, Patrol> Patrols
 		{
 			get { return m_patrols; }
 			set { m_patrols = value; }
@@ -519,11 +535,11 @@ namespace DOL.GS.Keeps
 		/// </summary>
 		public AbstractGameKeep()
 		{
-			m_guards = new Hashtable();
+			m_guards = new Dictionary<string, GameKeepGuard>();
 			m_keepComponents = new List<GameKeepComponent>();
-			m_banners = new Hashtable();
-			m_doors = new Hashtable();
-			m_patrols = new Hashtable();
+			m_banners = new Dictionary<string, GameKeepBanner>();
+			m_doors = new Dictionary<string, GameKeepDoor>();
+			m_patrols = new Dictionary<string, Patrol>();
 		}
 
 		~AbstractGameKeep()
@@ -574,19 +590,22 @@ namespace DOL.GS.Keeps
 		/// <param name="area"></param>
 		public virtual void Remove(KeepArea area)
 		{
-			foreach (GameKeepGuard guard in (m_guards.Clone() as Hashtable).Values)
+			Dictionary<string, GameKeepGuard> guards = new Dictionary<string, GameKeepGuard>(m_guards); // Use a shallow copy
+			foreach (GameKeepGuard guard in guards.Values)
 			{
 				guard.Delete();
 				guard.DeleteFromDatabase();
 			}
 
-			foreach (GameKeepBanner banner in (m_banners.Clone() as Hashtable).Values)
+			Dictionary<string, GameKeepBanner> banners = new Dictionary<string, GameKeepBanner>(m_banners); // Use a shallow copy
+			foreach (GameKeepBanner banner in banners.Values)
 			{
 				banner.Delete();
 				banner.DeleteFromDatabase();
 			}
 
-			foreach (GameKeepDoor door in (m_doors.Clone() as Hashtable).Values)
+			Dictionary<string, GameKeepDoor> doors = new Dictionary<string, GameKeepDoor>(m_doors); // Use a shallow copy
+			foreach (GameKeepDoor door in doors.Values)
 			{
 				door.Delete();
 				GameDoor d = new GameDoor();
@@ -1251,12 +1270,9 @@ namespace DOL.GS.Keeps
 			if (hookpoint == null)
 				return;
 
-			//calculate target height
-			int height = GameServer.KeepManager.GetHeightFromLevel(this.Level);
-
 			//predict Z
 			DBKeepHookPoint hp = GameServer.Database.SelectObjects<DBKeepHookPoint>("`HookPointID` = @HookPointID AND `Height` = @Height",
-			                                                                        new[] { new QueryParameter("@HookPointID", 97), new QueryParameter("@Height", height) }).FirstOrDefault();
+			                                                                        new[] { new QueryParameter("@HookPointID", 97), new QueryParameter("@Height", Height) }).FirstOrDefault();
 			if (hp == null)
 				return;
 			int z = component.Z + hp.Z;

--- a/GameServer/keeps/GameKeepComponent.cs
+++ b/GameServer/keeps/GameKeepComponent.cs
@@ -464,16 +464,6 @@ namespace DOL.GS.Keeps
 									create = true;
 								}
 								break;
-							case "DOL.GS.Keeps.GuardChampion":
-								if (AbstractKeep.HasChampion && log.IsWarnEnabled)
-									log.Warn($"FillPositions(): KeepComponent_ID {this.InternalID}, KeepPosition_ID {position.ObjectId}: There is already a {position.ClassType} on Keep {AbstractKeep.KeepID}");
-
-								if (this.AbstractKeep.Guards.ContainsKey(sKey) == false)
-								{
-									AbstractKeep.HasChampion = true;
-									create = true;
-								}
-								break;
 							case "DOL.GS.Keeps.MissionMaster":
 								if (AbstractKeep.HasCommander && log.IsWarnEnabled)
 									log.Warn($"FillPositions(): KeepComponent_ID {this.InternalID}, KeepPosition_ID {position.ObjectId}: There is already a {position.ClassType} on Keep {AbstractKeep.KeepID}");

--- a/GameServer/keeps/GameKeepComponent.cs
+++ b/GameServer/keeps/GameKeepComponent.cs
@@ -64,6 +64,7 @@ namespace DOL.GS.Keeps
 			BridgeHightWithHook2 = 20,
 			
 			NewSkinClimbingWall = 27,
+			NewSkinKeep = 30,
 			NewSkinTower = 31,
 		}
 
@@ -102,12 +103,10 @@ namespace DOL.GS.Keeps
 		}
 
 		/// <summary>
-		/// height of keep grow with level
+		/// Height of the component
 		/// </summary>
 		public int Height
-		{
-			get { return GameServer.KeepManager.GetHeightFromLevel(this.AbstractKeep.Level); }
-		}
+		{ get { return AbstractKeep.Height; } }
 
 		/// <summary>
 		/// skin of keep component (wall, tower, ...)
@@ -417,50 +416,90 @@ namespace DOL.GS.Keeps
 			}
 		}
 
+		/// <summary>
+		/// Populate GameKeepItems for this component into the keep
+		/// </summary>
 		public virtual void FillPositions()
 		{
 			foreach (DBKeepPosition[] positionGroup in this.Positions.Values)
 			{
 				for (int i = this.Height; i >= 0; i--)
 				{
-					DBKeepPosition position = positionGroup[i] as DBKeepPosition;
-					if (position != null)
+					if (positionGroup[i] is DBKeepPosition position)
 					{
 						bool create = false;
-						if (position.ClassType == "DOL.GS.Keeps.GameKeepBanner")
+						string sKey = position.TemplateID;
+
+						switch (position.ClassType)
 						{
-							if (this.AbstractKeep.Banners[position.TemplateID] == null)
-								create = true;
-						}
-						else if (position.ClassType == "DOL.GS.Keeps.GameKeepDoor")
-						{
-							if (this.AbstractKeep.Doors[position.TemplateID] == null)
-								create = true;
-						}
-						else if (position.ClassType == "DOL.GS.Keeps.FrontierTeleportStone")
-						{
-							if (this.AbstractKeep.TeleportStone == null)
-								create = true;
-						}
-						else if (position.ClassType == "DOL.GS.Keeps.Patrol")
-						{
-							if (position.KeepType == (int)AbstractGameKeep.eKeepType.Any || position.KeepType == (int)AbstractKeep.KeepType)
-							{
-								if (this.AbstractKeep.Patrols[position.TemplateID] == null)
+							case "DOL.GS.Keeps.GameKeepBanner":
+								if (this.AbstractKeep.Banners.ContainsKey(sKey) == false)
+									create = true;
+								break;
+							case "DOL.GS.Keeps.GameKeepDoor":
+								if (this.AbstractKeep.Doors.ContainsKey(sKey) == false)
+									create = true;
+								break;
+							case "DOL.GS.Keeps.FrontierTeleportStone":
+								if (this.AbstractKeep.TeleportStone == null)
+									create = true;
+								break;
+							case "DOL.GS.Keeps.Patrol":
+								if ((position.KeepType == (int)AbstractGameKeep.eKeepType.Any || position.KeepType == (int)AbstractKeep.KeepType)
+									&& this.AbstractKeep.Patrols.ContainsKey(sKey) == false)
 								{
 									Patrol p = new Patrol(this);
 									p.SpawnPosition = position;
 									p.PatrolID = position.TemplateID;
 									p.InitialiseGuards();
 								}
-							}
-							continue;
-						}
-						else
-						{
-							if (this.AbstractKeep.Guards[position.TemplateID] == null)
-								create = true;
-						}
+								continue;
+							case "DOL.GS.Keeps.FrontierHastener":
+								if (AbstractKeep.HasHastener && log.IsWarnEnabled)
+									log.Warn($"FillPositions(): KeepComponent_ID {this.InternalID}, KeepPosition_ID {position.ObjectId}: There is already a {position.ClassType} on Keep {AbstractKeep.KeepID}");
+
+								if (this.AbstractKeep.Guards.ContainsKey(sKey) == false)
+								{
+									AbstractKeep.HasHastener = true;
+									create = true;
+								}
+								break;
+							case "DOL.GS.Keeps.GuardChampion":
+								if (AbstractKeep.HasChampion && log.IsWarnEnabled)
+									log.Warn($"FillPositions(): KeepComponent_ID {this.InternalID}, KeepPosition_ID {position.ObjectId}: There is already a {position.ClassType} on Keep {AbstractKeep.KeepID}");
+
+								if (this.AbstractKeep.Guards.ContainsKey(sKey) == false)
+								{
+									AbstractKeep.HasChampion = true;
+									create = true;
+								}
+								break;
+							case "DOL.GS.Keeps.MissionMaster":
+								if (AbstractKeep.HasCommander && log.IsWarnEnabled)
+									log.Warn($"FillPositions(): KeepComponent_ID {this.InternalID}, KeepPosition_ID {position.ObjectId}: There is already a {position.ClassType} on Keep {AbstractKeep.KeepID}");
+
+								if (this.AbstractKeep.Guards.ContainsKey(sKey) == false)
+								{
+									AbstractKeep.HasCommander = true;
+									create = true;
+								}
+								break;
+							case "DOL.GS.Keeps.GuardLord":
+								if (AbstractKeep.HasLord && log.IsWarnEnabled)
+									log.Warn($"FillPositions(): KeepComponent_ID {this.InternalID}, KeepPosition_ID {position.ObjectId}: There is already a {position.ClassType} on Keep {AbstractKeep.KeepID}");
+
+								if (this.AbstractKeep.Guards.ContainsKey(sKey) == false)
+								{
+									AbstractKeep.HasLord = true;
+									create = true;
+								}
+								break;
+							default:
+								if (this.AbstractKeep.Guards.ContainsKey(sKey) == false)
+									create = true;
+								break;
+						}// switch (position.ClassType)
+
 						if (create)
 						{
 							//create the object
@@ -473,47 +512,43 @@ namespace DOL.GS.Keeps
 
 								if (ServerProperties.Properties.ENABLE_DEBUG)
 								{
-									if (obj is GameLiving)
-										(obj as GameLiving).Name += " is living, component " + obj.Component.ID;
-									else if (obj is GameObject)
-										(obj as GameObject).Name += " is object, component " + obj.Component.ID;
+									if (obj is GameLiving living)
+										living.Name += " is living, component " + obj.Component.ID;
+									else if (obj is GameObject game)
+										game.Name += " is object, component " + obj.Component.ID;
 								}
 							}
 							catch (Exception ex)
 							{
-								log.Error("GameKeepComponent:FillPositions: " + position.ClassType, ex);
+								log.Error("FillPositions(): " + position.ClassType, ex);
 							}
-								
 						}
 						else
 						{
+							/* Why move the object?  We should notify the server admin of the duplicate and let them figure out what is causing it in their DB.
+							* Otherwise, we're assuming the former position/component combination wasn't valid, and that's an error that should be reported in any case.						
 							//move the object
-							if (position.ClassType == "DOL.GS.Keeps.GameKeepBanner")
+							switch (position.ClassType)
 							{
-								IKeepItem banner = this.AbstractKeep.Banners[position.TemplateID] as IKeepItem;
-								if (banner.Position != position)
-								{
-									banner.MoveToPosition(position);
-								}
-							}
-							else if (position.ClassType == "DOL.GS.Keeps.GameKeepDoor")
-							{
-								//doors dont move
-							}
-							else if (position.ClassType == "DOL.GS.Keeps.FrontierPortalStone")
-							{ 
-								//these dont move
-							}
-							else
-							{
-								IKeepItem guard = this.AbstractKeep.Guards[position.TemplateID] as IKeepItem;
-								guard.MoveToPosition(position);
-							}
-						}
-						break;
+								case "DOL.GS.Keeps.GameKeepBanner":
+									if (this.AbstractKeep.Banners[position.TemplateID] is IKeepItem banner && banner.Position != position)
+										banner.MoveToPosition(position);
+									break;
+								case "DOL.GS.Keeps.GameKeepDoor":
+								case "DOL.GS.Keeps.FrontierPortalStone":
+									break;  // these dont move
+								default:
+									if (this.AbstractKeep.Guards[position.TemplateID] is IKeepItem guard)
+										guard.MoveToPosition(position);
+									break;
+							}*/
+							if (log.IsWarnEnabled)
+								log.Warn($"FillPositions(): Keep {AbstractKeep.KeepID} already has a {position.ClassType} assigned to Position {position.ObjectId} on Component {this.InternalID}");
 					}
-				}
-			}
+						break; // We found the highest item for that position, move onto the next one
+					}// if (positionGroup[i] is DBKeepPosition position)
+				}// for (int i = this.Height; i >= 0; i--)
+			}// foreach (DBKeepPosition[] positionGroup in this.Positions.Values)
 
 			foreach (GameKeepGuard guard in this.AbstractKeep.Guards.Values)
 			{

--- a/GameServer/keeps/Gameobjects/GameKeepDoor.cs
+++ b/GameServer/keeps/Gameobjects/GameKeepDoor.cs
@@ -626,14 +626,14 @@ namespace DOL.GS.Keeps
 
 			foreach (AbstractArea area in this.CurrentAreas)
 			{
-				if (area is KeepArea)
+				if (area is KeepArea keepArea)
 				{
-					AbstractGameKeep keep = (area as KeepArea).Keep;
-					if (!keep.Doors.Contains(door.InternalID))
+					string sKey = door.InternalID.ToString();
+					if (!keepArea.Keep.Doors.ContainsKey(sKey))
 					{
 						Component = new GameKeepComponent();
-						Component.AbstractKeep = keep;
-						keep.Doors.Add(door.InternalID, this);
+						Component.AbstractKeep = keepArea.Keep;
+						keepArea.Keep.Doors.Add(sKey, this);
 					}
 					break;
 				}

--- a/GameServer/keeps/Gameobjects/GameKeepDoor.cs
+++ b/GameServer/keeps/Gameobjects/GameKeepDoor.cs
@@ -566,7 +566,7 @@ namespace DOL.GS.Keeps
 			{
 				if (Component.AbstractKeep != null)
 				{
-					Component.AbstractKeep.Doors.Remove(this.ObjectID);
+					Component.AbstractKeep.Doors.Remove(this.ObjectID.ToString());
 				}
 
 				Component.Delete();

--- a/GameServer/keeps/Gameobjects/GameKeepDoor.cs
+++ b/GameServer/keeps/Gameobjects/GameKeepDoor.cs
@@ -667,7 +667,7 @@ namespace DOL.GS.Keeps
 			}
 			else
 			{
-				log.Error("Failed to load keep door from position! DoorID=" + m_doorID + ". Component SkinID=" + component.Skin + ". KeepID=" + component.AbstractKeep.KeepID);
+				log.Error("Failed to load keep door from keepposition_id =" + pos.ObjectId + ". Component SkinID=" + component.Skin + ". KeepID=" + component.AbstractKeep.KeepID);
 			}
 
 		}

--- a/GameServer/keeps/Gameobjects/Guards/Patrol.cs
+++ b/GameServer/keeps/Gameobjects/Guards/Patrol.cs
@@ -81,7 +81,7 @@ namespace DOL.GS.Keeps
 		/// </summary>
 		public void InitialiseGuards()
 		{
-			Component.AbstractKeep.Patrols[PatrolID] = this;
+			Component.AbstractKeep.Patrols.Add(PatrolID, this);
 
 			//need this here becuase it's checked in add to world
 			PatrolPath = PositionMgr.LoadPatrolPath(PatrolID, Component);
@@ -146,14 +146,10 @@ namespace DOL.GS.Keeps
 		public void DeletePatrol()
 		{
 			if (Component != null && Component.AbstractKeep != null)
-			{
-				Component.AbstractKeep.Patrols.Remove(this);
-			}
+				Component.AbstractKeep.Patrols.Remove(PatrolID); // .Remove(this) - InitialiseGuards() adds patrols using PatrolID as the key
 
 			foreach (GameKeepGuard guard in PatrolGuards)
-			{
 				guard.DeleteObject();
-			}
 
 			PatrolGuards.Clear();
 			Component = null;

--- a/GameServer/keeps/HookPointInventory.cs
+++ b/GameServer/keeps/HookPointInventory.cs
@@ -293,10 +293,10 @@ namespace DOL.GS.Keeps
 				((GameNPC)hookPointObj).RespawnInterval = -1;//do not respawn
 			}
 			hookPointObj.AddToWorld();
-			if (hookPointObj is GameKeepGuard)
+			if (hookPointObj is GameKeepGuard guard)
 			{
-				(hookPointObj as GameKeepGuard).Component.AbstractKeep.Guards.Add(hookPointObj.ObjectID, hookPointObj);
-				((GameNPC)hookPointObj).RespawnInterval = Util.Random(10, 30) * 60 * 1000;
+				guard.Component.AbstractKeep.Guards.Add(hookPointObj.ObjectID.ToString(), guard);
+				guard.RespawnInterval = Util.Random(10, 30) * 60 * 1000;
 			}
 			hookpoint.Object = hookPointObj;
 
@@ -346,10 +346,10 @@ namespace DOL.GS.Keeps
 				((GameNPC)hookPointObj).RespawnInterval = -1;//do not respawn
 			}
 			hookPointObj.AddToWorld();
-			if (hookPointObj is GameKeepGuard)
+			if (hookPointObj is GameKeepGuard guard)
 			{
-				(hookPointObj as GameKeepGuard).Component.AbstractKeep.Guards.Add(hookPointObj.ObjectID, hookPointObj);
-				((GameNPC)hookPointObj).RespawnInterval = Util.Random(10, 30) * 60 * 1000;
+				guard.Component.AbstractKeep.Guards.Add(hookPointObj.ObjectID.ToString(), guard);
+				guard.RespawnInterval = Util.Random(10, 30) * 60 * 1000;
 			}
 			hookpoint.Object = hookPointObj;
 		}

--- a/GameServer/keeps/IGameKeep.cs
+++ b/GameServer/keeps/IGameKeep.cs
@@ -28,8 +28,8 @@ namespace DOL.GS.Keeps
 	{
 		List<IGameKeepComponent> SentKeepComponents { get; }
 		
-		Hashtable Guards { get; }
-		Hashtable Banners { get; }
+		Dictionary<string, GameKeepGuard> Guards { get; }
+		Dictionary<string, GameKeepBanner> Banners { get; }
 
 		void LoadFromDatabase(DataObject keep);
 		void SaveIntoDatabase();

--- a/GameServer/keeps/KeepManager.cs
+++ b/GameServer/keeps/KeepManager.cs
@@ -85,8 +85,8 @@ namespace DOL.GS.Keeps
 
 			ClothingMgr.LoadTemplates();
 
-            //Dinberg - moved this here, battlegrounds must be loaded before keepcomponents are.
-            LoadBattlegroundCaps();
+			//Dinberg - moved this here, battlegrounds must be loaded before keepcomponents are.
+			LoadBattlegroundCaps();
 
 			if (!ServerProperties.Properties.LOAD_KEEPS)
 				return true;
@@ -113,7 +113,7 @@ namespace DOL.GS.Keeps
 					}
 
 					keep.Load(datakeep);
-                    RegisterKeep(datakeep.KeepID, keep);
+					RegisterKeep(datakeep.KeepID, keep);
 				}
 
 				// This adds owner keeps to towers / portal keeps
@@ -137,37 +137,39 @@ namespace DOL.GS.Keeps
 						}
 					}
 				}
-                if (ServerProperties.Properties.USE_NEW_KEEPS == 2) log.ErrorFormat("ServerProperty USE_NEW_KEEPS is actually set to 2 but it is no longer used. Loading as if he were 0 but please set to 0 or 1 !");
+				if (ServerProperties.Properties.USE_NEW_KEEPS == 2)
+					log.ErrorFormat("ServerProperty USE_NEW_KEEPS is actually set to 2 but it is no longer used. Loading as if he were 0 but please set to 0 or 1 !");
 				    
-				var keepcomponents = default(IList<DBKeepComponent>);
+				// var keepcomponents = default(IList<DBKeepComponent>); Why was this done this way rather than being strictly typed?
+				IList<DBKeepComponent> keepcomponents = null;
 
-                if (ServerProperties.Properties.USE_NEW_KEEPS == 0 || ServerProperties.Properties.USE_NEW_KEEPS == 2)
-                	keepcomponents = GameServer.Database.SelectObjects<DBKeepComponent>("`Skin` < @Skin", new QueryParameter("@Skin", 20));
-                else if (ServerProperties.Properties.USE_NEW_KEEPS == 1)
-                	keepcomponents = GameServer.Database.SelectObjects<DBKeepComponent>("`Skin` > @Skin", new QueryParameter("@Skin", 20));
+				if (ServerProperties.Properties.USE_NEW_KEEPS == 0 || ServerProperties.Properties.USE_NEW_KEEPS == 2)
+					keepcomponents = GameServer.Database.SelectObjects<DBKeepComponent>("`Skin` < @Skin", new QueryParameter("@Skin", 20));
+				else if (ServerProperties.Properties.USE_NEW_KEEPS == 1)
+					keepcomponents = GameServer.Database.SelectObjects<DBKeepComponent>("`Skin` > @Skin", new QueryParameter("@Skin", 20));
 
-			    if (keepcomponents != null)
-			    {
-			        keepcomponents
-			            .GroupBy(x => x.KeepID)
-			            .AsParallel()
-			            .ForAll(components =>
-			            {
-			                foreach (DBKeepComponent component in components)
-			                {
-			                    AbstractGameKeep keep = GetKeepByID(component.KeepID);
-			                    if (keep == null)
-			                    {
-			                        //missingKeeps = true;
-			                        continue;
-			                    }
+				if (keepcomponents != null)
+				{
+					keepcomponents
+					.GroupBy(x => x.KeepID)
+					.AsParallel()
+					.ForAll(components =>
+					{
+						foreach (DBKeepComponent component in components)
+						{
+							AbstractGameKeep keep = GetKeepByID(component.KeepID);
+							if (keep == null)
+							{
+								//missingKeeps = true;
+								continue;
+							}
 
-			                    GameKeepComponent gamecomponent = keep.CurrentRegion.CreateGameKeepComponent();
-			                    gamecomponent.LoadFromDatabase(component, keep);
-			                    keep.KeepComponents.Add(gamecomponent);
-			                }
-			            });
-			    }
+							GameKeepComponent gamecomponent = keep.CurrentRegion.CreateGameKeepComponent();
+							gamecomponent.LoadFromDatabase(component, keep);
+							keep.KeepComponents.Add(gamecomponent);
+						}
+					});
+				}
 
 				/*if (missingKeeps && log.IsWarnEnabled)
 				{


### PR DESCRIPTION
There is a lot of pattern matching in here, so AppVeyor won't like it.

This started out with me wanting to put in logging to see if I could track down why dolpub is putting multiple lords and other characters in keeps.  I thought the code for GameKeepComponent.FillPositions() was difficult to red and maintain, so I changed it to make it more legible.

While I was there, I figured I may as well optimize code a bit by doing things like using .Add(), Contains(), and Remove() rather than [] on Hashtables, and from there looked for other things I could speed up.  Ultimately, I ended up changing Hashtables to Dictionaries to force proper typing to catch coding errors, and speed things up by removing the boxing and unboxing necessary with Hashtables.

I also found a bunch of small things like key mismatches in which an item was added using one thing as a key but another when removing it, and in some cases a string/int key being used to add but another type used when trying to remove.  So I fixed those.

This produces a LOT of warning log entries.  I'm not sure if that's due to mistakes in dolpub that weren't being reported before and thus weren't ever addressed, or if I'm reporting errors when it's not appropriate.  I'll be working on cleaning up the DB next, and if I find some of those log entries are inappropriate I'll come back and remove them from code.