### PR TITLE
Set default value in db for number types

### DIFF
--- a/DOLDatabase/Handlers/MySQLObjectDatabase.cs
+++ b/DOLDatabase/Handlers/MySQLObjectDatabase.cs
@@ -179,6 +179,11 @@ namespace DOL.Database.Handlers
 		{
 			string type = GetDatabaseType(bind, table);
 			string defaultDef = null;
+		    Type[] numberTypes =
+		    {
+		        typeof(int), typeof(byte), typeof(bool), typeof(long), typeof(short),
+		        typeof(ushort), typeof(ulong), typeof(uint), typeof(double)
+		    };
 						
 			// Check for Default Value depending on Constraints and Type
 			if (bind.PrimaryKey != null && bind.PrimaryKey.AutoIncrement)
@@ -191,9 +196,13 @@ namespace DOL.Database.Handlers
 			}
 			else if (bind.ValueType == typeof(DateTime))
 			{
-				defaultDef = "NOT NULL DEFAULT '2000-01-01 00:00:00'";
+			    defaultDef = "NOT NULL DEFAULT '2000-01-01 00:00:00'";
 			}
-			else
+			else if (numberTypes.Contains(bind.ValueType))
+			{
+			    defaultDef = "NOT NULL DEFAULT 0";
+			}
+            else
 			{
                 defaultDef = "NOT NULL";
 			}

--- a/DOLDatabase/Tables/Ability.cs
+++ b/DOLDatabase/Tables/Ability.cs
@@ -158,7 +158,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Ability ID (new in 1.112)
 		/// </summary>
-		[DataElement(AllowDbNull=true)]
+		[DataElement(AllowDbNull=false)]
 		public int InternalID
 		{
 			get { return m_internalID; }

--- a/DOLDatabase/Tables/Account.cs
+++ b/DOLDatabase/Tables/Account.cs
@@ -125,7 +125,7 @@ namespace DOL.Database
 		/// <summary>
 		/// The realm of this account
 		/// </summary>
-		[DataElement(AllowDbNull=true)]
+		[DataElement(AllowDbNull=false)]
 		public int Realm
 		{
 			get
@@ -142,7 +142,7 @@ namespace DOL.Database
 		/// <summary>
 		/// The private level of this account (admin=3, GM=2 or player=1)
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public uint PrivLevel
 		{
 			get
@@ -159,7 +159,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Status of this account
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int Status {
 			get { return m_state; }
 			set { Dirty = true; m_state = value; }
@@ -207,7 +207,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Is this account muted from public channels?
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public bool IsMuted
 		{
 			get { return m_isMuted; }

--- a/DOLDatabase/Tables/Area.cs
+++ b/DOLDatabase/Tables/Area.cs
@@ -49,7 +49,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int X
 		{
 			get
@@ -133,7 +133,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public bool CanBroadcast
 		{
 			get
@@ -147,7 +147,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public byte Sound
 		{
 			get
@@ -161,7 +161,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public bool CheckLOS
 		{
 			get

--- a/DOLDatabase/Tables/Artifact.cs
+++ b/DOLDatabase/Tables/Artifact.cs
@@ -67,7 +67,7 @@ namespace DOL.Database
 		/// The artifact ID.
 		/// </summary>
 		[DataElement(AllowDbNull = false)]
-		public String ArtifactID
+		public string ArtifactID
 		{
 			get { return m_artifactID; }
 			set
@@ -82,7 +82,7 @@ namespace DOL.Database
 		/// this artifact.
 		/// </summary>
 		[DataElement(AllowDbNull = false)]
-		public String EncounterID
+		public string EncounterID
 		{
 			get { return m_encounterID; }
 			set
@@ -97,7 +97,7 @@ namespace DOL.Database
 		/// to unlock this artifact.
 		/// </summary>
 		[DataElement(AllowDbNull = false)]
-		public String QuestID
+		public string QuestID
 		{
 			get { return m_questID; }
 			set
@@ -111,7 +111,7 @@ namespace DOL.Database
 		/// The zone this artifact belongs to.
 		/// </summary>
 		[DataElement(AllowDbNull = false)]
-		public String Zone
+		public string Zone
 		{
 			get { return m_zone; }
 			set
@@ -125,7 +125,7 @@ namespace DOL.Database
 		/// The scholar(s) studying this artifact.
 		/// </summary>
 		[DataElement(AllowDbNull = false)]
-		public String ScholarID
+		public string ScholarID
 		{
 			get { return m_scholarID; }
 			set
@@ -167,7 +167,7 @@ namespace DOL.Database
 		/// The book ID.
 		/// </summary>
 		[DataElement(AllowDbNull = false)]
-		public String BookID
+		public string BookID
 		{
 			get { return m_bookID; }
 			set
@@ -195,7 +195,7 @@ namespace DOL.Database
 		/// Scroll 1 name.
 		/// </summary>
 		[DataElement(AllowDbNull = false)]
-		public String Scroll1
+		public string Scroll1
 		{
 			get { return m_scroll1; }
 			set
@@ -209,7 +209,7 @@ namespace DOL.Database
 		/// Scroll 2 name.
 		/// </summary>
 		[DataElement(AllowDbNull = false)]
-		public String Scroll2
+		public string Scroll2
 		{
 			get { return m_scroll2; }
 			set
@@ -223,7 +223,7 @@ namespace DOL.Database
 		/// Scroll 3 name.
 		/// </summary>
 		[DataElement(AllowDbNull = false)]
-		public String Scroll3
+		public string Scroll3
 		{
 			get { return m_scroll3; }
 			set
@@ -237,7 +237,7 @@ namespace DOL.Database
 		/// Scrolls 1+2 name.
 		/// </summary>
 		[DataElement(AllowDbNull = false)]
-		public String Scroll12
+		public string Scroll12
 		{
 			get { return m_scroll12; }
 			set
@@ -251,7 +251,7 @@ namespace DOL.Database
 		/// Scrolls 1+3 name.
 		/// </summary>
 		[DataElement(AllowDbNull = false)]
-		public String Scroll13
+		public string Scroll13
 		{
 			get { return m_scroll13; }
 			set
@@ -265,7 +265,7 @@ namespace DOL.Database
 		/// Scrolls 2+3 name.
 		/// </summary>
 		[DataElement(AllowDbNull = false)]
-		public String Scroll23
+		public string Scroll23
 		{
 			get { return m_scroll23; }
 			set
@@ -321,7 +321,7 @@ namespace DOL.Database
 		/// Message issued when scroll is used.
 		/// </summary>
 		[DataElement(AllowDbNull = false)]
-		public String MessageUse
+		public string MessageUse
 		{
 			get { return m_messageUse; }
 			set
@@ -335,7 +335,7 @@ namespace DOL.Database
 		/// Message issued when scrolls are combined.
 		/// </summary>
 		[DataElement(AllowDbNull = false)]
-		public String MessageCombineScrolls
+		public string MessageCombineScrolls
 		{
 			get { return m_messageCombineScrolls; }
 			set
@@ -349,7 +349,7 @@ namespace DOL.Database
 		/// Message issued when book is combined.
 		/// </summary>
 		[DataElement(AllowDbNull = false)]
-		public String MessageCombineBook
+		public string MessageCombineBook
 		{
 			get { return m_messageCombineBook; }
 			set
@@ -363,7 +363,7 @@ namespace DOL.Database
 		/// Message issued when player receives scrolls.
 		/// </summary>
 		[DataElement(AllowDbNull = false)]
-		public String MessageReceiveScrolls
+		public string MessageReceiveScrolls
 		{
 			get { return m_messageReceiveScrolls; }
 			set
@@ -377,7 +377,7 @@ namespace DOL.Database
 		/// Message issued when player receives the book.
 		/// </summary>
 		[DataElement(AllowDbNull = false)]
-		public String MessageReceiveBook
+		public string MessageReceiveBook
 		{
 			get { return m_messageReceiveBook; }
 			set
@@ -391,7 +391,7 @@ namespace DOL.Database
 		/// The bounty point credit for this artifact.
 		/// </summary>
 		[DataElement(AllowDbNull = true)]
-		public String Credit
+		public string Credit
 		{
 			get { return m_credit; }
 			set

--- a/DOLDatabase/Tables/ArtifactBonus.cs
+++ b/DOLDatabase/Tables/ArtifactBonus.cs
@@ -77,7 +77,7 @@ namespace DOL.Database
 		/// The book ID.
 		/// </summary>
 		[DataElement(AllowDbNull = false)]
-		public String ArtifactID
+		public string ArtifactID
 		{
 			get { return m_artifactID; }
 			set

--- a/DOLDatabase/Tables/ArtifactXItem.cs
+++ b/DOLDatabase/Tables/ArtifactXItem.cs
@@ -30,9 +30,9 @@ namespace DOL.Database
 	[DataTable(TableName = "ArtifactXItem")]
 	public class ArtifactXItem : DataObject
 	{
-		private String m_artifactID;
-		private String m_itemID;
-		private String m_version;
+		private string m_artifactID;
+		private string m_itemID;
+		private string m_version;
 		private int m_realm;
 
 		/// <summary>
@@ -54,7 +54,7 @@ namespace DOL.Database
 		/// The artifact ID.
 		/// </summary>
 		[DataElement(AllowDbNull = false)]
-		public String ArtifactID
+		public string ArtifactID
 		{
 			get { return m_artifactID; }
 			set
@@ -68,7 +68,7 @@ namespace DOL.Database
 		/// The item ID.
 		/// </summary>
 		[DataElement(AllowDbNull = false)]
-		public String ItemID
+		public string ItemID
 		{
 			get { return m_itemID; }
 			set
@@ -82,7 +82,7 @@ namespace DOL.Database
 		/// The artifact version.
 		/// </summary>
 		[DataElement(AllowDbNull = false)]
-		public String Version
+		public string Version
 		{
 			get { return m_version; }
 			set

--- a/DOLDatabase/Tables/BindPoint.cs
+++ b/DOLDatabase/Tables/BindPoint.cs
@@ -27,14 +27,8 @@ namespace DOL.Database
 	public class BindPoint : DataObject
 	{
 		//This needs to be uint and ushort!
-		private int	m_xpos;
-		private int	m_ypos;
-		private int	m_zpos;
-		private int		m_region;
-		private ushort	m_radius;
-		private int		m_realm;
 
-		/// <summary>
+	    /// <summary>
 		/// Create a bind point
 		/// </summary>
 		public BindPoint()
@@ -45,90 +39,36 @@ namespace DOL.Database
 		/// The X position of bind
 		/// </summary>
 		[DataElement(AllowDbNull=false)]
-		public int X
-		{
-			get
-			{
-				return m_xpos;
-			}
-			set
-			{
-				m_xpos=value;
-			}
-		}
+		public int X { get; set; }
 
-		/// <summary>
+	    /// <summary>
 		/// The Y position of bind
 		/// </summary>
 		[DataElement(AllowDbNull=false)]
-		public int Y
-		{
-			get
-			{
-				return m_ypos;
-			}
-			set
-			{
-				m_ypos=value;
-			}
-		}
+		public int Y { get; set; }
 
-		/// <summary>
+	    /// <summary>
 		/// The Z position of bind
 		/// </summary>
 		[DataElement(AllowDbNull=false)]
-		public int Z
-		{
-			get
-			{
-				return m_zpos;
-			}
-			set
-			{
-				m_zpos=value;
-			}
-		}
+		public int Z { get; set; }
 
-		/// <summary>
+	    /// <summary>
 		/// The radius of bind
 		/// </summary>
 		[DataElement(AllowDbNull=false)]
-		public ushort Radius
-		{
-			get
-			{
-				return m_radius;
-			}
-			set
-			{
-				m_radius=value;
-			}
-		}
+		public ushort Radius { get; set; }
 
-		/// <summary>
+	    /// <summary>
 		/// The region of bind
 		/// </summary>
 		[DataElement(AllowDbNull=false)]
-		public int Region
-		{
-			get
-			{
-				return m_region;
-			}
-			set
-			{
-				m_region=value;
-			}
-		}
+		public int Region { get; set; }
 
-		/// <summary>
+	    /// <summary>
 		/// The realm of this bind
 		/// </summary>
-		[DataElement(AllowDbNull=true)]
-		public int Realm
-		{
-			get { return m_realm; }
-			set { m_realm = value; }
-		}
+		[DataElement(AllowDbNull=false)]
+		public int Realm { get; set; }
 	}
 }

--- a/DOLDatabase/Tables/CharacterXMasterLevel.cs
+++ b/DOLDatabase/Tables/CharacterXMasterLevel.cs
@@ -76,7 +76,7 @@ namespace DOL.Database
 		}
 		
 		// ML completition flag
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public bool StepCompleted
 		{
 			get { return m_stepcompleted; }

--- a/DOLDatabase/Tables/ClassXSpecialization.cs
+++ b/DOLDatabase/Tables/ClassXSpecialization.cs
@@ -43,7 +43,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Class ID attached to this specialization (0 = all)
 		/// </summary>
-		[DataElement(AllowDbNull=true, Index=true)]
+		[DataElement(AllowDbNull= false, Index=true)]
 		public int ClassID {
 			get { return m_classID; }
 			set { Dirty = true; m_classID = value; }
@@ -65,7 +65,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Level at which Specialization is enabled. (default 0 = always enabled)
 		/// </summary>
-		[DataElement(AllowDbNull=true, Index=true)]
+		[DataElement(AllowDbNull= false, Index=true)]
 		public int LevelAcquired {
 			get { return m_levelAcquired; }
 			set { Dirty = true; m_levelAcquired = value; }

--- a/DOLDatabase/Tables/DBHouse.cs
+++ b/DOLDatabase/Tables/DBHouse.cs
@@ -169,7 +169,7 @@ namespace DOL
 					m_name = value;
 				}
 			}
-			[DataElement(AllowDbNull=true)]
+			[DataElement(AllowDbNull= false)]
 			public int Model
 			{
 				get
@@ -182,7 +182,7 @@ namespace DOL
 					m_model = value;
 				}
 			}
-			[DataElement(AllowDbNull=true)]
+			[DataElement(AllowDbNull= false)]
 			public int Emblem
 			{
 				get
@@ -195,7 +195,7 @@ namespace DOL
 					m_emblem = value;
 				}
 			}
-			[DataElement(AllowDbNull=true)]
+			[DataElement(AllowDbNull= false)]
 			public int PorchRoofColor
 			{
 				get
@@ -208,7 +208,7 @@ namespace DOL
 					m_porchroofcolor = value;
 				}
 			}
-			[DataElement(AllowDbNull=true)]
+			[DataElement(AllowDbNull= false)]
 			public int PorchMaterial
 			{
 				get
@@ -221,7 +221,7 @@ namespace DOL
 					m_porchmaterial = value;
 				}
 			}
-			[DataElement(AllowDbNull=true)]
+			[DataElement(AllowDbNull= false)]
 			public int RoofMaterial
 			{
 				get
@@ -234,7 +234,7 @@ namespace DOL
 					m_roofmaterial = value;
 				}
 			}
-			[DataElement(AllowDbNull=true)]
+			[DataElement(AllowDbNull= false)]
 			public int DoorMaterial
 			{
 				get
@@ -247,7 +247,7 @@ namespace DOL
 					m_doormaterial = value;
 				}
 			}
-			[DataElement(AllowDbNull=true)]
+			[DataElement(AllowDbNull= false)]
 			public int WallMaterial
 			{
 				get
@@ -260,7 +260,7 @@ namespace DOL
 					m_wallmaterial = value;
 				}
 			}
-			[DataElement(AllowDbNull=true)]
+			[DataElement(AllowDbNull= false)]
 			public int TrussMaterial
 			{
 				get
@@ -273,7 +273,7 @@ namespace DOL
 					m_trussmaterial = value;
 				}
 			}
-			[DataElement(AllowDbNull=true)]
+			[DataElement(AllowDbNull= false)]
 			public int WindowMaterial
 			{
 				get
@@ -286,7 +286,7 @@ namespace DOL
 					m_windowmaterial = value;
 				}
 			}
-			[DataElement(AllowDbNull=true)]
+			[DataElement(AllowDbNull= false)]
 			public int Rug1Color
 			{
 				get
@@ -299,7 +299,7 @@ namespace DOL
 					m_rug1color = value;
 				}
 			}
-			[DataElement(AllowDbNull=true)]
+			[DataElement(AllowDbNull= false)]
 			public int Rug2Color
 			{
 				get
@@ -312,7 +312,7 @@ namespace DOL
 					m_rug2color = value;
 				}
 			}
-			[DataElement(AllowDbNull=true)]
+			[DataElement(AllowDbNull= false)]
 			public int Rug3Color
 			{
 				get
@@ -325,7 +325,7 @@ namespace DOL
 					m_rug3color = value;
 				}
 			}
-			[DataElement(AllowDbNull=true)]
+			[DataElement(AllowDbNull= false)]
 			public int Rug4Color
 			{
 				get
@@ -338,7 +338,7 @@ namespace DOL
 					m_rug4color = value;
 				}
 			}
-			[DataElement(AllowDbNull=true)]
+			[DataElement(AllowDbNull= false)]
 			public bool IndoorGuildBanner
 			{
 				get
@@ -351,7 +351,7 @@ namespace DOL
 					m_indoorguildbanner = value;
 				}
 			}
-			[DataElement(AllowDbNull=true)]
+			[DataElement(AllowDbNull= false)]
 			public bool IndoorGuildShield
 			{
 				get
@@ -364,7 +364,7 @@ namespace DOL
 					m_indoorguildshield = value;
 				}
 			}
-			[DataElement(AllowDbNull=true)]
+			[DataElement(AllowDbNull= false)]
 			public bool OutdoorGuildBanner
 			{
 				get
@@ -377,7 +377,7 @@ namespace DOL
 					m_outdoorguildbanner = value;
 				}
 			}
-			[DataElement(AllowDbNull=true)]
+			[DataElement(AllowDbNull= false)]
 			public bool OutdoorGuildShield
 			{
 				get
@@ -390,7 +390,7 @@ namespace DOL
 					m_outdoorguildshield = value;
 				}
 			}
-			[DataElement(AllowDbNull=true)]
+			[DataElement(AllowDbNull= false)]
 			public bool Porch
 			{
 				get
@@ -432,7 +432,7 @@ namespace DOL
 				}
 			}
 
-			[DataElement(AllowDbNull = true)]
+			[DataElement(AllowDbNull = false)]
 			public long KeptMoney
 			{
 				get
@@ -446,7 +446,7 @@ namespace DOL
 				}
 			}
 
-			[DataElement(AllowDbNull = true)]
+			[DataElement(AllowDbNull = false)]
 			public bool NoPurge
 			{
 				get
@@ -460,7 +460,7 @@ namespace DOL
 				}
 			}
 
-			[DataElement(AllowDbNull = true)]
+			[DataElement(AllowDbNull = false)]
 			public bool GuildHouse
 			{
 				get
@@ -487,7 +487,7 @@ namespace DOL
 				}
 			}
 
-			[DataElement(AllowDbNull = true)]
+			[DataElement(AllowDbNull = false)]
 			public bool HasConsignment
 			{
 				get

--- a/DOLDatabase/Tables/DBHouseIndoorItem.cs
+++ b/DOLDatabase/Tables/DBHouseIndoorItem.cs
@@ -141,7 +141,7 @@ namespace DOL
 					m_baseitemid = value;
 				}
 			}
-			[DataElement(AllowDbNull=true)]
+			[DataElement(AllowDbNull= false)]
 			public int Color
 			{
 				get
@@ -154,7 +154,7 @@ namespace DOL
 					m_color = value;
 				}
 			}
-			[DataElement(AllowDbNull = true)]
+			[DataElement(AllowDbNull = false)]
 			public int Emblem
 			{
 				get
@@ -167,7 +167,7 @@ namespace DOL
 					m_emblem = value;
 				}
 			}
-			[DataElement(AllowDbNull=true)]
+			[DataElement(AllowDbNull= false)]
 			public int Rotation
 			{
 				get
@@ -180,7 +180,7 @@ namespace DOL
 					m_rotation = value;
 				}
 			}
-			[DataElement(AllowDbNull=true)]
+			[DataElement(AllowDbNull= false)]
 			public int Size
 			{
 				get

--- a/DOLDatabase/Tables/DOLCharacters.cs
+++ b/DOLDatabase/Tables/DOLCharacters.cs
@@ -233,7 +233,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Gets/sets if this character has xp in a gravestone
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public bool HasGravestone
 		{
 			get
@@ -250,7 +250,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Gets/sets the region id where the gravestone of the player is located
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int GravestoneRegion
 		{
 			get
@@ -267,7 +267,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Gets/sets character constitution
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int Constitution
 		{
 			get
@@ -284,7 +284,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Gets/sets character dexterity
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int Dexterity
 		{
 			get
@@ -301,7 +301,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Gets/sets character strength
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int Strength
 		{
 			get
@@ -318,7 +318,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Gets/sets character quickness
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int Quickness
 		{
 			get
@@ -335,7 +335,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Gets/sets character intelligence
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int Intelligence
 		{
 			get
@@ -352,7 +352,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Gets/sets character piety
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int Piety
 		{
 			get
@@ -369,7 +369,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Gets/sets character empathy
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int Empathy
 		{
 			get
@@ -386,7 +386,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Gets/sets character charisma
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int Charisma
 		{
 			get
@@ -403,7 +403,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Gets/sets chracter bounty points
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public long BountyPoints
 		{
 			get
@@ -420,7 +420,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Gets/sets character realm points
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public long RealmPoints
 		{
 			get
@@ -437,7 +437,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Gets/sets realm rank
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int RealmLevel
 		{
 			get
@@ -454,7 +454,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Gets/sets experience
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public long Experience
 		{
 			get
@@ -471,7 +471,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Gets/sets max endurance
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int MaxEndurance
 		{
 			get
@@ -488,7 +488,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Gets/sets maximum health
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int Health
 		{
 			get
@@ -505,7 +505,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Gets/sets max mana
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int Mana
 		{
 			get
@@ -522,7 +522,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Gets/sets max endurance
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int Endurance
 		{
 			get
@@ -539,7 +539,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Gets/sets the object concentration
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int Concentration
 		{
 			get
@@ -573,7 +573,7 @@ namespace DOL.Database
 		/// <summary>
 		/// The slot of character in account
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int AccountSlot
 		{
 			get
@@ -879,7 +879,7 @@ namespace DOL.Database
 		/// <summary>
 		/// The bind X position of character
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int BindXpos
 		{
 			get
@@ -896,7 +896,7 @@ namespace DOL.Database
 		/// <summary>
 		/// The bind Y position of character
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int BindYpos
 		{
 			get
@@ -913,7 +913,7 @@ namespace DOL.Database
 		/// <summary>
 		/// The bind Z position of character
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int BindZpos
 		{
 			get
@@ -930,7 +930,7 @@ namespace DOL.Database
 		/// <summary>
 		/// The bind region position of character
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int BindRegion
 		{
 			get
@@ -947,7 +947,7 @@ namespace DOL.Database
 		/// <summary>
 		/// The bind heading position of character
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int BindHeading
 		{
 			get
@@ -964,7 +964,7 @@ namespace DOL.Database
 		/// <summary>
 		/// The house bind X position of character
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int BindHouseXpos
 		{
 			get
@@ -981,7 +981,7 @@ namespace DOL.Database
 		/// <summary>
 		/// The bind house Y position of character
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int BindHouseYpos
 		{
 			get
@@ -998,7 +998,7 @@ namespace DOL.Database
 		/// <summary>
 		/// The bind house Z position of character
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int BindHouseZpos
 		{
 			get
@@ -1015,7 +1015,7 @@ namespace DOL.Database
 		/// <summary>
 		/// The bind house region position of character
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int BindHouseRegion
 		{
 			get
@@ -1032,7 +1032,7 @@ namespace DOL.Database
 		/// <summary>
 		/// The bind house heading position of character
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int BindHouseHeading
 		{
 			get
@@ -1049,7 +1049,7 @@ namespace DOL.Database
 		/// <summary>
 		/// The number of chacter is dead at this level
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public byte DeathCount
 		{
 			get
@@ -1066,7 +1066,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Constitution lost at death
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int ConLostAtDeath
 		{
 			get
@@ -1117,7 +1117,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Money copper part player own
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int Copper
 		{
 			get
@@ -1134,7 +1134,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Money silver part player own
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int Silver
 		{
 			get
@@ -1151,7 +1151,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Money gold part player own
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int Gold
 		{
 			get
@@ -1168,7 +1168,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Money platinum part player own
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int Platinum
 		{
 			get
@@ -1185,7 +1185,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Money mithril part player own
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int Mithril
 		{
 			get
@@ -1306,7 +1306,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Is cloak hood up
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public bool IsCloakHoodUp
 		{
 			get { return m_isCloakHoodUp; }
@@ -1348,7 +1348,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Spell queue flag
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public bool SpellQueue
 		{
 			get { return m_spellQueue; }
@@ -1362,7 +1362,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Gets/sets half-level flag
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public bool IsLevelSecondStage
 		{
 			get
@@ -1379,7 +1379,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Gets/sets guildname flag to print guildname or crafting title
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public bool FlagClassName
 		{
 			get
@@ -1397,7 +1397,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Is the character an advisor
 		/// </summary>
-		[DataElement(AllowDbNull=true)]
+		[DataElement(AllowDbNull= false)]
 		public bool Advisor
 		{
 			get { return m_advisor; }
@@ -1407,7 +1407,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Gets/sets guild rank in the guild
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public ushort GuildRank
 		{
 			get
@@ -1423,7 +1423,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Gets/sets the characters /played time
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public long PlayedTime
 		{
 			get
@@ -1439,7 +1439,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Gets/sets the characters death /played time
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public long DeathTime
 		{
 			get { return m_deathTime; }
@@ -1452,7 +1452,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Gets/sets the characters full skill respecs available
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int RespecAmountAllSkill
 		{
 			get
@@ -1468,7 +1468,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Gets/sets the characters single-line respecs available
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int RespecAmountSingleSkill
 		{
 			get
@@ -1485,7 +1485,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Gets/Sets the characters realm respecs available
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int RespecAmountRealmSkill
 		{
 			get
@@ -1502,7 +1502,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Gets/Sets the characters DOL respecs available
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int RespecAmountDOL
 		{
 			get
@@ -1519,7 +1519,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Gets/sets the characters single-line respecs available
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int RespecAmountChampionSkill
 		{
 			get
@@ -1535,7 +1535,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Gets/Sets level respec flag
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public bool IsLevelRespecUsed
 		{
 			get { return m_isLevelRespecUsed; }
@@ -1548,7 +1548,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Gets/Sets level respec bought
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int RespecBought
 		{
 			get { return m_respecBought; }
@@ -1561,7 +1561,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Gets/sets the characters safety flag
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public bool SafetyFlag
 		{
 			get { return m_safetyFlag; }
@@ -1575,7 +1575,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Gets/sets the characters safety flag
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int CraftingPrimarySkill
 		{
 			get { return m_craftingPrimarySkill; }
@@ -1589,7 +1589,7 @@ namespace DOL.Database
 		/// <summary>
 		/// the cancel style
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public bool CancelStyle
 		{
 			get { return m_cancelStyle; }
@@ -1604,7 +1604,7 @@ namespace DOL.Database
 		/// is anonymous( can not seen him in /who and some other things
 		/// /anon to toggle
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public bool IsAnonymous
 		{
 			get { return m_isAnonymous; }
@@ -1618,7 +1618,7 @@ namespace DOL.Database
 		/// <summary>
 		/// the face customisation step
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public byte CustomisationStep
 		{
 			get { return m_customisationStep; }
@@ -1632,7 +1632,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Gets/sets character EyeSize
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public byte EyeSize
 		{
 			get
@@ -1648,7 +1648,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Gets/sets character LipSize
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public byte LipSize
 		{
 			get
@@ -1665,7 +1665,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Gets/sets character EyeColor
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public byte EyeColor
 		{
 			get
@@ -1682,7 +1682,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Gets/sets character HairColor
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public byte HairColor
 		{
 			get
@@ -1699,7 +1699,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Gets/sets character FaceType
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public byte FaceType
 		{
 			get
@@ -1716,7 +1716,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Gets/sets character HairStyle
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public byte HairStyle
 		{
 			get
@@ -1733,7 +1733,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Gets/sets character MoodType
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public byte MoodType
 		{
 			get
@@ -1750,7 +1750,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Gets/sets weather a character has used /level
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public bool UsedLevelCommand
 		{
 			get
@@ -1794,7 +1794,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Amount of Albion Players Killed
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int KillsAlbionPlayers
 		{
 			get { return m_killsAlbionPlayers; }
@@ -1804,7 +1804,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Amount of Midgard Players Killed
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int KillsMidgardPlayers
 		{
 			get { return m_killsMidgardPlayers; }
@@ -1814,7 +1814,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Amount of Hibernia Players Killed
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int KillsHiberniaPlayers
 		{
 			get { return m_killsHiberniaPlayers; }
@@ -1824,7 +1824,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Amount of Death Blows on Albion Players
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int KillsAlbionDeathBlows
 		{
 			get { return m_killsAlbionDeathBlows; }
@@ -1834,7 +1834,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Amount of Death Blows on Midgard Players
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int KillsMidgardDeathBlows
 		{
 			get { return m_killsMidgardDeathBlows; }
@@ -1844,7 +1844,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Amount of Death Blows on Hibernia Players
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int KillsHiberniaDeathBlows
 		{
 			get { return m_killsHiberniaDeathBlows; }
@@ -1854,7 +1854,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Amount of Solo Albion Kills
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int KillsAlbionSolo
 		{
 			get { return m_killsAlbionSolo; }
@@ -1864,7 +1864,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Amount of Solo Midgard Kills
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int KillsMidgardSolo
 		{
 			get { return m_killsMidgardSolo; }
@@ -1874,7 +1874,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Amount of Solo Hibernia Kills
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int KillsHiberniaSolo
 		{
 			get { return m_killsHiberniaSolo; }
@@ -1884,7 +1884,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Amount of Keeps Captured
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int CapturedKeeps
 		{
 			get { return m_capturedKeeps; }
@@ -1894,7 +1894,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Amount of Towers Captured
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int CapturedTowers
 		{
 			get { return m_capturedTowers; }
@@ -1904,7 +1904,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Amount of Relics Captured
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int CapturedRelics
 		{
 			get { return m_capturedRelics; }
@@ -1914,7 +1914,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Amount of Dragons Killed
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int KillsDragon
 		{
 			get { return m_killsDragon; }
@@ -1924,7 +1924,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Amount of PvP deaths
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int DeathsPvP
 		{
 			get { return m_deathsPvP; }
@@ -1938,7 +1938,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Amount of killed Legions
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int KillsLegion
 		{
 			get { return m_killsLegion; }
@@ -1948,7 +1948,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Amount of killed EpicDungeon Boss
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int KillsEpicBoss
 		{
 			get { return m_killsEpicBoss; }
@@ -1961,7 +1961,7 @@ namespace DOL.Database
 		/// can gain experience points
 		/// /xp to toggle
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public bool GainXP
 		{
 			get { return m_gainXP; }
@@ -1976,7 +1976,7 @@ namespace DOL.Database
 		/// can gain realm points
 		/// /rp to toggle
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public bool GainRP
 		{
 			get { return m_gainRP; }
@@ -1989,7 +1989,7 @@ namespace DOL.Database
 		/// <summary>
 		/// autoloot
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public bool Autoloot
 		{
 			get { return m_autoloot; }
@@ -2022,7 +2022,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Last Level for FreeLevel
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int LastFreeLevel
 		{
 			get
@@ -2052,7 +2052,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public bool ShowXFireInfo
 		{
 			get
@@ -2066,14 +2066,14 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public bool NoHelp
 		{
 			get { return m_noHelp; }
 			set { Dirty = true; m_noHelp = value; }
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public bool ShowGuildLogins
 		{
 			get { return m_showGuildLogins; }
@@ -2083,7 +2083,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Is Champion level activated
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public bool Champion
 		{
 			get
@@ -2099,7 +2099,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Champion level
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int ChampionLevel
 		{
 			get
@@ -2116,7 +2116,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Champion Experience
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public long ChampionExperience
 		{
 			get
@@ -2197,7 +2197,7 @@ namespace DOL.Database
 		/// <summary>
 		/// is the player a roleplayer
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public bool RPFlag
 		{
 			get { return m_roleplay; }
@@ -2211,7 +2211,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Do we ignore all statistics for this player?
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public bool IgnoreStatistics
 		{
 			get { return m_ignoreStatistics; }
@@ -2225,7 +2225,7 @@ namespace DOL.Database
 		/// <summary>
 		/// what should we not display in Herald ?
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public byte NotDisplayedInHerald 
 		{
 			get { return m_notDisplayedInHerald; }
@@ -2236,7 +2236,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public byte ActiveSaddleBags
 		{
 			get { return m_activeSaddleBags; }

--- a/DOLDatabase/Tables/Door.cs
+++ b/DOLDatabase/Tables/Door.cs
@@ -73,7 +73,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int Type
 		{
 			get
@@ -90,7 +90,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Z position of door
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int Z
 		{
 			get
@@ -107,7 +107,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Y position of door
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int Y
 		{
 			get
@@ -124,7 +124,7 @@ namespace DOL.Database
 		/// <summary>
 		/// X position of door
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int X
 		{
 			get
@@ -141,7 +141,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Heading of door
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int Heading
 		{
 			get
@@ -158,7 +158,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Internal index of Door
 		/// </summary>
-		[DataElement(AllowDbNull = true, Index = true)]
+		[DataElement(AllowDbNull = false, Index = true)]
 		public int InternalID
 		{
 			get
@@ -228,7 +228,7 @@ namespace DOL.Database
 			}
 		}
 		
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public uint Flags
 		{
 			get

--- a/DOLDatabase/Tables/Faction.cs
+++ b/DOLDatabase/Tables/Faction.cs
@@ -78,7 +78,7 @@ namespace DOL.Database
 		/// base friendship/relationship/aggro level at start for playe when never it before
 		///
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int BaseAggroLevel
 		{
 			get { return m_baseAggroLevel; }

--- a/DOLDatabase/Tables/Guild.cs
+++ b/DOLDatabase/Tables/Guild.cs
@@ -111,7 +111,7 @@ namespace DOL.Database
 		}
 
 		[ReadOnly]
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public byte Realm
 		{
 			get
@@ -124,7 +124,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public bool GuildBanner
 		{
 			get
@@ -194,7 +194,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int Emblem
 		{
 			get
@@ -208,7 +208,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public long RealmPoints
 		{
 			get
@@ -222,7 +222,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public long BountyPoints
 		{
 			get
@@ -258,7 +258,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public bool Dues
 		{
 			get { return m_guildDues; }
@@ -269,7 +269,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public double Bank
 		{
 			get { return m_guildBank; }
@@ -280,7 +280,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public long DuesPercent
 		{
 			get { return m_guildDuesPercent; }
@@ -313,7 +313,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public long GuildLevel
 		{
 			get
@@ -327,7 +327,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public byte BonusType
 		{
 			get

--- a/DOLDatabase/Tables/GuildRank.cs
+++ b/DOLDatabase/Tables/GuildRank.cs
@@ -113,7 +113,7 @@ namespace DOL.Database
 		/// <summary>
 		/// rank level between 1 and 10
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public byte RankLevel
 		{
 			get
@@ -130,7 +130,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Is player allowed to make alliance
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public bool Alli
 		{
 			get
@@ -147,7 +147,7 @@ namespace DOL.Database
 		/// <summary>
 		/// is member alowed to wear alliance
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public bool Emblem
 		{
 			get
@@ -161,7 +161,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public bool Buff
 		{
 			get
@@ -177,7 +177,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Can player with this rank hear guild chat
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public bool GcHear
 		{
 			get
@@ -194,7 +194,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Can player with this rank talk on guild chat
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public bool GcSpeak
 		{
 			get
@@ -211,7 +211,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Can player with this rank hear officier chat
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public bool OcHear
 		{
 			get
@@ -228,7 +228,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Can player with this rank talk on officier chat
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public bool OcSpeak
 		{
 			get
@@ -245,7 +245,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Can player with this rank hear alliance chat
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public bool AcHear
 		{
 			get
@@ -262,7 +262,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Can player with this rank talk on alliance chat
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public bool AcSpeak
 		{
 			get
@@ -279,7 +279,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Can player with this rank invite player to join the guild
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public bool Invite
 		{
 			get
@@ -296,7 +296,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Can player with this rank promote player in the guild
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public bool Promote
 		{
 			get
@@ -313,7 +313,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Can player with this rank removed player from the guild
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public bool Remove
 		{
 			get
@@ -330,7 +330,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Can player with this rank view player in the guild
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public bool View
 		{
 			get
@@ -347,7 +347,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Can player with this rank claim keep
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public bool Claim
 		{
 			get
@@ -364,7 +364,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Can player with this rank upgrade keep
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public bool Upgrade
 		{
 			get
@@ -381,7 +381,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Can player with this rank released the keep claimed
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public bool Release
 		{
 			get
@@ -394,7 +394,7 @@ namespace DOL.Database
 				m_release = value;
 			}
 		}
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public bool Dues
 		{
 			get
@@ -407,7 +407,7 @@ namespace DOL.Database
 				m_dues = value;
 			}
 		}
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public bool Withdraw
 		{
 			get

--- a/DOLDatabase/Tables/HousepointItem.cs
+++ b/DOLDatabase/Tables/HousepointItem.cs
@@ -73,7 +73,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public ushort Heading
 		{
 			get { return m_heading; }
@@ -99,7 +99,7 @@ namespace DOL.Database
 		/// Index of this item in case there is more than 1
 		/// of the same type.
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public byte Index
 		{
 			get { return m_index; }

--- a/DOLDatabase/Tables/InstanceXElement.cs
+++ b/DOLDatabase/Tables/InstanceXElement.cs
@@ -28,13 +28,7 @@ namespace DOL.Database
 	[DataTable(TableName = "InstanceXElement")]
 	public class DBInstanceXElement : DataObject
 	{
-		protected string m_instanceID;
-		protected string m_classType;
-		protected int m_X, m_Y, m_Z;
-		protected ushort m_Heading;
-		protected string m_NPCTemplate;
-
-		public DBInstanceXElement()
+	    public DBInstanceXElement()
 		{
 		}
 
@@ -42,58 +36,30 @@ namespace DOL.Database
 		/// The unique name of this instance. Eg 'My Task Dungeon'
 		/// </summary>
 		[DataElement(AllowDbNull = false, Index = true)]
-		public String InstanceID
-		{
-			get { return m_instanceID; }
-			set { m_instanceID = value; }
-		}
+		public string InstanceID { get; set; }
 
-		[DataElement(AllowDbNull = true)]
-		public String ClassType
-		{
-			get { return m_classType; }
-			set { m_classType = value; }
-		}
+	    [DataElement(AllowDbNull = true)]
+		public string ClassType { get; set; }
 
-		[DataElement(AllowDbNull = false)]
-		public int X
-		{
-			get { return m_X; }
-			set { m_X = value; }
-		}
+	    [DataElement(AllowDbNull = false)]
+		public int X { get; set; }
 
-		[DataElement(AllowDbNull = false)]
-		public int Y
-		{
-			get { return m_Y; }
-			set { m_Y = value; }
-		}
+	    [DataElement(AllowDbNull = false)]
+		public int Y { get; set; }
 
-		[DataElement(AllowDbNull = false)]
-		public int Z
-		{
-			get { return m_Z; }
-			set { m_Z = value; }
-		}
+	    [DataElement(AllowDbNull = false)]
+		public int Z { get; set; }
 
-		[DataElement(AllowDbNull = false)]
-		public ushort Heading
-		{
-			get { return m_Heading; }
-			set { m_Heading = value; }
-		}
+	    [DataElement(AllowDbNull = false)]
+		public ushort Heading { get; set; }
 
-		/// <summary>
+	    /// <summary>
 		/// Where applicable, the npc template to create this mob from.
 		/// </summary>
 		[DataElement(AllowDbNull = false, Varchar = 255)]
-		public string NPCTemplate
-		{
-			get { return m_NPCTemplate; }
-			set { m_NPCTemplate = value; }
-		}
+		public string NPCTemplate { get; set; }
 
-		/// <summary>
+	    /// <summary>
 		/// Convert the NPCTemplate to/from int, assuming a single ID
 		/// </summary>
 		public int NPCTemplateID

--- a/DOLDatabase/Tables/Inventory.cs
+++ b/DOLDatabase/Tables/Inventory.cs
@@ -52,7 +52,7 @@ namespace DOL.Database
 		}
 		
 		protected ushort m_ownerLot; 		// house lot owner id
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public ushort OwnerLot
 		{
 			get{return m_ownerLot;}
@@ -75,7 +75,7 @@ namespace DOL.Database
 		}
 		
 		protected bool m_iscrafted;			// iscrafted or looted ?
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public virtual bool IsCrafted {
 			get { return m_iscrafted; }
 			set { Dirty = true; m_iscrafted = value; }
@@ -90,7 +90,7 @@ namespace DOL.Database
 		}
 		
 		protected int m_slot_pos;			// slot in inventory
-		[DataElement(AllowDbNull = true, Index = true)]
+		[DataElement(AllowDbNull = false, Index = true)]
 		public virtual int SlotPosition
 		{
 			get{return m_slot_pos;}
@@ -98,7 +98,7 @@ namespace DOL.Database
 		}
 		
 		protected int m_count; 				// count of items, for stack
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public virtual int Count
 		{
 			get{return m_count;}
@@ -106,7 +106,7 @@ namespace DOL.Database
 		}
 		
 		protected int m_sellPrice;			// sell price in CM
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public virtual int SellPrice
 		{
 			get{return m_sellPrice;}
@@ -114,7 +114,7 @@ namespace DOL.Database
 		}
 		
 		protected long m_experience;			// artefact experience
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public virtual long Experience
 		{
 			get { return m_experience; }
@@ -124,21 +124,21 @@ namespace DOL.Database
 		// Itemtemplate fields
 		// apparence fields
 		protected int m_color;
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public virtual int Color
 		{
 			get { return m_color; }
 			set {Dirty = true; m_color = value; }
 		}
 		protected int m_emblem;
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public virtual int Emblem
 		{
 			get { return m_emblem; }
 			set { Dirty = true;m_emblem = value; }
 		}
 		protected byte m_extension;
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public virtual byte Extension
 		{
 			get { return m_extension; }
@@ -163,35 +163,35 @@ namespace DOL.Database
 		
 		// poison & current charges
 		protected int m_poisonSpellID;
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public virtual int PoisonSpellID
 		{
 			get { return m_poisonSpellID; }
 			set { Dirty = true;m_poisonSpellID = value; }
 		}
 		protected int m_poisonMaxCharges;
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public virtual int PoisonMaxCharges
 		{
 			get { return m_poisonMaxCharges; }
 			set { Dirty = true;m_poisonMaxCharges = value; }
 		}
 		protected int m_poisonCharges;
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public virtual int PoisonCharges
 		{
 			get { return m_poisonCharges; }
 			set { Dirty = true;m_poisonCharges = value; }
 		}
 		protected int m_charges;
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public virtual int Charges
 		{
 			get { return m_charges; }
 			set { Dirty = true;m_charges = value; }
 		}
 		protected int m_charges1;
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public virtual int Charges1
 		{
 			get { return m_charges1; }

--- a/DOLDatabase/Tables/ItemTemplate.cs
+++ b/DOLDatabase/Tables/ItemTemplate.cs
@@ -372,14 +372,14 @@ namespace DOL.Database
 			set { Dirty = true; m_level = value; }
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int Durability
 		{
 			get { return m_durability == 0 ? m_maxdurability : m_durability; }
 			set { Dirty = true; m_durability = value; }
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int MaxDurability
 		{
 			get { return m_maxdurability; }
@@ -389,98 +389,98 @@ namespace DOL.Database
 		/// <summary>
 		/// Your item will not lose dur over repairs
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public bool IsNotLosingDur
 		{
 			get { return m_isNotLosingDur; }
 			set { Dirty = true; m_isNotLosingDur = value; }
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int Condition
 		{
 			get { return m_condition == 0 ? m_maxcondition : m_condition; }
 			set { Dirty = true; m_condition = value; }
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int MaxCondition
 		{
 			get { return m_maxcondition; }
 			set { Dirty = true; m_maxcondition = value; }
 		}
 		
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int Quality
 		{
 			get { return m_quality; }
 			set { Dirty = true; m_quality = value; }
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int DPS_AF
 		{
 			get { return m_dps_af; }
 			set { Dirty = true; m_dps_af = value; }
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int SPD_ABS
 		{
 			get { return m_spd_abs; }
 			set { Dirty = true; m_spd_abs = value; }
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int Hand
 		{
 			get { return m_hand; }
 			set { Dirty = true; m_hand = value; }
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int Type_Damage
 		{
 			get { return m_type_damage; }
 			set { Dirty = true; m_type_damage = value; }
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int Object_Type
 		{
 			get { return m_object_type; }
 			set { Dirty = true; m_object_type = value; }
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int Item_Type
 		{
 			get { return m_item_type; }
 			set { Dirty = true; m_item_type = value; }
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int Color
 		{
 			get { return m_color; }
 			set { Dirty = true; m_color = value; }
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int Emblem
 		{
 			get { return m_emblem; }
 			set { Dirty = true; m_emblem = value; }
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int Effect
 		{
 			get { return m_effect; }
 			set { Dirty = true; m_effect = value; }
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int Weight
 		{
 			get { return m_weight; }
@@ -494,7 +494,7 @@ namespace DOL.Database
 			set { Dirty = true; m_model = value; }
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public byte Extension
 		{
 			get { return m_extension; }
@@ -503,84 +503,84 @@ namespace DOL.Database
 
 		#region Bonuses
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int Bonus
 		{
 			get { return m_bonus; }
 			set { Dirty = true; m_bonus = value; }
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public virtual int Bonus1
 		{
 			get { return m_bonus1; }
 			set { Dirty = true; m_bonus1 = value; }
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public virtual int Bonus2
 		{
 			get { return m_bonus2; }
 			set { Dirty = true; m_bonus2 = value; }
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public virtual int Bonus3
 		{
 			get { return m_bonus3; }
 			set { Dirty = true; m_bonus3 = value; }
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public virtual int Bonus4
 		{
 			get { return m_bonus4; }
 			set { Dirty = true; m_bonus4 = value; }
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public virtual int Bonus5
 		{
 			get { return m_bonus5; }
 			set { Dirty = true; m_bonus5 = value; }
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public virtual int Bonus6
 		{
 			get { return m_bonus6; }
 			set { Dirty = true; m_bonus6 = value; }
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public virtual int Bonus7
 		{
 			get { return m_bonus7; }
 			set { Dirty = true; m_bonus7 = value; }
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public virtual int Bonus8
 		{
 			get { return m_bonus8; }
 			set { Dirty = true; m_bonus8 = value; }
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public virtual int Bonus9
 		{
 			get { return m_bonus9; }
 			set { Dirty = true; m_bonus9 = value; }
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public virtual int Bonus10
 		{
 			get { return m_bonus10; }
 			set { Dirty = true; m_bonus10 = value; }
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int ExtraBonus
 		{
 			get { return m_extrabonus; }
@@ -591,77 +591,77 @@ namespace DOL.Database
 
 		#region BonusTypes
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public virtual int Bonus1Type
 		{
 			get { return m_bonus1Type; }
 			set { Dirty = true; m_bonus1Type = value; }
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public virtual int Bonus2Type
 		{
 			get { return m_bonus2Type; }
 			set { Dirty = true; m_bonus2Type = value; }
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public virtual int Bonus3Type
 		{
 			get { return m_bonus3Type; }
 			set { Dirty = true; m_bonus3Type = value; }
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public virtual int Bonus4Type
 		{
 			get { return m_bonus4Type; }
 			set { Dirty = true; m_bonus4Type = value; }
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public virtual int Bonus5Type
 		{
 			get { return m_bonus5Type; }
 			set { Dirty = true; m_bonus5Type = value; }
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public virtual int Bonus6Type
 		{
 			get { return m_bonus6Type; }
 			set { Dirty = true; m_bonus6Type = value; }
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public virtual int Bonus7Type
 		{
 			get { return m_bonus7Type; }
 			set { Dirty = true; m_bonus7Type = value; }
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public virtual int Bonus8Type
 		{
 			get { return m_bonus8Type; }
 			set { Dirty = true; m_bonus8Type = value; }
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public virtual int Bonus9Type
 		{
 			get { return m_bonus9Type; }
 			set { Dirty = true; m_bonus9Type = value; }
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public virtual int Bonus10Type
 		{
 			get { return m_bonus10Type; }
 			set { Dirty = true; m_bonus10Type = value; }
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int ExtraBonusType
 		{
 			get { return m_extrabonusType; }
@@ -684,7 +684,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Spell id for items with charge
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public virtual int SpellID
 		{
 			get { return m_spellID; }
@@ -694,7 +694,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Charge of item when he have some charge of a spell
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int Charges
 		{
 			get { return m_charges; }
@@ -704,7 +704,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Max charge of item when he have some charge of a spell
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int MaxCharges
 		{
 			get { return m_maxCharges; }
@@ -717,14 +717,14 @@ namespace DOL.Database
 		/// <summary>
 		/// Spell id for items with charge
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public virtual int SpellID1
 		{
 			get { return m_spellID1; }
 			set { Dirty = true; m_spellID1 = value; }
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int Charges1
 		{
 			get { return m_charges1; }
@@ -734,7 +734,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Max charge of item when he have some charge of a spell
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int MaxCharges1
 		{
 			get { return m_maxCharges1; }
@@ -747,7 +747,7 @@ namespace DOL.Database
 
 		#region Procs
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public virtual byte ProcChance
 		{
 			get { return m_procChance; }
@@ -759,7 +759,7 @@ namespace DOL.Database
 		/// <summary>
 		/// ProcSpell id for items
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public virtual int ProcSpellID
 		{
 			get { return m_procSpellID; }
@@ -769,7 +769,7 @@ namespace DOL.Database
 		#endregion
 		#region second proc
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public virtual int ProcSpellID1
 		{
 			get { return m_procSpellID1; }
@@ -782,21 +782,21 @@ namespace DOL.Database
 
 		#region Poison
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int PoisonSpellID
 		{
 			get { return m_poisonSpellID; }
 			set { Dirty = true; m_poisonSpellID = value; }
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int PoisonCharges
 		{
 			get { return m_poisonCharges; }
 			set { Dirty = true; m_poisonCharges = value; }
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int PoisonMaxCharges
 		{
 			get { return m_poisonMaxCharges; }
@@ -805,35 +805,35 @@ namespace DOL.Database
 
 		#endregion
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public bool IsPickable
 		{
 			get { return m_isPickable; }
 			set { Dirty = true; m_isPickable = value; }
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public bool IsDropable
 		{
 			get { return m_isDropable; }
 			set { Dirty = true; m_isDropable = value; }
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public bool CanDropAsLoot
 		{
 			get { return m_canDropAsLoot; }
 			set { Dirty = true; m_canDropAsLoot = value; }
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public bool IsTradable
 		{
 			get { return m_isTradable; }
 			set { Dirty = true; m_isTradable = value; }
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public long Price
 		{
 			get { return m_Price; }
@@ -843,7 +843,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Max amount allowed in one stack
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int MaxCount
 		{
 			get { return m_maxCount; }
@@ -858,7 +858,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Your item cannot be shift + d
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public bool IsIndestructible {
 			get { return m_isIndestructible; }
 			set { Dirty = true; m_isIndestructible = value; }
@@ -867,14 +867,14 @@ namespace DOL.Database
 		/// <summary>
 		/// Amount of items sold at once
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int PackSize
 		{
 			get { return m_packSize; }
 			set	{ Dirty = true; m_packSize = value; }
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int Realm
 		{
 			get { return m_realm; }
@@ -891,21 +891,21 @@ namespace DOL.Database
 			set { Dirty = true; m_allowedClasses = value; }
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int Flags
 		{
 			get { return m_flags; }
 			set { Dirty = true; m_flags = value; }
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int BonusLevel
 		{
 			get { return m_bonusLevel; }
 			set { Dirty = true; m_bonusLevel = value; }
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int LevelRequirement
 		{
 			get { return m_levelRequirement; }
@@ -934,7 +934,7 @@ namespace DOL.Database
 			set { Dirty = true; m_classType = value; }
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int SalvageYieldID
 		{
 			get { return m_salvageYieldID; }

--- a/DOLDatabase/Tables/Keep.cs
+++ b/DOLDatabase/Tables/Keep.cs
@@ -213,7 +213,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Realm of keep
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public byte Realm
 		{
 			get
@@ -264,7 +264,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Albion difficulty level
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int AlbionDifficultyLevel
 		{
 			get
@@ -281,7 +281,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Midgard difficulty level
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int MidgardDifficultyLevel
 		{
 			get
@@ -298,7 +298,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Hibernia difficulty level
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int HiberniaDifficultyLevel
 		{
 			get
@@ -315,7 +315,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Realm at start
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int OriginalRealm
 		{
 			get
@@ -332,7 +332,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Keep type
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int KeepType
 		{
 			get
@@ -366,7 +366,7 @@ namespace DOL.Database
 		/// Use old or new skins for this keep.  0 = any, 1 = old, 2 = new
 		/// Access via KeepSkinType
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public byte SkinType
 		{
 			get

--- a/DOLDatabase/Tables/KeepComponent.cs
+++ b/DOLDatabase/Tables/KeepComponent.cs
@@ -72,7 +72,7 @@ namespace DOL.Database
 		/// <summary>
 		/// X position of component
 		/// </summary>
-		[DataElement(AllowDbNull=true)]
+		[DataElement(AllowDbNull= false)]
 		public int X
 		{
 			get
@@ -89,7 +89,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Y position of component
 		/// </summary>
-		[DataElement(AllowDbNull=true)]
+		[DataElement(AllowDbNull= false)]
 		public int Y
 		{
 			get
@@ -106,7 +106,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Heading of component
 		/// </summary>
-		[DataElement(AllowDbNull=true)]
+		[DataElement(AllowDbNull= false)]
 		public int Heading
 		{
 			get
@@ -140,7 +140,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Skin of component (see enum skin in GameKeepComponent)
 		/// </summary>
-		[DataElement(AllowDbNull=true)]
+		[DataElement(AllowDbNull= false)]
 		public int Skin
 		{
 			get
@@ -157,7 +157,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Index of keep
 		/// </summary>
-		[DataElement(AllowDbNull=true, Index=true)]
+		[DataElement(AllowDbNull= false, Index=true)]
 		public int KeepID
 		{
 			get
@@ -174,7 +174,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Index of component
 		/// </summary>
-		[DataElement(AllowDbNull=true, Index = true)]
+		[DataElement(AllowDbNull= false, Index = true)]
 		public int ID
 		{
 			get

--- a/DOLDatabase/Tables/KeepHookPoint.cs
+++ b/DOLDatabase/Tables/KeepHookPoint.cs
@@ -78,7 +78,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Z position of door
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int Z
 		{
 			get
@@ -95,7 +95,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Y position of door
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int Y
 		{
 			get
@@ -112,7 +112,7 @@ namespace DOL.Database
 		/// <summary>
 		/// X position of door
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int X
 		{
 			get
@@ -129,7 +129,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Heading of door
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int Heading
 		{
 			get
@@ -146,7 +146,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Height of door
 		/// </summary>
-		[DataElement(AllowDbNull = true, Index = true)]
+		[DataElement(AllowDbNull = false, Index = true)]
 		public int Height
 		{
 			set

--- a/DOLDatabase/Tables/KeepPosition.cs
+++ b/DOLDatabase/Tables/KeepPosition.cs
@@ -32,7 +32,7 @@ namespace DOL.Database
 		/// <summary>
 		/// The Skin ID of the Keep Component the Position is assigned to
 		/// </summary>
-		[DataElement(AllowDbNull = true, Index = true)]
+		[DataElement(AllowDbNull = false, Index = true)]
 		public int ComponentSkin
 		{
 			get
@@ -49,7 +49,7 @@ namespace DOL.Database
 		/// <summary>
 		/// The Rotation of the Keep Component the Position is assigned to
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int ComponentRotation
 		{
 			get
@@ -66,7 +66,7 @@ namespace DOL.Database
 		/// <summary>
 		/// The KeepObjectID, consider this a template ID
 		/// </summary>
-		[DataElement(AllowDbNull = true, Index = true)]
+		[DataElement(AllowDbNull = false, Index = true)]
 		public string TemplateID
 		{
 			get
@@ -83,7 +83,7 @@ namespace DOL.Database
 		/// <summary>
 		/// The Height that this position is stored for, 0,1,2,3
 		/// </summary>
-		[DataElement(AllowDbNull = true, Index = true)]
+		[DataElement(AllowDbNull = false, Index = true)]
 		public int Height
 		{
 			get
@@ -100,7 +100,7 @@ namespace DOL.Database
 		/// <summary>
 		/// X Offset Position of the object for the component
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int XOff
 		{
 			get
@@ -117,7 +117,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Y Offset Position of the object for the component
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int YOff
 		{
 			get
@@ -135,7 +135,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Z Offset Position of the object for the component
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int ZOff
 		{
 			get
@@ -152,7 +152,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Heading Offset Position of the object for the component
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int HOff
 		{
 			get
@@ -186,7 +186,7 @@ namespace DOL.Database
 		/// <summary>
 		/// The type of object
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int TemplateType
 		{
 			get
@@ -203,7 +203,7 @@ namespace DOL.Database
 		/// <summary>
 		/// The keep type this position belongs too
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int KeepType
 		{
 			get

--- a/DOLDatabase/Tables/LinkedFaction.cs
+++ b/DOLDatabase/Tables/LinkedFaction.cs
@@ -63,7 +63,7 @@ namespace DOL.Database
 		/// <summary>
 		/// The linked faction index
 		/// </summary>
-		[DataElement(AllowDbNull=true,Unique=false)]
+		[DataElement(AllowDbNull= false, Unique=false)]
 		public int LinkedFactionID
 		{
 			get
@@ -80,7 +80,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Is faction linked is friend or enemy
 		/// </summary>
-		[DataElement(AllowDbNull=true,Unique=false)]
+		[DataElement(AllowDbNull= false, Unique=false)]
 		public bool IsFriend
 		{
 			get

--- a/DOLDatabase/Tables/LootGenerator.cs
+++ b/DOLDatabase/Tables/LootGenerator.cs
@@ -79,7 +79,7 @@ namespace DOL.Database
 		/// MobGuild
 		/// </summary>
 		[DataElement(AllowDbNull = true, Unique = false)]
-		public String MobGuild
+		public string MobGuild
 		{
 			get { return m_mobGuild; }
 			set
@@ -93,7 +93,7 @@ namespace DOL.Database
 		/// MobFaction
 		/// </summary>
 		[DataElement(AllowDbNull = true, Unique = false)]
-		public String MobFaction
+		public string MobFaction
 		{
 			get { return m_mobFaction; }
 			set
@@ -121,7 +121,7 @@ namespace DOL.Database
 		/// LootGeneratorClass
 		/// </summary>
 		[DataElement(AllowDbNull = false, Unique = false)]
-		public String LootGeneratorClass
+		public string LootGeneratorClass
 		{
 			get { return m_lootGeneratorClass; }
 			set

--- a/DOLDatabase/Tables/Mob.cs
+++ b/DOLDatabase/Tables/Mob.cs
@@ -569,7 +569,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int NPCTemplateID
 		{
 			get
@@ -583,7 +583,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement( AllowDbNull = true )]
+		[DataElement( AllowDbNull = false)]
 		public int Race
 		{
 			get
@@ -600,7 +600,7 @@ namespace DOL.Database
 		/// <summary>
 		/// The Mob's Flags
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public uint Flags
 		{
 			get
@@ -617,7 +617,7 @@ namespace DOL.Database
 		/// <summary>
 		/// The Mob's Aggro Level
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int AggroLevel
 		{
 			get { return m_aggrolevel; }
@@ -627,7 +627,7 @@ namespace DOL.Database
 		/// <summary>
 		/// The Mob's Aggro Range
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int AggroRange
 		{
 			get { return m_aggrorange; }
@@ -637,7 +637,7 @@ namespace DOL.Database
 		/// <summary>
 		/// The Mob's Melee Damage Type
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int MeleeDamageType
 		{
 			get { return m_meleeDamageType; }
@@ -657,7 +657,7 @@ namespace DOL.Database
 		/// <summary>
 		/// The Mob's Faction ID
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int FactionID
 		{
 			get { return m_faction; }
@@ -667,7 +667,7 @@ namespace DOL.Database
 		/// <summary>
 		/// The mob's body type
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int BodyType
 		{
 			get { return m_bodyType; }
@@ -724,7 +724,7 @@ namespace DOL.Database
 		/// if MaxDistance = 0 ... no maxdistance check
 		/// if MaxDistance less than 0 ... the amount is calculated in procent of the value and the aggrorange (in StandardMobBrain)
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int MaxDistance
 		{
 			get
@@ -760,7 +760,7 @@ namespace DOL.Database
 		/// if RoamingRange = 0 ... no roaming
 		/// if RoamingRange > 0 ... the mob's individual roaming radius
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int RoamingRange
 		{
 			get
@@ -777,7 +777,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Is cloak hood up
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public bool IsCloakHoodUp
 		{
 			get { return m_isCloakHoodUp; }
@@ -793,7 +793,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Gender of this mob.
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public byte Gender
 		{
 			get { return m_gender; }

--- a/DOLDatabase/Tables/MobXAmbientBehaviour.cs
+++ b/DOLDatabase/Tables/MobXAmbientBehaviour.cs
@@ -75,7 +75,7 @@ public class MobXAmbientBehaviour : DataObject
 		set { m_trigger = value; }
 	}
 
-	[DataElement(AllowDbNull = true)]
+	[DataElement(AllowDbNull = false)]
 	public ushort Emote
 	{
 		get { return m_emote; }

--- a/DOLDatabase/Tables/NPCEquipment.cs
+++ b/DOLDatabase/Tables/NPCEquipment.cs
@@ -119,7 +119,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Color
 		/// </summary>
-		[DataElement(AllowDbNull=true)]
+		[DataElement(AllowDbNull= false)]
 		public int Color
 		{
 			get
@@ -136,7 +136,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Effect
 		/// </summary>
-		[DataElement(AllowDbNull=true)]
+		[DataElement(AllowDbNull= false)]
 		public int Effect
 		{
 			get
@@ -153,7 +153,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Extension
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int Extension
 		{
 			get
@@ -170,7 +170,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Emblem
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int Emblem
 		{
 			get

--- a/DOLDatabase/Tables/News.cs
+++ b/DOLDatabase/Tables/News.cs
@@ -73,7 +73,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public byte Realm
 		{
 			get

--- a/DOLDatabase/Tables/NpcTemplate.cs
+++ b/DOLDatabase/Tables/NpcTemplate.cs
@@ -228,7 +228,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Model
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public ushort Gender
 		{
 			get { return m_gender; }
@@ -312,7 +312,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Flags
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public ushort Flags
 		{
 			get { return m_flags; }
@@ -326,7 +326,7 @@ namespace DOL.Database
 		/// <summary>
 		/// MeleeDamageType
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public byte MeleeDamageType
 		{
 			get { return m_meleeDamageType; }
@@ -340,7 +340,7 @@ namespace DOL.Database
 		/// <summary>
 		/// ParryChance
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public byte ParryChance
 		{
 			get { return m_parryChance; }
@@ -354,7 +354,7 @@ namespace DOL.Database
 		/// <summary>
 		/// EvadeChance
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public byte EvadeChance
 		{
 			get { return m_evadeChance; }
@@ -368,7 +368,7 @@ namespace DOL.Database
 		/// <summary>
 		/// BlockChance
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public byte BlockChance
 		{
 			get { return m_blockChance; }
@@ -382,7 +382,7 @@ namespace DOL.Database
 		/// <summary>
 		/// LeftHandSwingChance
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public byte LeftHandSwingChance
 		{
 			get { return m_leftHandSwingChance; }
@@ -421,7 +421,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int Strength
 		{
 			get { return m_strength; }
@@ -432,7 +432,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int Constitution
 		{
 			get { return m_constitution; }
@@ -443,7 +443,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int Dexterity
 		{
 			get { return m_dexterity; }
@@ -454,7 +454,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int Quickness
 		{
 			get { return m_quickness; }
@@ -465,7 +465,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int Intelligence
 		{
 			get { return m_intelligence; }
@@ -476,7 +476,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int Piety
 		{
 			get { return m_piety; }
@@ -487,7 +487,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int Charisma
 		{
 			get { return m_charisma; }
@@ -498,7 +498,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int Empathy
 		{
 			get { return m_empathy; }
@@ -520,7 +520,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public byte AggroLevel
 		{
 			get { return m_aggroLevel; }
@@ -531,7 +531,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int AggroRange
 		{
 			get { return m_aggroRange; }
@@ -542,7 +542,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement( AllowDbNull = true )]
+		[DataElement( AllowDbNull = false)]
 		public int Race
 		{
 			get { return m_race; }
@@ -553,7 +553,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int BodyType
 		{
 			get { return m_bodyType; }
@@ -570,7 +570,7 @@ namespace DOL.Database
 		/// if MaxDistance = 0 ... no maxdistance check
 		/// if MaxDistance less than 0 ... the amount is calculated in procent of the value and the aggrorange (in StandardMobBrain)
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int MaxDistance
 		{
 			get
@@ -590,7 +590,7 @@ namespace DOL.Database
 		/// if TetherRange > 0 ... the amount is the normal value
 		/// if TetherRange less than or equal to 0 ... no tether check
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int TetherRange
 		{
 			get
@@ -617,7 +617,7 @@ namespace DOL.Database
 				m_visibleWeaponSlots = value;
 			}
 		}
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public bool ReplaceMobValues
 		{
 			get

--- a/DOLDatabase/Tables/Path.cs
+++ b/DOLDatabase/Tables/Path.cs
@@ -49,7 +49,7 @@ namespace DOL.Database
 		}
 
 		[DataElement(AllowDbNull = false,Unique=true)]
-		public String PathID {
+		public string PathID {
 			get { return m_pathID; }
 			set { m_pathID = value; }
 		}
@@ -63,7 +63,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Used in PathDesigner tool, only. Not in DoL code
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public ushort RegionID
 		{
 			get { return m_region; }

--- a/DOLDatabase/Tables/PathPoints.cs
+++ b/DOLDatabase/Tables/PathPoints.cs
@@ -81,13 +81,13 @@ namespace DOL.Database
 		/// <summary>
 		/// Maximum speed, 0 = no limit
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int MaxSpeed {
 			get { return m_maxspeed; }
 			set { m_maxspeed = value; }
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int WaitTime
 		{
 			get { return m_waitTime; }

--- a/DOLDatabase/Tables/PlayerXEffect.cs
+++ b/DOLDatabase/Tables/PlayerXEffect.cs
@@ -47,7 +47,7 @@ namespace DOL
 			{
 			}
 
-			[DataElement(AllowDbNull = true)]
+			[DataElement(AllowDbNull = false)]
 			public bool IsHandler
 			{
 				get
@@ -60,7 +60,7 @@ namespace DOL
 					m_ishandler = value;
 				}
 			}
-			[DataElement(AllowDbNull = true)]
+			[DataElement(AllowDbNull = false)]
 			public int Var6
 			{
 				get
@@ -73,7 +73,7 @@ namespace DOL
 					m_var6 = value;
 				}
 			}
-			[DataElement(AllowDbNull = true)]
+			[DataElement(AllowDbNull = false)]
 			public int Var5
 			{
 				get
@@ -86,7 +86,7 @@ namespace DOL
 					m_var5 = value;
 				}
 			}
-			[DataElement(AllowDbNull = true)]
+			[DataElement(AllowDbNull = false)]
 			public int Var4
 			{
 				get
@@ -99,7 +99,7 @@ namespace DOL
 					m_var4 = value;
 				}
 			}
-			[DataElement(AllowDbNull = true)]
+			[DataElement(AllowDbNull = false)]
 			public int Var3
 			{
 				get
@@ -112,7 +112,7 @@ namespace DOL
 					m_var3 = value;
 				}
 			}
-			[DataElement(AllowDbNull = true)]
+			[DataElement(AllowDbNull = false)]
 			public int Var2
 			{
 				get
@@ -125,7 +125,7 @@ namespace DOL
 					m_var2 = value;
 				}
 			}
-			[DataElement(AllowDbNull = true)]
+			[DataElement(AllowDbNull = false)]
 			public int Var1
 			{
 				get
@@ -138,7 +138,7 @@ namespace DOL
 					m_var1 = value;
 				}
 			}
-			[DataElement(AllowDbNull = true)]
+			[DataElement(AllowDbNull = false)]
 			public int Duration
 			{
 				get

--- a/DOLDatabase/Tables/PvPKillsLog.cs
+++ b/DOLDatabase/Tables/PvPKillsLog.cs
@@ -145,7 +145,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public bool IsInstance
 		{
 			get { return m_isInstance; }

--- a/DOLDatabase/Tables/Race.cs
+++ b/DOLDatabase/Tables/Race.cs
@@ -66,7 +66,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement( AllowDbNull = true )]
+		[DataElement( AllowDbNull = false)]
 		public sbyte ResistBody
 		{
 			get { return m_ResistBody; }
@@ -77,7 +77,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement( AllowDbNull = true )]
+		[DataElement( AllowDbNull = false)]
 		public sbyte ResistCold
 		{
 			get { return m_ResistCold; }
@@ -88,7 +88,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement( AllowDbNull = true )]
+		[DataElement( AllowDbNull = false)]
 		public sbyte ResistCrush
 		{
 			get { return m_ResistCrush; }
@@ -99,7 +99,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement( AllowDbNull = true )]
+		[DataElement( AllowDbNull = false)]
 		public sbyte ResistEnergy
 		{
 			get { return m_ResistEnergy; }
@@ -110,7 +110,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement( AllowDbNull = true )]
+		[DataElement( AllowDbNull = false)]
 		public sbyte ResistHeat
 		{
 			get { return m_ResistHeat; }
@@ -121,7 +121,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement( AllowDbNull = true )]
+		[DataElement( AllowDbNull = false)]
 		public sbyte ResistMatter
 		{
 			get { return m_ResistMatter; }
@@ -132,7 +132,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement( AllowDbNull = true )]
+		[DataElement( AllowDbNull = false)]
 		public sbyte ResistNatural
 		{
 			get { return m_ResistNatural; }
@@ -143,7 +143,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement( AllowDbNull = true )]
+		[DataElement( AllowDbNull = false)]
 		public sbyte ResistSlash
 		{
 			get { return m_ResistSlash; }
@@ -154,7 +154,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement( AllowDbNull = true )]
+		[DataElement( AllowDbNull = false)]
 		public sbyte ResistSpirit
 		{
 			get { return m_ResistSpirit; }
@@ -165,7 +165,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement( AllowDbNull = true )]
+		[DataElement( AllowDbNull = false)]
 		public sbyte ResistThrust
 		{
 			get { return m_ResistThrust; }

--- a/DOLDatabase/Tables/SalvageYield.cs
+++ b/DOLDatabase/Tables/SalvageYield.cs
@@ -47,7 +47,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Object type of item to salvage, 0 if not used
 		/// </summary>
-		[DataElement(AllowDbNull = true, Index = true)]
+		[DataElement(AllowDbNull = false, Index = true)]
 		public int ObjectType
 		{
 			get
@@ -63,7 +63,7 @@ namespace DOL.Database
 		/// <summary>
 		/// The salvage level, 0 if not used
 		/// </summary>
-		[DataElement(AllowDbNull = true, Index = true)]
+		[DataElement(AllowDbNull = false, Index = true)]
 		public int SalvageLevel
 		{
 			get
@@ -97,7 +97,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Count of material to return, 0 if calculated in the code
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int Count
 		{
 			get
@@ -114,7 +114,7 @@ namespace DOL.Database
         /// <summary>
         /// Realm of item to salvage, 0 for all realms
         /// </summary>
-        [DataElement(AllowDbNull = true, Index = true)]
+        [DataElement(AllowDbNull = false, Index = true)]
         public int Realm
         {
             get

--- a/DOLDatabase/Tables/Spell.cs
+++ b/DOLDatabase/Tables/Spell.cs
@@ -163,7 +163,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int Range
 		{
 			get
@@ -177,7 +177,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int Power
 		{
 			get
@@ -191,7 +191,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public double CastTime
 		{
 			get
@@ -205,7 +205,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public double Damage
 		{
 			get
@@ -220,7 +220,7 @@ namespace DOL.Database
 		}
 
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int DamageType
 		{
 			get
@@ -248,7 +248,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int Duration
 		{
 			get
@@ -262,7 +262,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int Frequency
 		{
 			get
@@ -276,7 +276,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int Pulse
 		{
 			get
@@ -290,7 +290,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int PulsePower
 		{
 			get
@@ -304,7 +304,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int Radius
 		{
 			get
@@ -318,7 +318,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int RecastDelay
 		{
 			get
@@ -332,7 +332,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int ResurrectHealth
 		{
 			get
@@ -346,7 +346,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int ResurrectMana
 		{
 			get
@@ -360,7 +360,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public double Value
 		{
 			get
@@ -374,7 +374,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int Concentration
 		{
 			get
@@ -388,7 +388,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int LifeDrainReturn
 		{
 			get
@@ -402,7 +402,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int AmnesiaChance
 		{
 			get
@@ -460,7 +460,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int InstrumentRequirement
 		{
 			get { return m_instrumentRequirement; }
@@ -471,7 +471,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int SpellGroup
 		{
 			get
@@ -485,7 +485,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int EffectGroup
 		{
 			get
@@ -500,7 +500,7 @@ namespace DOL.Database
 		}
 
 		//Multiple spells
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int SubSpellID
 		{
 			get
@@ -514,7 +514,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public bool MoveCast
 		{
 			get { return m_moveCast; }
@@ -525,7 +525,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public bool Uninterruptible
 		{
 			get { return m_uninterruptible; }
@@ -536,7 +536,7 @@ namespace DOL.Database
 			}
 		}
 		
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public bool IsFocus
 		{
 			get { return m_isfocus; }
@@ -547,7 +547,7 @@ namespace DOL.Database
 			}
 		}
 		
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int SharedTimerGroup
 		{
 			get
@@ -562,7 +562,7 @@ namespace DOL.Database
 		}
 
 		#region warlock
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public bool IsPrimary
 		{
 			get
@@ -576,7 +576,7 @@ namespace DOL.Database
 			}
 		}
 		
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public bool IsSecondary
 		{
 			get
@@ -590,7 +590,7 @@ namespace DOL.Database
 			}
 		}
 		
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public bool AllowBolt
 		{
 			get

--- a/DOLDatabase/Tables/SpellLine.cs
+++ b/DOLDatabase/Tables/SpellLine.cs
@@ -102,7 +102,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Baseline or Specline ?
 		/// </summary>
-		[DataElement(AllowDbNull=true)]
+		[DataElement(AllowDbNull= false)]
 		public bool IsBaseLine
 		{
 			get
@@ -119,7 +119,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Class ID hint or other values used by Specialization Handler
 		/// </summary>
-		[DataElement(AllowDbNull=true)]
+		[DataElement(AllowDbNull= false)]
 		public int ClassIDHint {
 			get { return m_classIDHint; }
 			set { m_classIDHint = value; }

--- a/DOLDatabase/Tables/Style.cs
+++ b/DOLDatabase/Tables/Style.cs
@@ -204,7 +204,7 @@ namespace DOL.Database
 		/// <summary>
 		/// The Style Spec Level Requirement
 		/// </summary>
-		[DataElement(AllowDbNull=true)]
+		[DataElement(AllowDbNull= false)]
 		public int SpecLevelRequirement
 		{
 			get { return m_SpecLevelRequirement; }
@@ -231,7 +231,7 @@ namespace DOL.Database
 		/// <summary>
 		/// The Style Stealth Requirement
 		/// </summary>
-		[DataElement(AllowDbNull=true)]
+		[DataElement(AllowDbNull= false)]
 		public bool StealthRequirement
 		{
 			get { return m_StealthRequirement; }
@@ -241,7 +241,7 @@ namespace DOL.Database
 		/// <summary>
 		/// The Style Opening Requirement Type
 		/// </summary>
-		[DataElement(AllowDbNull=true)]
+		[DataElement(AllowDbNull= false)]
 		public int OpeningRequirementType
 		{
 			get { return m_openingRequirementType; }
@@ -251,7 +251,7 @@ namespace DOL.Database
 		/// <summary>
 		/// The Style Opening Requirement Value
 		/// </summary>
-		[DataElement(AllowDbNull=true)]
+		[DataElement(AllowDbNull= false)]
 		public int OpeningRequirementValue
 		{
 			get { return m_openingRequirementValue; }
@@ -261,7 +261,7 @@ namespace DOL.Database
 		/// <summary>
 		/// The Style Attack Result Requirement
 		/// </summary>
-		[DataElement(AllowDbNull=true)]
+		[DataElement(AllowDbNull= false)]
 		public int AttackResultRequirement
 		{
 			get { return m_AttackResultRequirement; }
@@ -271,7 +271,7 @@ namespace DOL.Database
 		/// <summary>
 		/// The Style Weapon Type Requirement
 		/// </summary>
-		[DataElement(AllowDbNull=true)]
+		[DataElement(AllowDbNull= false)]
 		public int WeaponTypeRequirement
 		{
 			get { return m_WeaponTypeRequirement; }
@@ -281,7 +281,7 @@ namespace DOL.Database
 		/// <summary>
 		/// The Style Growth Offset
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public double GrowthOffset
 		{
 			get { return m_growthOffset; }
@@ -291,7 +291,7 @@ namespace DOL.Database
 		/// <summary>
 		/// The Style Growth Rate
 		/// </summary>
-		[DataElement(AllowDbNull=true)]
+		[DataElement(AllowDbNull= false)]
 		public double GrowthRate
 		{
 			get { return m_growthRate; }
@@ -301,7 +301,7 @@ namespace DOL.Database
 		/// <summary>
 		/// The Style Bonus To Hit
 		/// </summary>
-		[DataElement(AllowDbNull=true)]
+		[DataElement(AllowDbNull= false)]
 		public int BonusToHit
 		{
 			get { return m_BonusToHit; }
@@ -311,7 +311,7 @@ namespace DOL.Database
 		/// <summary>
 		/// The Style Bonus to Defense
 		/// </summary>
-		[DataElement(AllowDbNull=true)]
+		[DataElement(AllowDbNull= false)]
 		public int BonusToDefense
 		{
 			get { return m_BonusToDefense; }
@@ -321,7 +321,7 @@ namespace DOL.Database
 		/// <summary>
 		/// The Style Two Hand Animation
 		/// </summary>
-		[DataElement(AllowDbNull=true)]
+		[DataElement(AllowDbNull= false)]
 		public int TwoHandAnimation
 		{
 			get { return m_TwoHandAnimation; }
@@ -331,7 +331,7 @@ namespace DOL.Database
 		/// <summary>
 		///(procs) The Style should Randomly cast a proc
 		/// </summary>
-		[DataElement(AllowDbNull=true)]
+		[DataElement(AllowDbNull= false)]
 		public bool RandomProc
 		{
 			get { return m_RandomProc; }
@@ -341,7 +341,7 @@ namespace DOL.Database
 		/// <summary>
 		/// What armor location should this style hit, take from eInventorySlot
 		/// </summary>
-		[DataElement(AllowDbNull=true)]
+		[DataElement(AllowDbNull= false)]
 		public int ArmorHitLocation
 		{
 			get { return m_armorHitLocation; }

--- a/DOLDatabase/Tables/Task.cs
+++ b/DOLDatabase/Tables/Task.cs
@@ -68,7 +68,7 @@ namespace DOL.Database
 		}
 
 		[DataElement(AllowDbNull=true,Unique=false)]
-		public String TaskType
+		public string TaskType
 		{
 			get {return m_TaskType;}
 			set
@@ -78,7 +78,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull=true,Unique=false)]
+		[DataElement(AllowDbNull= false, Unique=false)]
 		public int TasksDone
 		{
 			get {return m_TasksDone;}

--- a/DOLDatabase/Tables/Teleport.cs
+++ b/DOLDatabase/Tables/Teleport.cs
@@ -28,108 +28,67 @@ namespace DOL.Database
 	[DataTable(TableName = "Teleport")]
 	public class Teleport : DataObject
 	{
-		private String m_type;
-		private String m_teleportID;
-		private int m_realm;
-		private int m_regionID;
-		private int m_x;
-		private int m_y;
-		private int m_z;
-		private int m_heading;
-
-		/// <summary>
+	    /// <summary>
 		/// Create a new teleport location.
 		/// </summary>
 		public Teleport()
 		{
-			m_type = string.Empty;
-			m_teleportID = "UNDEFINED";
-			m_realm = 0;
-			m_regionID = 0;
-			m_x = 0;
-			m_y = 0;
-			m_z = 0;
-			m_heading = 0;
+			Type = string.Empty;
+			TeleportID = "UNDEFINED";
+			Realm = 0;
+			RegionID = 0;
+			X = 0;
+			Y = 0;
+			Z = 0;
+			Heading = 0;
 		}
 
 		/// <summary>
 		/// Teleporter type.
 		/// </summary>
 		[DataElement(AllowDbNull = false)]
-		public String Type
-		{
-			get { return m_type; }
-			set	{ m_type = value;	}
-		}
+		public string Type { get; set; }
 
-		/// <summary>
+	    /// <summary>
 		/// ID for this teleport location.
 		/// </summary>
 		[DataElement(AllowDbNull = false, Index = true)] // Dre: Index or Unique ?
-		public String TeleportID
-		{
-			get { return m_teleportID; }
-			set { m_teleportID = value; }
-		}
+		public string TeleportID { get; set; }
 
-		/// <summary>
+	    /// <summary>
 		/// Realm for this teleport location.
 		/// </summary>
 		[DataElement(AllowDbNull = false)]
-		public int Realm
-		{
-			get { return m_realm; }
-			set { m_realm = value; }
-		}
+		public int Realm { get; set; }
 
-		/// <summary>
+	    /// <summary>
 		/// Realm for this teleport location.
 		/// </summary>
 		[DataElement(AllowDbNull = false)]
-		public int RegionID
-		{
-			get { return m_regionID; }
-			set { m_regionID = value; }
-		}
+		public int RegionID { get; set; }
 
-		/// <summary>
+	    /// <summary>
 		/// X coordinate for teleport location.
 		/// </summary>
 		[DataElement(AllowDbNull = false)]
-		public int X
-		{
-			get { return m_x; }
-			set { m_x = value; }
-		}
+		public int X { get; set; }
 
-		/// <summary>
+	    /// <summary>
 		/// Y coordinate for teleport location.
 		/// </summary>
 		[DataElement(AllowDbNull = false)]
-		public int Y
-		{
-			get { return m_y; }
-			set { m_y = value; }
-		}
+		public int Y { get; set; }
 
-		/// <summary>
+	    /// <summary>
 		/// Z coordinate for teleport location.
 		/// </summary>
 		[DataElement(AllowDbNull = false)]
-		public int Z
-		{
-			get { return m_z; }
-			set { m_z = value; }
-		}
+		public int Z { get; set; }
 
-		/// <summary>
+	    /// <summary>
 		/// Heading for teleport location.
 		/// </summary>
 		[DataElement(AllowDbNull = false)]
-		public int Heading
-		{
-			get { return m_heading; }
-			set { m_heading = value; }
-		}
+		public int Heading { get; set; }
 	}
 }

--- a/DOLDatabase/Tables/WorldObject.cs
+++ b/DOLDatabase/Tables/WorldObject.cs
@@ -221,7 +221,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Respawn interval, in seconds
 		/// </summary>
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int RespawnInterval
 		{
 			get

--- a/DOLDatabase/Tables/ZonePoint.cs
+++ b/DOLDatabase/Tables/ZonePoint.cs
@@ -58,7 +58,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull=true)]
+		[DataElement(AllowDbNull= false)]
 		public int TargetX
 		{
 			get
@@ -72,7 +72,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull=true)]
+		[DataElement(AllowDbNull= false)]
 		public int TargetY
 		{
 			get
@@ -86,7 +86,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull=true)]
+		[DataElement(AllowDbNull= false)]
 		public int TargetZ
 		{
 			get
@@ -100,7 +100,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull=true)]
+		[DataElement(AllowDbNull= false)]
 		public ushort TargetRegion
 		{
 			get
@@ -114,7 +114,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public ushort TargetHeading
 		{
 			get
@@ -128,7 +128,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int SourceX
 		{
 			get
@@ -142,7 +142,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int SourceY
 		{
 			get
@@ -156,7 +156,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public int SourceZ
 		{
 			get
@@ -170,7 +170,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull = true)]
+		[DataElement(AllowDbNull = false)]
 		public ushort SourceRegion
 		{
 			get
@@ -184,7 +184,7 @@ namespace DOL.Database
 			}
 		}
 
-		[DataElement(AllowDbNull=true, Index=true)]
+		[DataElement(AllowDbNull= false, Index=true)]
 		public ushort Realm
 		{
 			get

--- a/DOLDatabase/Tables/Zones.cs
+++ b/DOLDatabase/Tables/Zones.cs
@@ -198,7 +198,7 @@ namespace DOL
 					m_height = value;
 				}
 			}
-			[DataElement(AllowDbNull=true)]
+			[DataElement(AllowDbNull= false)]
 			public int Experience
 			{
 				get
@@ -211,7 +211,7 @@ namespace DOL
 					m_bonusXP = value;
 				}
 			}
-			[DataElement(AllowDbNull = true)]
+			[DataElement(AllowDbNull = false)]
 			public int Realmpoints
 			{
 				get
@@ -224,7 +224,7 @@ namespace DOL
 					m_bonusRP = value;
 				}
 			}
-			[DataElement(AllowDbNull = true)]
+			[DataElement(AllowDbNull = false)]
 			public int Bountypoints
 			{
 				get
@@ -237,7 +237,7 @@ namespace DOL
 					m_bonusBP = value;
 				}
 			}
-			[DataElement(AllowDbNull = true)]
+			[DataElement(AllowDbNull = false)]
 			public int Coin
 			{
 				get
@@ -251,7 +251,7 @@ namespace DOL
 				}
 			}
 
-            [DataElement(AllowDbNull=true)]
+            [DataElement(AllowDbNull= false)]
             public byte Realm
             {
                 get

--- a/GameServerScripts/web/XMLWebUIGenerator.cs
+++ b/GameServerScripts/web/XMLWebUIGenerator.cs
@@ -107,56 +107,56 @@ namespace DOL.GS.Scripts
 				set { m_srvrStatus = value; }
 			}
 
-			[DataElement(AllowDbNull=true)]
+			[DataElement(AllowDbNull= false)]
 			public int NumClients
 			{
 				get { return m_numClients; }
 				set { m_numClients = value; }
 			}
 
-			[DataElement(AllowDbNull=true)]
+			[DataElement(AllowDbNull= false)]
 			public int NumAccounts
 			{
 				get { return m_numAccts; }
 				set { m_numAccts = value; }
 			}
 
-			[DataElement(AllowDbNull=true)]
+			[DataElement(AllowDbNull= false)]
 			public int NumMobs
 			{
 				get { return m_numMobs; }
 				set { m_numMobs = value; }
 			}
 
-			[DataElement(AllowDbNull=true)]
+			[DataElement(AllowDbNull= false)]
 			public int NumInventoryItems
 			{
 				get { return m_numInvItems; }
 				set { m_numInvItems = value; }
 			}
 
-			[DataElement(AllowDbNull=true)]
+			[DataElement(AllowDbNull= false)]
 			public int NumPlayerChars
 			{
 				get { return m_numPlrChars; }
 				set { m_numPlrChars = value; }
 			}
 
-			[DataElement(AllowDbNull=true)]
+			[DataElement(AllowDbNull= false)]
 			public int NumMerchantItems
 			{
 				get { return m_numMerchantItems; }
 				set { m_numMerchantItems = value; }
 			}
 
-			[DataElement(AllowDbNull=true)]
+			[DataElement(AllowDbNull= false)]
 			public int NumItemTemplates
 			{
 				get { return m_numItemTemplates; }
 				set { m_numItemTemplates = value; }
 			}
 
-			[DataElement(AllowDbNull=true)]
+			[DataElement(AllowDbNull= false)]
 			public int NumWorldObjects
 			{
 				get { return m_numWorldObj; }
@@ -235,21 +235,21 @@ namespace DOL.GS.Scripts
 				set { m_region = value; }
 			}
 
-			[DataElement(AllowDbNull=true)]
+			[DataElement(AllowDbNull= false)]
 			public int Level
 			{
 				get { return m_lvl; }
 				set { m_lvl = value; }
 			}
 
-			[DataElement(AllowDbNull=true)]
+			[DataElement(AllowDbNull= false)]
 			public int X
 			{
 				get { return m_x; }
 				set { m_x = value; }
 			}
 
-			[DataElement(AllowDbNull=true)]
+			[DataElement(AllowDbNull= false)]
 			public int Y
 			{
 				get { return m_y; }


### PR DESCRIPTION
Currently there are a bunch of fields in the DAL defined as being nullable, but the datatype in C# forbids this.  This changeset corrects this for number types and for MySQL sets the default value to 0 correcting any existing db data. I did notice that there are still DateTime fields marked as nullable.