### PR TITLE
Server props for keep guard stats

### DIFF
--- a/GameServer/gameobjects/GameNPC.cs
+++ b/GameServer/gameobjects/GameNPC.cs
@@ -945,15 +945,15 @@ namespace DOL.GS
 		/// <summary>
 		/// Property entry on follow timer, wether the follow target is in range
 		/// </summary>
-		protected const string FOLLOW_TARGET_IN_RANGE = "FollowTargetInRange";
+		protected static readonly string FOLLOW_TARGET_IN_RANGE = "FollowTargetInRange";
 		/// <summary>
 		/// Minimum allowed attacker follow distance to avoid issues with client / server resolution (herky jerky motion)
 		/// </summary>
-		protected const int MIN_ALLOWED_FOLLOW_DISTANCE = 100;
+		protected static readonly int MIN_ALLOWED_FOLLOW_DISTANCE = 100;
 		/// <summary>
 		/// Minimum allowed pet follow distance
 		/// </summary>
-		protected const int MIN_ALLOWED_PET_FOLLOW_DISTANCE = 90;
+		protected static readonly int MIN_ALLOWED_PET_FOLLOW_DISTANCE = 90;
 		/// <summary>
 		/// At what health percent will npc give up range attack and rush the attacker
 		/// </summary>
@@ -1451,8 +1451,8 @@ namespace DOL.GS
 			BroadcastUpdate();
 		}
 
-		public const int STICKMINIMUMRANGE = 100;
-		public const int STICKMAXIMUMRANGE = 5000;
+		private const int STICKMINIMUMRANGE = 100;
+		private const int STICKMAXIMUMRANGE = 5000;
 
 		/// <summary>
 		/// Follow given object

--- a/GameServer/gameobjects/GameNPC.cs
+++ b/GameServer/gameobjects/GameNPC.cs
@@ -945,15 +945,15 @@ namespace DOL.GS
 		/// <summary>
 		/// Property entry on follow timer, wether the follow target is in range
 		/// </summary>
-		protected static readonly string FOLLOW_TARGET_IN_RANGE = "FollowTargetInRange";
+		protected const string FOLLOW_TARGET_IN_RANGE = "FollowTargetInRange";
 		/// <summary>
 		/// Minimum allowed attacker follow distance to avoid issues with client / server resolution (herky jerky motion)
 		/// </summary>
-		protected static readonly int MIN_ALLOWED_FOLLOW_DISTANCE = 100;
+		protected const int MIN_ALLOWED_FOLLOW_DISTANCE = 100;
 		/// <summary>
 		/// Minimum allowed pet follow distance
 		/// </summary>
-		protected static readonly int MIN_ALLOWED_PET_FOLLOW_DISTANCE = 90;
+		protected const int MIN_ALLOWED_PET_FOLLOW_DISTANCE = 90;
 		/// <summary>
 		/// At what health percent will npc give up range attack and rush the attacker
 		/// </summary>
@@ -1451,8 +1451,8 @@ namespace DOL.GS
 			BroadcastUpdate();
 		}
 
-		private const int STICKMINIMUMRANGE = 100;
-		private const int STICKMAXIMUMRANGE = 5000;
+		public const int STICKMINIMUMRANGE = 100;
+		public const int STICKMAXIMUMRANGE = 5000;
 
 		/// <summary>
 		/// Follow given object

--- a/GameServer/keeps/Managers/Template Manager.cs
+++ b/GameServer/keeps/Managers/Template Manager.cs
@@ -19,6 +19,7 @@
 using DOL.AI.Brain;
 using DOL.Database;
 using DOL.GS.PacketHandler;
+using DOL.GS.ServerProperties;
 using DOL.Language;
 
 namespace DOL.GS.Keeps
@@ -1036,17 +1037,19 @@ namespace DOL.GS.Keeps
 		{
 			if (guard is GuardLord)
 			{
-				guard.Strength = (short)(20 + (guard.Level * 8));
-				guard.Dexterity = (short)(guard.Level * 2);
-				guard.Constitution = (short)(DOL.GS.ServerProperties.Properties.GAMENPC_BASE_CON);
-				guard.Quickness = 60;
+				guard.Strength = (short)(Properties.LORD_AUTOSET_STR_BASE + (guard.Level * Properties.LORD_AUTOSET_STR_MULTIPLIER));
+				guard.Dexterity = (short)(Properties.LORD_AUTOSET_DEX_BASE + (guard.Level * Properties.LORD_AUTOSET_DEX_MULTIPLIER));
+				guard.Constitution = (short)(Properties.LORD_AUTOSET_CON_BASE + (guard.Level * Properties.LORD_AUTOSET_CON_MULTIPLIER));
+				guard.Quickness = (short)(Properties.LORD_AUTOSET_QUI_BASE + (guard.Level * Properties.LORD_AUTOSET_QUI_MULTIPLIER));
+				guard.Intelligence = (short)(Properties.LORD_AUTOSET_INT_BASE + (guard.Level * Properties.LORD_AUTOSET_INT_MULTIPLIER));
 			}
 			else
 			{
-				guard.Strength = (short)(20 + (guard.Level * 7));
-				guard.Dexterity = (short)(guard.Level);
-				guard.Constitution = (short)(DOL.GS.ServerProperties.Properties.GAMENPC_BASE_CON);
-				guard.Quickness = 40;
+				guard.Strength = (short)(Properties.GUARD_AUTOSET_STR_BASE + (guard.Level * Properties.GUARD_AUTOSET_STR_MULTIPLIER));
+				guard.Dexterity = (short)(Properties.GUARD_AUTOSET_DEX_BASE + (guard.Level * Properties.GUARD_AUTOSET_DEX_MULTIPLIER));
+				guard.Constitution = (short)(Properties.GUARD_AUTOSET_CON_BASE + (guard.Level * Properties.GUARD_AUTOSET_CON_MULTIPLIER));
+				guard.Quickness = (short)(Properties.GUARD_AUTOSET_QUI_BASE + (guard.Level * Properties.GUARD_AUTOSET_QUI_MULTIPLIER));
+				guard.Intelligence = (short)(Properties.GUARD_AUTOSET_INT_BASE + (guard.Level * Properties.GUARD_AUTOSET_INT_MULTIPLIER));
 			}
 		}
 	}

--- a/GameServer/keeps/Managers/Template Manager.cs
+++ b/GameServer/keeps/Managers/Template Manager.cs
@@ -1037,7 +1037,7 @@ namespace DOL.GS.Keeps
 		{
 			if (guard is GuardLord)
 			{
-				guard.Strength = (short)(Properties.LORD_AUTOSET_STR_BASE + (guard.Level * Properties.LORD_AUTOSET_STR_MULTIPLIER));
+				guard.Strength = (short)(Properties.LORD_AUTOSET_STR_BASE + (10 * guard.Level * Properties.LORD_AUTOSET_STR_MULTIPLIER));
 				guard.Dexterity = (short)(Properties.LORD_AUTOSET_DEX_BASE + (guard.Level * Properties.LORD_AUTOSET_DEX_MULTIPLIER));
 				guard.Constitution = (short)(Properties.LORD_AUTOSET_CON_BASE + (guard.Level * Properties.LORD_AUTOSET_CON_MULTIPLIER));
 				guard.Quickness = (short)(Properties.LORD_AUTOSET_QUI_BASE + (guard.Level * Properties.LORD_AUTOSET_QUI_MULTIPLIER));
@@ -1045,7 +1045,7 @@ namespace DOL.GS.Keeps
 			}
 			else
 			{
-				guard.Strength = (short)(Properties.GUARD_AUTOSET_STR_BASE + (guard.Level * Properties.GUARD_AUTOSET_STR_MULTIPLIER));
+				guard.Strength = (short)(Properties.GUARD_AUTOSET_STR_BASE + (10 * guard.Level * Properties.GUARD_AUTOSET_STR_MULTIPLIER));
 				guard.Dexterity = (short)(Properties.GUARD_AUTOSET_DEX_BASE + (guard.Level * Properties.GUARD_AUTOSET_DEX_MULTIPLIER));
 				guard.Constitution = (short)(Properties.GUARD_AUTOSET_CON_BASE + (guard.Level * Properties.GUARD_AUTOSET_CON_MULTIPLIER));
 				guard.Quickness = (short)(Properties.GUARD_AUTOSET_QUI_BASE + (guard.Level * Properties.GUARD_AUTOSET_QUI_MULTIPLIER));

--- a/GameServer/serverproperty/ServerProperties.cs
+++ b/GameServer/serverproperty/ServerProperties.cs
@@ -1516,8 +1516,128 @@ namespace DOL.GS.ServerProperties
 		/// <summary>
 		/// Keep guard heal when a target is below what percentage of their health?
 		/// </summary>
-		[ServerProperty("npc", "keep_heal_threshold", "Keep guards heal targets whose health falls below this value.", 60)]
+		[ServerProperty("keeps", "keep_heal_threshold", "Keep guards heal targets whose health falls below this value.", 60)]
 		public static int KEEP_HEAL_THRESHOLD;
+		
+		/// <summary>
+		/// Base Value to use when auto-setting STR stat.
+		/// </summary>
+		[ServerProperty("keeps", "guard_autoset_str_base", "Base Value to use when auto-setting STR stat. ", 20)]
+		public static int GUARD_AUTOSET_STR_BASE;
+
+		/// <summary>
+		/// Multiplier to use when auto-setting STR stat.
+		/// </summary>
+		[ServerProperty("keeps", "guard_autoset_str_multiplier", "Multiplier to use when auto-setting STR stat.  Multiplied by 10 when used.", 0.7)]
+		public static double GUARD_AUTOSET_STR_MULTIPLIER;
+
+		/// <summary>
+		/// Base Value to use when auto-setting CON stat.
+		/// </summary>
+		[ServerProperty("keeps", "guard_autoset_con_base", "Base Value to use when auto-setting CON stat. ", 30)]
+		public static int GUARD_AUTOSET_CON_BASE;
+
+		/// <summary>
+		/// Multiplier to use when auto-setting CON stat.
+		/// </summary>
+		[ServerProperty("keeps", "guard_autoset_con_multiplier", "Multiplier to use when auto-setting CON stat. ", 0.0)]
+		public static double GUARD_AUTOSET_CON_MULTIPLIER;
+
+		/// <summary>
+		/// Base Value to use when auto-setting QUI stat.
+		/// </summary>
+		[ServerProperty("keeps", "guard_autoset_qui_base", "Base Value to use when auto-setting qui stat. ", 40)]
+		public static int GUARD_AUTOSET_QUI_BASE;
+
+		/// <summary>
+		/// Multiplier to use when auto-setting QUI stat.
+		/// </summary>
+		[ServerProperty("keeps", "guard_autoset_qui_multiplier", "Multiplier to use when auto-setting QUI stat. ", 0.0)]
+		public static double GUARD_AUTOSET_QUI_MULTIPLIER;
+
+		/// <summary>
+		/// Base Value to use when auto-setting DEX stat.
+		/// </summary>
+		[ServerProperty("keeps", "guard_autoset_dex_base", "Base Value to use when auto-setting DEX stat. ", 1)]
+		public static int GUARD_AUTOSET_DEX_BASE;
+
+		/// <summary>
+		/// Multiplier to use when auto-setting DEX stat.
+		/// </summary>
+		[ServerProperty("keeps", "guard_autoset_dex_multiplier", "Multiplier to use when auto-setting DEX stat. ", 1.0)]
+		public static double GUARD_AUTOSET_DEX_MULTIPLIER;
+
+		/// <summary>
+		/// Base Value to use when auto-setting INT stat.
+		/// </summary>
+		[ServerProperty("keeps", "guard_autoset_int_base", "Base Value to use when auto-setting INT stat. ", 30)]
+		public static int GUARD_AUTOSET_INT_BASE;
+
+		/// <summary>
+		/// Multiplier to use when auto-setting INT stat.
+		/// </summary>
+		[ServerProperty("keeps", "guard_autoset_int_multiplier", "Multiplier to use when auto-setting INT stat. ", 1.0)]
+		public static double GUARD_AUTOSET_INT_MULTIPLIER;
+
+		/// <summary>
+		/// Base Value to use when auto-setting STR stat.
+		/// </summary>
+		[ServerProperty("keeps", "lord_autoset_str_base", "Base Value to use when auto-setting STR stat. ", 20)]
+		public static int LORD_AUTOSET_STR_BASE;
+
+		/// <summary>
+		/// Multiplier to use when auto-setting STR stat.
+		/// </summary>
+		[ServerProperty("keeps", "lord_autoset_str_multiplier", "Multiplier to use when auto-setting STR stat.  Multiplied by 10 when used.", 0.8)]
+		public static double LORD_AUTOSET_STR_MULTIPLIER;
+
+		/// <summary>
+		/// Base Value to use when auto-setting CON stat.
+		/// </summary>
+		[ServerProperty("keeps", "lord_autoset_con_base", "Base Value to use when auto-setting CON stat. ", 30)]
+		public static int LORD_AUTOSET_CON_BASE;
+
+		/// <summary>
+		/// Multiplier to use when auto-setting CON stat.
+		/// </summary>
+		[ServerProperty("keeps", "guard_autoset_con_multiplier", "Multiplier to use when auto-setting CON stat. ", 0)]
+		public static double LORD_AUTOSET_CON_MULTIPLIER;
+
+		/// <summary>
+		/// Base Value to use when auto-setting QUI stat.
+		/// </summary>
+		[ServerProperty("keeps", "lord_autoset_qui_base", "Base Value to use when auto-setting qui stat. ", 60)]
+		public static int LORD_AUTOSET_QUI_BASE;
+
+		/// <summary>
+		/// Multiplier to use when auto-setting QUI stat.
+		/// </summary>
+		[ServerProperty("keeps", "lord_autoset_qui_multiplier", "Multiplier to use when auto-setting QUI stat. ", 0)]
+		public static double LORD_AUTOSET_QUI_MULTIPLIER;
+
+		/// <summary>
+		/// Base Value to use when auto-setting DEX stat.
+		/// </summary>
+		[ServerProperty("keeps", "lord_autoset_dex_base", "Base Value to use when auto-setting DEX stat. ", 2)]
+		public static int LORD_AUTOSET_DEX_BASE;
+
+		/// <summary>
+		/// Multiplier to use when auto-setting DEX stat.
+		/// </summary>
+		[ServerProperty("keeps", "lord_autoset_dex_multiplier", "Multiplier to use when auto-setting DEX stat. ", 2.0)]
+		public static double LORD_AUTOSET_DEX_MULTIPLIER;
+
+		/// <summary>
+		/// Base Value to use when auto-setting INT stat.
+		/// </summary>
+		[ServerProperty("keeps", "lord_autoset_int_base", "Base Value to use when auto-setting INT stat. ", 30)]
+		public static int LORD_AUTOSET_INT_BASE;
+
+		/// <summary>
+		/// Multiplier to use when auto-setting INT stat.
+		/// </summary>
+		[ServerProperty("keeps", "lord_autoset_int_multiplier", "Multiplier to use when auto-setting INT stat. ", 1.0)]
+		public static double LORD_AUTOSET_INT_MULTIPLIER;
 		#endregion
 
 		#region PVE / TOA

--- a/GameServer/serverproperty/ServerProperties.cs
+++ b/GameServer/serverproperty/ServerProperties.cs
@@ -1600,7 +1600,7 @@ namespace DOL.GS.ServerProperties
 		/// <summary>
 		/// Multiplier to use when auto-setting CON stat.
 		/// </summary>
-		[ServerProperty("keeps", "guard_autoset_con_multiplier", "Multiplier to use when auto-setting CON stat. ", 0)]
+		[ServerProperty("keeps", "lord_autoset_con_multiplier", "Multiplier to use when auto-setting CON stat. ", 0)]
 		public static double LORD_AUTOSET_CON_MULTIPLIER;
 
 		/// <summary>


### PR DESCRIPTION
Stats for keep guards and lord was hardcoded in TemplateManager.  This replaces that with server properties for all guard and lord stats.

The default values are based on the old hard coded values so that guard/lord stats won't change on existing servers.