### PR TITLE
Make Lord heal self-only

### DIFF
--- a/GameServer/keeps/Managers/Spell Manager.cs
+++ b/GameServer/keeps/Managers/Spell Manager.cs
@@ -246,7 +246,7 @@ namespace DOL.GS.Keeps
 					spell.Name = "Guard Heal";
 					spell.Range = WorldMgr.VISIBILITY_DISTANCE;
 					spell.SpellID = 90001;
-					spell.Target = "Realm";
+					spell.Target = "Self";
 					spell.Type = "Heal";
 					spell.Uninterruptible = true;
 					m_albLordHealSpell = new Spell(spell, 50);
@@ -272,7 +272,7 @@ namespace DOL.GS.Keeps
 					spell.Name = "Guard Heal";
 					spell.Range = WorldMgr.VISIBILITY_DISTANCE;
 					spell.SpellID = 90002;
-					spell.Target = "Realm";
+					spell.Target = "Self";
 					spell.Type = "Heal";
 					spell.Uninterruptible = true;
 					m_midLordHealSpell = new Spell(spell, 50);
@@ -298,7 +298,7 @@ namespace DOL.GS.Keeps
 					spell.Name = "Guard Heal";
 					spell.Range = WorldMgr.VISIBILITY_DISTANCE;
 					spell.SpellID = 90003;
-					spell.Target = "Realm";
+					spell.Target = "Self";
 					spell.Type = "Heal";
 					spell.Uninterruptible = true;
 					m_hibLordHealSpell = new Spell(spell, 50);


### PR DESCRIPTION
Currently, Lords have a heal spell which has realm as the target, so they can heal other mobs.  Since there's no LOS check on that, it leads to lords spamming heal over and over again to heal guards on the outside of the keep.

This changes the three lord heal spells to be self targeted instead.