### PR TITLE
 Make PvE Lord heals interruptible

### DIFF
--- a/GameServer/keeps/Managers/Spell Manager.cs
+++ b/GameServer/keeps/Managers/Spell Manager.cs
@@ -248,7 +248,8 @@ namespace DOL.GS.Keeps
 					spell.SpellID = 90001;
 					spell.Target = "Self";
 					spell.Type = "Heal";
-					spell.Uninterruptible = true;
+                    if (GameServer.Instance.Configuration.ServerType != eGameServerType.GST_PvE)
+					    spell.Uninterruptible = true;
 					m_albLordHealSpell = new Spell(spell, 50);
 				}
 				return m_albLordHealSpell;
@@ -274,7 +275,8 @@ namespace DOL.GS.Keeps
 					spell.SpellID = 90002;
 					spell.Target = "Self";
 					spell.Type = "Heal";
-					spell.Uninterruptible = true;
+                    if (GameServer.Instance.Configuration.ServerType != eGameServerType.GST_PvE)
+                        spell.Uninterruptible = true;
 					m_midLordHealSpell = new Spell(spell, 50);
 				}
 				return m_midLordHealSpell;
@@ -300,7 +302,8 @@ namespace DOL.GS.Keeps
 					spell.SpellID = 90003;
 					spell.Target = "Self";
 					spell.Type = "Heal";
-					spell.Uninterruptible = true;
+                    if (GameServer.Instance.Configuration.ServerType != eGameServerType.GST_PvE)
+                        spell.Uninterruptible = true;
 					m_hibLordHealSpell = new Spell(spell, 50);
 				}
 				return m_hibLordHealSpell;


### PR DESCRIPTION
Removes the uninterruptible tag from PvE lords' self heal.  Lords should be soloable in PvE, and an uninterruptible self heal makes that impossible.