### PR TITLE
Replaced hard coded keep guard respawn time with server properties

### DIFF
--- a/GameServer/keeps/AbstractGameKeep.cs
+++ b/GameServer/keeps/AbstractGameKeep.cs
@@ -356,9 +356,17 @@ namespace DOL.GS.Keeps
 		{
 			get
             {
-                if (this.Realm == eRealm.None && GameServer.Instance.Configuration.ServerType == eGameServerType.GST_PvE)
-                    return ServerProperties.Properties.LORD_RP_WORTH_SECONDS * 1000;
-                return 1000;
+				if (this.Realm == eRealm.None && (GameServer.Instance.Configuration.ServerType == eGameServerType.GST_PvE ||
+					GameServer.Instance.Configuration.ServerType == eGameServerType.GST_PvP))
+				{
+					// In PvE & PvP servers, lords are really just mobs farmed for seals.
+					int iVariance = 1000 * Math.Abs(ServerProperties.Properties.GUARD_RESPAWN_VARIANCE);
+					int iRespawn = 60 * ((Math.Abs(ServerProperties.Properties.GUARD_RESPAWN) * 1000) +
+						(Util.Random(-iVariance, iVariance)));
+
+					return (iRespawn > 1000) ? iRespawn : 1000; // Make sure we don't end up with an impossibly low respawn interval.
+				}
+				return 1000;
             }
 		}
 

--- a/GameServer/keeps/Managers/Template Manager.cs
+++ b/GameServer/keeps/Managers/Template Manager.cs
@@ -16,6 +16,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  *
  */
+using System;
 using DOL.AI.Brain;
 using DOL.Database;
 using DOL.GS.PacketHandler;
@@ -97,24 +98,42 @@ namespace DOL.GS.Keeps
 				}
 				else
 				{
-                    if (GameServer.Instance.Configuration.ServerType == eGameServerType.GST_PvE)
-                        // In PvE servers, lords are really just mobs farmed for seals.
-                        guard.RespawnInterval = ServerProperties.Properties.LORD_RP_WORTH_SECONDS * 1000;
-                    else
-                        guard.RespawnInterval = 10000;
+					if (GameServer.Instance.Configuration.ServerType == eGameServerType.GST_PvE
+						|| GameServer.Instance.Configuration.ServerType == eGameServerType.GST_PvP)
+					{
+						// In PvE & PvP servers, lords are really just mobs farmed for seals.
+						int iVariance = 1000 * Math.Abs(ServerProperties.Properties.GUARD_RESPAWN_VARIANCE);
+						int iRespawn = 60 * ((Math.Abs(ServerProperties.Properties.GUARD_RESPAWN) * 1000) +
+							(Util.Random(-iVariance, iVariance)));
+
+						guard.RespawnInterval = (iRespawn > 1000) ? iRespawn : 1000; // Make sure we don't end up with an impossibly low respawn interval.
+					}
+					else
+						guard.RespawnInterval = 10000; // 10 seconds
 				}
 			}
 			else if (guard is MissionMaster)
 			{
-                if (guard.Realm == eRealm.None && GameServer.Instance.Configuration.ServerType == eGameServerType.GST_PvE)
-                    // In PvE servers, mission masters are also just mobs.
-                    guard.RespawnInterval = ServerProperties.Properties.LORD_RP_WORTH_SECONDS * 1000;
-                else
-                    guard.RespawnInterval = 10000; // 10 seconds
+				if (guard.Realm == eRealm.None && (GameServer.Instance.Configuration.ServerType == eGameServerType.GST_PvE ||
+				GameServer.Instance.Configuration.ServerType == eGameServerType.GST_PvP))
+				{
+					// In PvE & PvP servers, lords are really just mobs farmed for seals.
+					int iVariance = 1000 * Math.Abs(ServerProperties.Properties.GUARD_RESPAWN_VARIANCE);
+					int iRespawn = 60 * ((Math.Abs(ServerProperties.Properties.GUARD_RESPAWN) * 1000) +
+						(Util.Random(-iVariance, iVariance)));
+
+					guard.RespawnInterval = (iRespawn > 1000) ? iRespawn : 1000; // Make sure we don't end up with an impossibly low respawn interval.
+				}
+				else
+					guard.RespawnInterval = 10000; // 10 seconds
 			}
 			else
 			{
-				guard.RespawnInterval = Util.Random(5, 25) * 60 * 1000;
+				int iVariance = 1000 * Math.Abs(ServerProperties.Properties.GUARD_RESPAWN_VARIANCE);
+				int iRespawn = 60 * ((Math.Abs(ServerProperties.Properties.GUARD_RESPAWN) * 1000) +
+					(Util.Random(-iVariance, iVariance)));
+
+				guard.RespawnInterval = (iRespawn > 1000) ? iRespawn : 1000; // Make sure we don't end up with an impossibly low respawn interval.
 			}
 		}
 

--- a/GameServer/serverproperty/ServerProperties.cs
+++ b/GameServer/serverproperty/ServerProperties.cs
@@ -1648,6 +1648,18 @@ namespace DOL.GS.ServerProperties
 		/// </summary>
 		[ServerProperty("keeps", "lord_autoset_int_multiplier", "Multiplier to use when auto-setting INT stat. ", 1.0)]
 		public static double LORD_AUTOSET_INT_MULTIPLIER;
+		
+		/// <summary>
+		/// Respawn time for keep guards in minutes.
+		/// </summary>
+		[ServerProperty("keeps", "guard_respawn", "Respawn time for keep guards in minutes.", 15)]
+		public static int GUARD_RESPAWN;
+
+		/// <summary>
+		/// Respawn variance for keep guards in minutes.
+		/// </summary>
+		[ServerProperty("keeps", "guard_respawn_variance", "Respawn variance for keep guards in minutes.", 10)]
+		public static int GUARD_RESPAWN_VARIANCE;
 		#endregion
 
 		#region PVE / TOA


### PR DESCRIPTION
Keep guards were hard coded to respawn between 5 and 25 minutes.  This replaces that with two server properties: GUARD_RESPAWN and GUARD_RESPAWN_VARIANCE.

This is something I wanted for PvE servers, since keep lords pull the entire keep when aggro'd, so having guards respawn before you get to the lord makes keeps nearly impossible.  I figured it was better to expose this for people to be able to tweak it rather than hard code a different value for PvE/PvP servers.