### PR TITLE
Give DB more control over pets

### DIFF
--- a/GameServer/gameobjects/Bonedancer/CommanderPet.cs
+++ b/GameServer/gameobjects/Bonedancer/CommanderPet.cs
@@ -36,23 +36,25 @@ namespace DOL.GS
 		public CommanderPet(INpcTemplate npcTemplate)
 			: base(npcTemplate)
 		{
-			if (Name.ToLower() == LanguageMgr.GetTranslation(ServerProperties.Properties.SERV_LANGUAGE, "GameObjects.CommanderPet.ReturnedCommander"))
+			// Use the NpcTemplate TetherRange to determine the number of subpets the commander can have
+			if (npcTemplate.TetherRange > 0)
+			{
+				InitControlledBrainArray(npcTemplate.TetherRange);
+			}
+			else if (Name.ToLower() == LanguageMgr.GetTranslation(ServerProperties.Properties.SERV_LANGUAGE, "GameObjects.CommanderPet.ReturnedCommander"))
 			{
 				InitControlledBrainArray(0);
 			}
-
-			if (Name.ToLower() == LanguageMgr.GetTranslation(ServerProperties.Properties.SERV_LANGUAGE, "GameObjects.CommanderPet.DecayedCommander") ||
+			else if (Name.ToLower() == LanguageMgr.GetTranslation(ServerProperties.Properties.SERV_LANGUAGE, "GameObjects.CommanderPet.DecayedCommander") ||
 			    Name.ToLower() == LanguageMgr.GetTranslation(ServerProperties.Properties.SERV_LANGUAGE, "GameObjects.CommanderPet.SkeletalCommander"))
 			{
 				InitControlledBrainArray(1);
 			}
-
-			if (Name.ToLower() == LanguageMgr.GetTranslation(ServerProperties.Properties.SERV_LANGUAGE, "GameObjects.CommanderPet.BoneCommander"))
+			else if (Name.ToLower() == LanguageMgr.GetTranslation(ServerProperties.Properties.SERV_LANGUAGE, "GameObjects.CommanderPet.BoneCommander"))
 			{
 				InitControlledBrainArray(2);
 			}
-
-			if (Name.ToLower() == LanguageMgr.GetTranslation(ServerProperties.Properties.SERV_LANGUAGE, "GameObjects.CommanderPet.DreadCommander") ||
+			else if (Name.ToLower() == LanguageMgr.GetTranslation(ServerProperties.Properties.SERV_LANGUAGE, "GameObjects.CommanderPet.DreadCommander") ||
 			    Name.ToLower() == LanguageMgr.GetTranslation(ServerProperties.Properties.SERV_LANGUAGE, "GameObjects.CommanderPet.DreadGuardian") ||
 			    Name.ToLower() == LanguageMgr.GetTranslation(ServerProperties.Properties.SERV_LANGUAGE, "GameObjects.CommanderPet.DreadLich") ||
 			    Name.ToLower() == LanguageMgr.GetTranslation(ServerProperties.Properties.SERV_LANGUAGE, "GameObjects.CommanderPet.DreadArcher"))

--- a/GameServer/gameobjects/GameNPC.cs
+++ b/GameServer/gameobjects/GameNPC.cs
@@ -945,15 +945,15 @@ namespace DOL.GS
 		/// <summary>
 		/// Property entry on follow timer, wether the follow target is in range
 		/// </summary>
-		protected const string FOLLOW_TARGET_IN_RANGE = "FollowTargetInRange";
+		protected static readonly string FOLLOW_TARGET_IN_RANGE = "FollowTargetInRange";
 		/// <summary>
 		/// Minimum allowed attacker follow distance to avoid issues with client / server resolution (herky jerky motion)
 		/// </summary>
-		protected const int MIN_ALLOWED_FOLLOW_DISTANCE = 100;
+		protected static readonly int MIN_ALLOWED_FOLLOW_DISTANCE = 100;
 		/// <summary>
 		/// Minimum allowed pet follow distance
 		/// </summary>
-		protected const int MIN_ALLOWED_PET_FOLLOW_DISTANCE = 90;
+		protected static readonly int MIN_ALLOWED_PET_FOLLOW_DISTANCE = 90;
 		/// <summary>
 		/// At what health percent will npc give up range attack and rush the attacker
 		/// </summary>
@@ -1451,8 +1451,8 @@ namespace DOL.GS
 			BroadcastUpdate();
 		}
 
-		public const int STICKMINIMUMRANGE = 100;
-		public const int STICKMAXIMUMRANGE = 5000;
+		private const int STICKMINIMUMRANGE = 100;
+		private const int STICKMAXIMUMRANGE = 5000;
 
 		/// <summary>
 		/// Follow given object

--- a/GameServer/gameobjects/GameNPC.cs
+++ b/GameServer/gameobjects/GameNPC.cs
@@ -945,15 +945,15 @@ namespace DOL.GS
 		/// <summary>
 		/// Property entry on follow timer, wether the follow target is in range
 		/// </summary>
-		protected static readonly string FOLLOW_TARGET_IN_RANGE = "FollowTargetInRange";
+		protected const string FOLLOW_TARGET_IN_RANGE = "FollowTargetInRange";
 		/// <summary>
 		/// Minimum allowed attacker follow distance to avoid issues with client / server resolution (herky jerky motion)
 		/// </summary>
-		protected static readonly int MIN_ALLOWED_FOLLOW_DISTANCE = 100;
+		protected const int MIN_ALLOWED_FOLLOW_DISTANCE = 100;
 		/// <summary>
 		/// Minimum allowed pet follow distance
 		/// </summary>
-		protected static readonly int MIN_ALLOWED_PET_FOLLOW_DISTANCE = 90;
+		protected const int MIN_ALLOWED_PET_FOLLOW_DISTANCE = 90;
 		/// <summary>
 		/// At what health percent will npc give up range attack and rush the attacker
 		/// </summary>
@@ -1451,8 +1451,8 @@ namespace DOL.GS
 			BroadcastUpdate();
 		}
 
-		private const int STICKMINIMUMRANGE = 100;
-		private const int STICKMAXIMUMRANGE = 5000;
+		public const int STICKMINIMUMRANGE = 100;
+		public const int STICKMAXIMUMRANGE = 5000;
 
 		/// <summary>
 		/// Follow given object

--- a/GameServer/spells/SummonSpellHandler.cs
+++ b/GameServer/spells/SummonSpellHandler.cs
@@ -19,6 +19,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 using DOL.AI.Brain;
 using DOL.Events;
 using DOL.GS.Effects;
@@ -149,7 +150,18 @@ namespace DOL.GS.Spells
 
 			GameSpellEffect effect = CreateSpellEffect(target, effectiveness);
 
-			IControlledBrain brain = GetPetBrain(Caster);
+			IControlledBrain brain = null;
+			if (template.ClassType != null && template.ClassType.Length > 0)
+			{
+				Assembly asm = Assembly.GetExecutingAssembly();
+				brain = (IControlledBrain)asm.CreateInstance(template.ClassType, true);
+
+				if (brain == null && log.IsWarnEnabled)
+					log.Warn($"ApplyEffectOnTarget(): ClassType {template.ClassType} on NPCTemplateID {template.TemplateId} not found, using default ControlledBrain");
+			}
+			if (brain == null)
+				brain = GetPetBrain(Caster);
+
 			m_pet = GetGamePet(template);
 			//brain.WalkState = eWalkState.Stay;
 			m_pet.SetOwnBrain(brain as AI.ABrain);


### PR DESCRIPTION
These changes allow the brain of pets to be set by the ClassType in their NPCTemplate, and allows the number of subpets BD commanders can summon to be set by the TetherRange of their NPCTemplate.

Not only does this allow databases to add pets like the Dread Lord on live, but it also allows custom servers to create completely new pet behaviour without recompiling by changing which brain pets use or even creating and assigning a completely new scripted brain.

Amusingly enough, formations for a BD commander with 5 subpets are exactly like live; lines get longer and the last two pets stand over the commander for other formations.

Old hardcoded values are still present, so existing servers should not be impacted.