### PR TITLE
Fix Stacking Buffs, added more buff types

### DIFF
--- a/GameServer/ai/brain/ControlledNpcBrain.cs
+++ b/GameServer/ai/brain/ControlledNpcBrain.cs
@@ -594,11 +594,15 @@ namespace DOL.AI.Brain
                 case "SUPERIORCOURAGEBUFF":
                 case "TOHITBUFF":
                 case "WEAPONSKILLBUFF":
-					{
+                case "DAMAGEADD":
+                case "OFFENSIVEPROC":
+                case "DEFENSIVEPROC":
+                case "DAMAGESHIELD":
+                    {
 						//Buff self
 						if (!LivingHasEffect(Body, spell))
 						{
-							Body.TargetObject = Body;
+                            Body.TargetObject = Body;
 							break;
 						}
 
@@ -609,7 +613,7 @@ namespace DOL.AI.Brain
 							//Buff owner
 							if (!LivingHasEffect(owner, spell))
 							{
-								Body.TargetObject = owner;
+                                Body.TargetObject = owner;
 								break;
 							}
 
@@ -622,7 +626,7 @@ namespace DOL.AI.Brain
 										continue;
 									if (!LivingHasEffect(icb.Body, spell))
 									{
-										Body.TargetObject = icb.Body;
+                                        Body.TargetObject = icb.Body;
 										break;
 									}
 								}
@@ -635,7 +639,7 @@ namespace DOL.AI.Brain
 							{
 								if (!LivingHasEffect(player, spell))
 								{
-									Body.TargetObject = player;
+                                    Body.TargetObject = player;
 									break;
 								}
 
@@ -645,7 +649,7 @@ namespace DOL.AI.Brain
 									{
 										if (!LivingHasEffect(p, spell) && Body.GetDistanceTo(p) <= spell.Range)
 										{
-											Body.TargetObject = p;
+                                            Body.TargetObject = p;
 											break;
 										}
 									}

--- a/GameServer/ai/brain/StandardMobBrain.cs
+++ b/GameServer/ai/brain/StandardMobBrain.cs
@@ -1214,6 +1214,10 @@ namespace DOL.AI.Brain
                 case "SUPERIORCOURAGEBUFF":
                 case "TOHITBUFF":
                 case "WEAPONSKILLBUFF":
+                case "DAMAGEADD":
+                case "OFFENSIVEPROC":
+                case "DEFENSIVEPROC":
+                case "DAMAGESHIELD":
                     {
 						// Buff self, if not in melee, but not each and every mob
 						// at the same time, because it looks silly.
@@ -1224,7 +1228,7 @@ namespace DOL.AI.Brain
 						}
 						if (Body.ControlledBrain != null && Body.ControlledBrain.Body != null && Util.Chance(40) && Body.GetDistanceTo(Body.ControlledBrain.Body) <= spell.Range && !LivingHasEffect(Body.ControlledBrain.Body, spell) && spell.Target.ToLower() != "self")
 						{
-							Body.TargetObject = Body.ControlledBrain.Body;
+                            Body.TargetObject = Body.ControlledBrain.Body;
 							break;
 						}
 						break;
@@ -1480,11 +1484,6 @@ namespace DOL.AI.Brain
 					//if the effect effectgroup is the same as the checking spells effectgroup then these are considered the same
 					if (speffect.Spell.EffectGroup == spell.EffectGroup)
 						return true;
-
-					//otherwise continue unless the SpellType is the same
-					if (speffect.Spell.SpellType == spell.SpellType)
-						return true;
-
 				}
 			}
 


### PR DESCRIPTION
Added a few more buff types that mobs and pets weren't checking for.

LivingHasEffect() was checking for both matching spell effect group and spell type, which is incorrect.  Offensive procs should stack, as should pulsed damage adds and damage buffs.  Spell effect group exists specifically to allow those combinations, so it's odd to not use it exclusively.