### PR TITLE
Added con loss, xp loss, ress sickness on death server properties

### DIFF
--- a/GameServer/serverproperty/ServerProperties.cs
+++ b/GameServer/serverproperty/ServerProperties.cs
@@ -1760,13 +1760,26 @@ namespace DOL.GS.ServerProperties
 		/// </summary>
 		[ServerProperty("pve", "lootgenerator_dreadedseals_named_chance", "Increase chance of Dreaded Seals Loot Generator drop for Named mobs. (count * lootgenerator_dreadedseals_named_chance)", 1.5)]
 		public static double LOOTGENERATOR_DREADEDSEALS_NAMED_CHANCE;
-		#endregion
 
-		#region HOUSING
-		/// <summary>
-		/// Maximum number of houses supported on this server.  Limits the size of the housing array used for updates
-		/// </summary>
-		[ServerProperty("housing", "max_num_houses", "Max number of houses supported on this server.", 5000)]
+        /// <summary>
+        /// PvE Experience Loss Start Level
+        /// </summary>
+        [ServerProperty("pve", "pve_exp_loss_level", "Which level should players killed in PvE start losing experience?", (byte)6)]
+        public static byte PVE_EXP_LOSS_LEVEL;
+
+        /// <summary>
+        /// PvE Conn Loss Start Level
+        /// </summary>
+        [ServerProperty("pve", "pve_con_loss_level", "Which level should players killed in PvE start losing constitution?", (byte)6)]
+        public static byte PVE_CON_LOSS_LEVEL;
+
+        #endregion
+
+        #region HOUSING
+        /// <summary>
+        /// Maximum number of houses supported on this server.  Limits the size of the housing array used for updates
+        /// </summary>
+        [ServerProperty("housing", "max_num_houses", "Max number of houses supported on this server.", 5000)]
 		public static int MAX_NUM_HOUSES;
 
 		/// <summary>
@@ -1957,20 +1970,25 @@ namespace DOL.GS.ServerProperties
 		public static int SLASH_LEVEL_REQUIREMENT;
 
 		/// <summary>
-		/// Should the server start characters as Base Class?
+		/// Should we allow archers to be able to use arrows from their quiver?
 		/// </summary>
 		[ServerProperty("classes", "allow_old_archery", "Should we allow archers to be able to use arrows from their quiver?", false)]
 		public static bool ALLOW_OLD_ARCHERY;
 
+        /// <summary>
+        /// Level at which res sickness starts to apply
+        /// </summary>
+        [ServerProperty("classes", "ress_sickness_level", "What level should ress sickness start to apply?", (byte)6)]
+        public static byte RESS_SICKNESS_LEVEL;
 
-		#endregion
+        #endregion
 
-		#region SPELLS
+        #region SPELLS
 
-		/// <summary>
-		/// Spells-related properties
-		/// </summary>
-		[ServerProperty("spells", "spell_interrupt_duration", "", 4500)]
+        /// <summary>
+        /// Spells-related properties
+        /// </summary>
+        [ServerProperty("spells", "spell_interrupt_duration", "", 4500)]
 		public static int SPELL_INTERRUPT_DURATION;
 
 		[ServerProperty("spells", "spell_interrupt_recast", "", 2000)]


### PR DESCRIPTION
Added server properties to replace hard coded values determining at which level characters start to lose xp on death, lose con on death, and suffer ress sickness on death.

I did it to set those values at level 51 and not have them happen at all, but figured some folks might want to still have such things at high levels.