### PR TITLE
Resurrection illness and Realm Speed restored

### DIFF
--- a/GameServer/GlobalConstants.cs
+++ b/GameServer/GlobalConstants.cs
@@ -1026,7 +1026,7 @@ namespace DOL.GS
 	{
 		public const string Combat_Styles_Effect = "Combat Style Effects";
 		public const string Mundane_Poisons = "Mundane Poisons";
-		public const string Reserved_Spells = "Reserved Spells"; // Resurrection illness, Speed of the realm
+		public const string Reserved_Spells = "Reserved Spells"; // Masterlevels
 		public const string SiegeWeapon_Spells = "SiegeWeapon Spells";
 		public const string Item_Effects = "Item Effects";
 		public const string Potions_Effects = "Potions";
@@ -1034,7 +1034,8 @@ namespace DOL.GS
 		public const string Character_Abilities = "Character Abilities"; // dirty tricks, flurry ect...
 		public const string Item_Spells = "Item Spells";	// Combine scroll etc.
 		public const string Champion_Lines_StartWith = "Champion ";
-	}
+        public const string Realm_Spells = "Realm Spells"; // Resurrection illness, Speed of the realm
+    }
 
 	public static class GlobalConstants
 	{
@@ -2457,64 +2458,7 @@ namespace DOL.GS
 		#endregion
 		
 	}
-
-	public static class GlobalSpells
-	{
-		public const string PvEResurrectionIllnessSpellType = "PveResurrectionIllness";
-		private static Spell m_PvERezIllness;
-		public static Spell PvERezIllness
-		{
-			get
-			{
-				if (m_PvERezIllness == null)
-				{
-					DBSpell spell = new DBSpell();
-					spell.AllowAdd = false;
-					spell.CastTime = 0;
-					spell.ClientEffect = 2435;
-					spell.Icon = 2435;
-					spell.SpellID = 2435;
-					spell.Name = LanguageMgr.GetTranslation(ServerProperties.Properties.DB_LANGUAGE, "GamePlayer.Spell.ResurrectionIllness");
-					spell.Range = 0;
-					spell.Duration = 300;
-					spell.Value = 30;
-					spell.Target = "Self";
-					spell.Type = PvEResurrectionIllnessSpellType;
-					spell.Description = "The player's effectiveness is greatly reduced due to being recently resurrected.";
-					m_PvERezIllness = new Spell(spell, 50);
-					SkillBase.AddScriptedSpell(GlobalSpellsLines.Reserved_Spells, m_PvERezIllness);
-				}
-				return m_PvERezIllness;
-			}
-		}
-		public const string RvRResurrectionIllnessSpellType = "RvrResurrectionIllness";
-		private static Spell m_RvRRezIllness;
-		public static Spell RvRRezIllness
-		{
-			get
-			{
-				if (m_RvRRezIllness == null)
-				{
-					DBSpell spelltwo = new DBSpell();
-					spelltwo.AllowAdd = false;
-					spelltwo.CastTime = 0;
-					spelltwo.ClientEffect = 2435;
-					spelltwo.Icon = 2435;
-					spelltwo.SpellID = 8181;
-					spelltwo.Name = LanguageMgr.GetTranslation(ServerProperties.Properties.DB_LANGUAGE, "GamePlayer.Spell.RvrResurrectionIllness");
-					spelltwo.Range = 0;
-					spelltwo.Duration = 300;
-					spelltwo.Value = 50;
-					spelltwo.Target = "Self";
-					spelltwo.Type = RvRResurrectionIllnessSpellType;
-					spelltwo.Description = "The player's effectiveness is greatly reduced due to being recently resurrected.";
-					m_RvRRezIllness = new Spell(spelltwo, 50);
-					SkillBase.AddScriptedSpell(GlobalSpellsLines.Reserved_Spells, m_RvRRezIllness);
-				}
-				return m_RvRRezIllness;
-			}
-		}
-	}
+	
 	public static class Constants
 	{
 		public static int USE_AUTOVALUES = -1;

--- a/GameServer/gameobjects/CustomNPC/Hastener.cs
+++ b/GameServer/gameobjects/CustomNPC/Hastener.cs
@@ -45,7 +45,7 @@ namespace DOL.GS
 				return false;
 
 			// just give out speed without asking
-			GameNPCHelper.CastSpellOnOwnerAndPets(this, player, SkillBase.GetSpellByID(GameHastener.SPEEDOFTHEREALMID), SkillBase.GetSpellLine(GlobalSpellsLines.Mob_Spells), false);
+			GameNPCHelper.CastSpellOnOwnerAndPets(this, player, SkillBase.GetSpellByID(GameHastener.SPEEDOFTHEREALMID), SkillBase.GetSpellLine(GlobalSpellsLines.Realm_Spells), false);
 
 
 			if (player.CurrentRegion.IsCapitalCity)
@@ -83,7 +83,7 @@ namespace DOL.GS
 					{
 						case "movement":
 							if (!player.CurrentRegion.IsRvR || player.Realm == Realm)
-								GameNPCHelper.CastSpellOnOwnerAndPets(this, player, SkillBase.GetSpellByID(GameHastener.SPEEDOFTHEREALMID), SkillBase.GetSpellLine(GlobalSpellsLines.Mob_Spells), false);
+								GameNPCHelper.CastSpellOnOwnerAndPets(this, player, SkillBase.GetSpellByID(GameHastener.SPEEDOFTHEREALMID), SkillBase.GetSpellLine(GlobalSpellsLines.Realm_Spells), false);
 							break;
 						case "strength":
 							if (player.CurrentRegion.IsCapitalCity)

--- a/GameServer/gameobjects/CustomNPC/Healer.cs
+++ b/GameServer/gameobjects/CustomNPC/Healer.cs
@@ -34,9 +34,9 @@ namespace DOL.GS
 	[NPCGuildScript("Healer")]
 	public class GameHealer : GameNPC
 	{
-		private const string CURED_SPELL_TYPE = GlobalSpells.PvEResurrectionIllnessSpellType;
+		private const string CURED_SPELL_TYPE = "PveResurrectionIllness";
 
-		private const string COST_BY_PTS = "cost";
+        private const string COST_BY_PTS = "cost";
 
 		/// <summary>
 		/// Constructor

--- a/GameServer/gameobjects/CustomNPC/HousingHastener.cs
+++ b/GameServer/gameobjects/CustomNPC/HousingHastener.cs
@@ -74,7 +74,7 @@ namespace DOL.GS
 			if (item.Id_nb == "Music_Ticket")
 			{
 				TargetObject = player;
-				CastSpell(SkillBase.GetSpellByID(GameHastener.SPEEDOFTHEREALMID), SkillBase.GetSpellLine(GlobalSpellsLines.Mob_Spells));
+				CastSpell(SkillBase.GetSpellByID(GameHastener.SPEEDOFTHEREALMID), SkillBase.GetSpellLine(GlobalSpellsLines.Realm_Spells));
 				player.Inventory.RemoveItem(item);
                 InventoryLogging.LogInventoryAction(player, this, eInventoryActionType.Merchant, item.Template, item.Count);
 			}

--- a/GameServer/gameobjects/GamePlayer.cs
+++ b/GameServer/gameobjects/GamePlayer.cs
@@ -1796,14 +1796,14 @@ namespace DOL.GS
 			switch (DeathType)
 			{
 				case eDeathType.RvR:
-					SpellLine rvrsick = SkillBase.GetSpellLine(GlobalSpellsLines.Reserved_Spells);
+					SpellLine rvrsick = SkillBase.GetSpellLine(GlobalSpellsLines.Realm_Spells);
 					if (rvrsick == null) return;
 					Spell rvrillness = SkillBase.FindSpell(8181, rvrsick);
 					player.CastSpell(rvrillness, rvrsick);
 					break;
 				case eDeathType.PvP: //PvP sickness is the same as PvE sickness - Curable
 				case eDeathType.PvE:
-					SpellLine pvesick = SkillBase.GetSpellLine(GlobalSpellsLines.Reserved_Spells);
+					SpellLine pvesick = SkillBase.GetSpellLine(GlobalSpellsLines.Realm_Spells);
 					if (pvesick == null) return;
 					Spell pveillness = SkillBase.FindSpell(2435, pvesick);
 					player.CastSpell(pveillness, pvesick);

--- a/GameServer/keeps/Gameobjects/Guards/Hastener.cs
+++ b/GameServer/keeps/Gameobjects/Guards/Hastener.cs
@@ -54,19 +54,9 @@ namespace DOL.GS.Keeps
 				return false;
 
 			TurnTo(player, 5000);
-			GameNPCHelper.CastSpellOnOwnerAndPets(this, player, SkillBase.GetSpellByID(GameHastener.SPEEDOFTHEREALMID), SkillBase.GetSpellLine(GlobalSpellsLines.Mob_Spells), false);
+			GameNPCHelper.CastSpellOnOwnerAndPets(this, player, SkillBase.GetSpellByID(GameHastener.SPEEDOFTHEREALMID), SkillBase.GetSpellLine(GlobalSpellsLines.Realm_Spells), false);
 			return true;
 		}
 		#endregion Examine/Interact Message
-		
-		/// <summary>
-		/// Hasteners don't respond to calls for help
-		/// </summary>
-		/// <param name="lord"></param>
-		/// <returns>Whether or not we are responding</returns>
-		public override bool AssistLord(GuardLord lord)
-		{
-			return false;
-		}
 	}
 }

--- a/GameServer/realmabilities/handlers/PerfectRecoveryAbility.cs
+++ b/GameServer/realmabilities/handlers/PerfectRecoveryAbility.cs
@@ -201,10 +201,10 @@ namespace DOL.GS.RealmAbilities
 			resurrectedPlayer.Out.SendPlayerRevive(resurrectedPlayer);
 			resurrectedPlayer.UpdatePlayerStatus();
 
-			GameSpellEffect effect = SpellHandler.FindEffectOnTarget(resurrectedPlayer, GlobalSpells.PvEResurrectionIllnessSpellType);
+			GameSpellEffect effect = SpellHandler.FindEffectOnTarget(resurrectedPlayer, "PveResurrectionIllness");
 			if (effect != null)
 				effect.Cancel(false);
-			GameSpellEffect effecttwo = SpellHandler.FindEffectOnTarget(resurrectedPlayer, GlobalSpells.RvRResurrectionIllnessSpellType);
+			GameSpellEffect effecttwo = SpellHandler.FindEffectOnTarget(resurrectedPlayer, "RvrResurrectionIllness");
 			if (effecttwo != null)
 				effecttwo.Cancel(false);
 			resurrectedPlayer.Out.SendMessage("You have been resurrected by " + rezzer.GetName(0, false) + "!", eChatType.CT_System, eChatLoc.CL_SystemWindow);

--- a/GameServer/spells/IllnessSpellHandler.cs
+++ b/GameServer/spells/IllnessSpellHandler.cs
@@ -16,8 +16,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  *
  */
-using System;
-using System.Collections;
+
 using System.Collections.Generic;
 using DOL.Database;
 using DOL.GS.Effects;
@@ -27,7 +26,7 @@ namespace DOL.GS.Spells
 	/// <summary>
 	/// Pve Resurrection Illness
 	/// </summary>
-	[SpellHandler(GlobalSpells.PvEResurrectionIllnessSpellType)]
+	[SpellHandler("PveResurrectionIllness")]
 	public class PveResurrectionIllness : AbstractIllnessSpellHandler
 	{
 		/// <summary>
@@ -92,28 +91,36 @@ namespace DOL.GS.Spells
 			}
 		}
 
-		public override void OnEffectRestored(GameSpellEffect effect, int[] vars)
+        /// <summary>
+        /// Saves the effect when player quits
+        /// </summary>        
+        public override PlayerXEffect GetSavedEffect(GameSpellEffect e)
+        {
+            PlayerXEffect eff = new PlayerXEffect();
+            eff.Var1 = Spell.ID;
+            eff.Duration = e.RemainingTime;
+            eff.IsHandler = true;
+            eff.SpellLine = SpellLine.KeyName;
+            return eff;
+        }
+
+        /// <summary>
+        /// Restart the effects of resurrection illness
+        /// </summary>        
+        public override void OnEffectRestored(GameSpellEffect effect, int[] vars)
 		{
 			OnEffectStart(effect);
 		}
 
+        /// <summary>
+        /// Remove the effects of resurrection illness 
+        /// </summary>        
 		public override int OnRestoredEffectExpires(GameSpellEffect effect, int[] vars, bool noMessages)
 		{
 			return OnEffectExpires(effect, false);
-		}
+		}		
 
-		public override PlayerXEffect GetSavedEffect(GameSpellEffect e)
-		{
-			PlayerXEffect eff = new PlayerXEffect();
-			eff.Var1 = Spell.ID;
-			eff.Duration = e.RemainingTime;
-			eff.IsHandler = true;
-			eff.SpellLine = SpellLine.KeyName;
-			return eff;
-		}
-
-		public PveResurrectionIllness(GameLiving caster, Spell spell, SpellLine spellLine) : base(caster, spell, spellLine) {}
-	
+		public PveResurrectionIllness(GameLiving caster, Spell spell, SpellLine spellLine) : base(caster, spell, spellLine) {}	
 	}
 
 	/// <summary>
@@ -153,5 +160,4 @@ namespace DOL.GS.Spells
 		public AbstractIllnessSpellHandler(GameLiving caster, Spell spell, SpellLine spellLine) : base(caster, spell, spellLine) {}
 	
 	}
-		
 }

--- a/GameServer/spells/ResurrectSpellHandler.cs
+++ b/GameServer/spells/ResurrectSpellHandler.cs
@@ -131,10 +131,10 @@ namespace DOL.GS.Spells
 						// -> any better solution -> post :)
 						if ( Spell.ResurrectHealth == 100 )
 						{
-							GameSpellEffect effect = SpellHandler.FindEffectOnTarget(player, GlobalSpells.PvEResurrectionIllnessSpellType);
+							GameSpellEffect effect = SpellHandler.FindEffectOnTarget(player, "PveResurrectionIllness");
 				            if ( effect != null )
 				            	effect.Overwrite(new GameSpellEffect(effect.SpellHandler, effect.Duration / 2, effect.PulseFreq));
-							GameSpellEffect effecttwo = SpellHandler.FindEffectOnTarget(player, GlobalSpells.RvRResurrectionIllnessSpellType);
+							GameSpellEffect effecttwo = SpellHandler.FindEffectOnTarget(player, "RvrResurrectionIllness");
 				            if ( effecttwo != null )
 				            	effecttwo.Overwrite(new GameSpellEffect(effecttwo.SpellHandler, effecttwo.Duration / 2, effecttwo.PulseFreq));
 						}

--- a/GameServer/spells/RvRSicknessSpellHandler.cs
+++ b/GameServer/spells/RvRSicknessSpellHandler.cs
@@ -20,11 +20,11 @@ using System;
 
 namespace DOL.GS.Spells
 {
-	/// <summary>
-	/// RvR Resurrection Illness Handler
-	/// </summary>
-	[SpellHandler(GlobalSpells.RvRResurrectionIllnessSpellType)]
-	public class RvrResurrectionIllness : PveResurrectionIllness
+    /// <summary>
+    /// RvR Resurrection Illness Handler
+    /// </summary>
+    [SpellHandlerAttribute("RvrResurrectionIllness")]
+    public class RvrResurrectionIllness : PveResurrectionIllness
 	{
 		// constructor
 		public RvrResurrectionIllness(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line)

--- a/GameServer/spells/SpeedOfTheRealmHandler.cs
+++ b/GameServer/spells/SpeedOfTheRealmHandler.cs
@@ -16,12 +16,8 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  *
  */
-using System;
-using DOL.GS;
-using DOL.GS.PacketHandler;
-using System.Collections;
+
 using DOL.GS.Effects;
-using DOL.Events;
 using DOL.Database;
 
 namespace DOL.GS.Spells
@@ -48,6 +44,25 @@ namespace DOL.GS.Spells
 			return Spell.Duration;
 		}
 
+        public override PlayerXEffect GetSavedEffect(GameSpellEffect e)
+        {
+            PlayerXEffect eff = new PlayerXEffect();
+            eff.Var1 = Spell.ID;
+            eff.Duration = e.RemainingTime;
+            eff.IsHandler = true;
+            eff.SpellLine = SpellLine.KeyName;
+            return eff;
+        }
+
+        public override void OnEffectRestored(GameSpellEffect effect, int[] vars)
+		{
+			OnEffectStart(effect);
+		}
+
+		public override int OnRestoredEffectExpires(GameSpellEffect effect, int[] vars, bool noMessages)
+		{
+			return OnEffectExpires(effect, false);
+		}		
 
 		/// <summary>
 		/// The spell handler constructor


### PR DESCRIPTION
Saves the effects of resurrection illness and Speed of the Realm on player exit and restores them when player logs back in.

Had to move these effects to a different 'globalspellline' as reserved spells are not saved on exit.