### PR TITLE
Add artifact quest placeholders

### DIFF
--- a/GameServer/GameServer.csproj
+++ b/GameServer/GameServer.csproj
@@ -63,8 +63,8 @@
     <FileAlignment>4096</FileAlignment>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="log4net">
-      <HintPath>..\packages\log4net.2.0.4\lib\net45-full\log4net.dll</HintPath>
+    <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\packages\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
     </Reference>
     <Reference Include="System">
       <Name>System</Name>
@@ -372,6 +372,7 @@
     <Compile Include="gameobjects\CharacterClasses\CharacterClassBase.cs" />
     <Compile Include="gameobjects\CharacterClasses\Midgard\CharacterClassBoneDancer.cs" />
     <Compile Include="gameobjects\CustomNPC\BuffMerchant.cs" />
+    <Compile Include="gameobjects\CustomNPC\DreadedSealCollector.cs" />
     <Compile Include="gameobjects\GameInventoryObject.cs" />
     <Compile Include="gameobjects\GameMythirian.cs" />
     <Compile Include="gameobjects\GameNPChelper.cs" />
@@ -381,8 +382,9 @@
     <Compile Include="gameutils\GamePlayerUtils.cs" />
     <Compile Include="gameutils\LootGeneratorAtlanteanGlass.cs" />
     <Compile Include="gameutils\LootGeneratorAurulite.cs" />
-	<Compile Include="gameutils\LootGeneratorChest.cs" />
+    <Compile Include="gameutils\LootGeneratorChest.cs" />
     <Compile Include="gameutils\LootGeneratorDragonscales.cs" />
+    <Compile Include="gameutils\LootGeneratorDreadedSeals.cs" />
     <Compile Include="gameutils\LosCheckMgr.cs" />
     <Compile Include="gameutils\MarketSearch.cs" />
     <Compile Include="gameutils\InventoryLogging.cs" />
@@ -1118,6 +1120,7 @@
     <Compile Include="propertycalc\XPPointsCalculator.cs" />
     <Compile Include="quests\Atlantis\ArtifactEncounter.cs" />
     <Compile Include="quests\Atlantis\ArtifactQuest.cs" />
+    <Compile Include="quests\Atlantis\Artifacts\AFlask.cs" />
     <Compile Include="quests\Atlantis\Artifacts\AHealersEmbrace.cs" />
     <Compile Include="quests\Atlantis\Artifacts\AlvarusLeggings.cs" />
     <Compile Include="quests\Atlantis\Artifacts\ArmsOfTheWinds.cs" />
@@ -1133,29 +1136,48 @@
     <Compile Include="quests\Atlantis\Artifacts\Cloudsong.cs" />
     <Compile Include="quests\Atlantis\Artifacts\CrocodileTearRing.cs" />
     <Compile Include="quests\Atlantis\Artifacts\DreamSphere.cs" />
+    <Compile Include="quests\Atlantis\Artifacts\EerieDarknessStone.cs" />
     <Compile Include="quests\Atlantis\Artifacts\EggofYouth.cs" />
     <Compile Include="quests\Atlantis\Artifacts\EirenesHauberk.cs" />
     <Compile Include="quests\Atlantis\Artifacts\EnyaliosBoots.cs" />
     <Compile Include="quests\Atlantis\Artifacts\ErinysCharm.cs" />
     <Compile Include="quests\Atlantis\Artifacts\EternalPlant.cs" />
+    <Compile Include="quests\Atlantis\Artifacts\FlamedancersBoots.cs" />
+    <Compile Include="quests\Atlantis\Artifacts\FoolsBow.cs" />
+    <Compile Include="quests\Atlantis\Artifacts\FoppishSleeves.cs" />
+    <Compile Include="quests\Atlantis\Artifacts\GemofLostMemories.cs" />
     <Compile Include="quests\Atlantis\Artifacts\GoddessNecklace.cs" />
+    <Compile Include="quests\Atlantis\Artifacts\GoldenScarabVest.cs" />
+    <Compile Include="quests\Atlantis\Artifacts\GoldenSpear.cs" />
     <Compile Include="quests\Atlantis\Artifacts\GuardOfValor.cs" />
     <Compile Include="quests\Atlantis\Artifacts\HarpyFeatherCloak.cs" />
     <Compile Include="quests\Atlantis\Artifacts\JacinasSash.cs" />
     <Compile Include="quests\Atlantis\Artifacts\KalaresNecklace.cs" />
     <Compile Include="quests\Atlantis\Artifacts\MaddeningScalars.cs" />
     <Compile Include="quests\Atlantis\Artifacts\MalicesAxe.cs" />
+    <Compile Include="quests\Atlantis\Artifacts\MariashasSharkskinGloves.cs" />
+    <Compile Include="quests\Atlantis\Artifacts\NailahsRobes.cs" />
     <Compile Include="quests\Atlantis\Artifacts\NightsShroudBracelet.cs" />
+    <Compile Include="quests\Atlantis\Artifacts\OrionsBelt.cs" />
+    <Compile Include="quests\Atlantis\Artifacts\PhoebusHarp.cs" />
+    <Compile Include="quests\Atlantis\Artifacts\RingofDances.cs" />
     <Compile Include="quests\Atlantis\Artifacts\RingofFire.cs" />
     <Compile Include="quests\Atlantis\Artifacts\RingofUnyieldingWill.cs" />
+    <Compile Include="quests\Atlantis\Artifacts\ScepteroftheMeritorious.cs" />
     <Compile Include="quests\Atlantis\Artifacts\ScorpionsTail.cs" />
     <Compile Include="quests\Atlantis\Artifacts\ShadesOfMist.cs" />
     <Compile Include="quests\Atlantis\Artifacts\ShieldOfKhaos.cs" />
+    <Compile Include="quests\Atlantis\Artifacts\SnakecharmersWeapon.cs" />
     <Compile Include="quests\Atlantis\Artifacts\Snatcher.cs" />
+    <Compile Include="quests\Atlantis\Artifacts\SpearofKings.cs" />
     <Compile Include="quests\Atlantis\Artifacts\StaffofGod.cs" />
     <Compile Include="quests\Atlantis\Artifacts\StoneofAtlantis.cs" />
     <Compile Include="quests\Atlantis\Artifacts\TabletofAtlantis.cs" />
     <Compile Include="quests\Atlantis\Artifacts\TartarosStaff.cs" />
+    <Compile Include="quests\Atlantis\Artifacts\TraitorsDagger.cs" />
+    <Compile Include="quests\Atlantis\Artifacts\TraldorsOracle.cs" />
+    <Compile Include="quests\Atlantis\Artifacts\WingedHelm.cs" />
+    <Compile Include="quests\Atlantis\Artifacts\WingsDive.cs" />
     <Compile Include="quests\Atlantis\ArtifactTurnInQuest.cs" />
     <Compile Include="quests\Atlantis\Encounters\AFlask.cs" />
     <Compile Include="quests\Atlantis\Encounters\AHealersEmbrace.cs" />
@@ -2785,6 +2807,7 @@
     <None Include="language\IT\Commands\GMCommands.txt" />
     <None Include="language\IT\Effects.txt" />
     <None Include="language\IT\Language-IT.txt" />
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <None Include="language\NL\NL - AdminCommands.txt" />

--- a/GameServer/quests/Atlantis/Artifacts/AFlask.cs
+++ b/GameServer/quests/Atlantis/Artifacts/AFlask.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * DAWN OF LIGHT - The first free open source DAoC server emulator
  * 
  * This program is free software; you can redistribute it and/or
@@ -28,28 +28,30 @@ using System.Collections;
 namespace DOL.GS.Quests.Atlantis.Artifacts
 {
 	/// <summary>
-	/// Quest for the Harpy Feather Cloak artifact.
+	/// Quest for the A Flask artifact.
 	/// </summary>
 	/// <author>Aredhel</author>
-	class HarpyFeatherCloak : ArtifactQuest
+	class AFlask : ArtifactQuest
 	{
 		/// <summary>
 		/// The name of the quest (not necessarily the same as
 		/// the name of the reward).
 		/// </summary>
-		public override string Name
+		public override String Name
 		{
-			get { return "Harpy Feather Cloak"; }
+			get { return "Tale of a Flask"; }
 		}
 
 		/// <summary>
 		/// The reward for this quest.
 		/// </summary>
-		private static String m_artifactID = "Harpy Feather Cloak";
+		private static String m_artifactID = "A Flask";
 		public override String ArtifactID
 		{
 			get { return m_artifactID; }
 		}
+
+		private static int m_requiredLevel = 45;
 
 		/// <summary>
 		/// Description for the current step.
@@ -60,20 +62,16 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			{
 				switch (Step)
 				{
-					case 1:
-						return "Defeat the Harpies.";
-					case 2:
-						return "Turn in the completed book.";
 					default:
 						return base.Description;
 				}
 			}
 		}
 
-		public HarpyFeatherCloak()
+		public AFlask()
 			: base() { }
 
-		public HarpyFeatherCloak(GamePlayer questingPlayer)
+		public AFlask(GamePlayer questingPlayer)
 			: base(questingPlayer) { }
 
 		/// <summary>
@@ -81,7 +79,7 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		/// <param name="questingPlayer"></param>
 		/// <param name="dbQuest"></param>
-        public HarpyFeatherCloak(GamePlayer questingPlayer, DBQuest dbQuest)
+		public AFlask(GamePlayer questingPlayer, DBQuest dbQuest)
 			: base(questingPlayer, dbQuest) { }
 
 		/// <summary>
@@ -89,22 +87,22 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		public static void Init()
 		{
-            ArtifactQuest.Init(m_artifactID, typeof(HarpyFeatherCloak));
+			ArtifactQuest.Init(m_artifactID, typeof(AFlask));
 		}
 
-        /// <summary>
-        /// Check if player is eligible for this quest.
-        /// </summary>
-        /// <param name="player"></param>
-        /// <returns></returns>
-        public override bool CheckQuestQualification(GamePlayer player)
-        {
-            if (!base.CheckQuestQualification(player))
-                return false;
+		/// <summary>
+		/// Check if player is eligible for this quest.
+		/// </summary>
+		/// <param name="player"></param>
+		/// <returns></returns>
+		public override bool CheckQuestQualification(GamePlayer player)
+		{
+			if (!base.CheckQuestQualification(player))
+				return false;
 
-            // TODO: Check if this is the correct level for the quest.
-            return (player.Level >= 45);
-        }
+			// TODO: Check if this is the correct level for the quest.
+			return (player.Level >= m_requiredLevel);
+		}
 
 		/// <summary>
 		/// Handle an item given to the scholar.
@@ -123,18 +121,21 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			if (player == null || scholar == null)
 				return false;
 
-			if (Step == 2 && ArtifactMgr.GetArtifactID(item.Name) == ArtifactID)
+			if (Step > -1 && ArtifactMgr.GetArtifactID(item.Name) == ArtifactID)
 			{
 				Dictionary<String, ItemTemplate> versions = ArtifactMgr.GetArtifactVersions(ArtifactID,
 					(eCharacterClass)player.CharacterClass.ID, (eRealm)player.Realm);
-				
+
 				if (versions.Count > 0 && RemoveItem(player, item))
 				{
 					GiveItem(scholar, player, ArtifactID, versions[";;"]);
-					String reply = String.Format("Brilliant, thank you! Here, take the artifact. {0} {1} {2}",
-						"I've unlocked its powers for you. As I've said before, I'm more interested",
-						"in the stories and the history behind these artifacts than the actual items",
-						"themselves.");
+					String reply = String.Format("Here is the {0}, {1} {2} {3} {4}, {5}!",
+						"restored to its original power. It is a fine item and I wish I could keep",
+						"it, but it is for you and you alone. Do not destroy it because you will never",
+						"have access to its full power again. Take care of it and it shall aid you in",
+						"the trials",
+						ArtifactID,
+						player.CharacterClass.Name);
 					scholar.TurnTo(player);
 					scholar.SayTo(player, eChatLoc.CL_PopupWindow, reply);
 					FinishQuest();
@@ -162,16 +163,25 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			if (player == null || scholar == null)
 				return false;
 
-			if (Step == 1 && text.ToLower() == ArtifactID.ToLower())
+			if (Step > -1 && text.ToLower() == ArtifactID.ToLower())
 			{
-                String reply = "Oh, the mysterious Harpy Feather Cloak. Do you have the scrolls on it? I've found a few that allude to its true nature, but haven't found anything with any detail.";
+				/* Commenting out to give a template for future development
+				String reply = String.Format("Vara was a very skilled healer and she put her skills {0} {1} {2}",
+					"into the Healer's Embrace cloak. It would help me to unlock them if I was to read",
+					"her Medical Log. Please give me Vara's Medical Log now so that I may awaken the",
+					"magic within the Cloak for you.");
 				scholar.TurnTo(player);
 				scholar.SayTo(player, eChatLoc.CL_PopupWindow, reply);
 				Step = 2;
-				return true;
+				return true;*/
 			}
 
 			return false;
+		}
+
+		public override void Notify(DOLEvent e, object sender, EventArgs args)
+		{
+			// Need to do anything here?
 		}
 	}
 }

--- a/GameServer/quests/Atlantis/Artifacts/AHealersEmbrace.cs
+++ b/GameServer/quests/Atlantis/Artifacts/AHealersEmbrace.cs
@@ -33,6 +33,42 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 	/// <author>Aredhel</author>
 	class AHealersEmbrace : ArtifactQuest
 	{
+		/// <summary>
+		/// The name of the quest (not necessarily the same as
+		/// the name of the reward).
+		/// </summary>
+		public override string Name
+		{
+			get { return "A Healing Embrace"; }
+		}
+
+		/// <summary>
+		/// The reward for this quest.
+		/// </summary>
+		private static String m_artifactID = "Healer's Embrace";
+		public override String ArtifactID
+		{
+			get { return m_artifactID; }
+		}
+
+		/// <summary>
+		/// Description for the current step.
+		/// </summary>
+		public override string Description
+		{
+			get
+			{
+				switch (Step)
+				{
+					case 1:
+						return "Defeat Mesedsubastet .";
+					case 2:
+						return "Turn in the completed book.";
+					default:
+						return base.Description;
+				}
+			}
+		}
 		public AHealersEmbrace()
 			: base() { }
 
@@ -52,7 +88,7 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		public static void Init()
 		{
-			ArtifactQuest.Init("Healer's Embrace", typeof(AHealersEmbrace));
+			ArtifactQuest.Init(m_artifactID, typeof(AHealersEmbrace));
 		}
 
         /// <summary>
@@ -140,42 +176,6 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			}
 
 			return false;
-		}
-
-		/// <summary>
-		/// Description for the current step.
-		/// </summary>
-		public override string Description
-		{
-			get
-			{
-				switch (Step)
-				{
-					case 1:
-						return "Defeat Mesedsubastet .";
-					case 2:
-						return "Turn in the completed book.";
-					default:
-						return base.Description;
-				}
-			}
-		}
-
-		/// <summary>
-		/// The name of the quest (not necessarily the same as
-		/// the name of the reward).
-		/// </summary>
-		public override string Name
-		{
-			get { return "A Healing Embrace"; }
-		}
-
-		/// <summary>
-		/// The reward for this quest.
-		/// </summary>
-		public override String ArtifactID
-		{
-			get { return "Healer's Embrace"; }
 		}
 
 		public override void Notify(DOLEvent e, object sender, EventArgs args)

--- a/GameServer/quests/Atlantis/Artifacts/AlvarusLeggings.cs
+++ b/GameServer/quests/Atlantis/Artifacts/AlvarusLeggings.cs
@@ -33,6 +33,43 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 	/// <author>Aredhel</author>
 	class AlvarusLeggings : ArtifactQuest
 	{
+		/// <summary>
+		/// The name of the quest (not necessarily the same as
+		/// the name of the reward).
+		/// </summary>
+		public override string Name
+		{
+			get { return "Alvarus' Leggings"; }
+		}
+
+		/// <summary>
+		/// The reward for this quest.
+		/// </summary>
+		private static String m_artifactID = "Alvarus's Leggings";
+		public override String ArtifactID
+		{
+			get { return m_artifactID; }
+		}
+
+		/// <summary>
+		/// Description for the current step.
+		/// </summary>
+		public override string Description
+		{
+			get
+			{
+				switch (Step)
+				{
+					case 1:
+						return "Defeat Minkhat.";
+					case 2:
+						return "Turn in the completed book.";
+					default:
+						return base.Description;
+				}
+			}
+		}
+
 		public AlvarusLeggings()
 			: base() { }
 
@@ -52,7 +89,7 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		public static void Init()
 		{
-			ArtifactQuest.Init("Alvarus's Leggings", typeof(AlvarusLeggings));
+			ArtifactQuest.Init(m_artifactID, typeof(AlvarusLeggings));
 		}
 
         /// <summary>
@@ -154,42 +191,6 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			}
 
 			return false;
-		}
-
-		/// <summary>
-		/// Description for the current step.
-		/// </summary>
-		public override string Description
-		{
-			get
-			{
-				switch (Step)
-				{
-					case 1:
-						return "Defeat Minkhat.";
-					case 2:
-						return "Turn in the completed book.";
-					default:
-						return base.Description;
-				}
-			}
-		}
-
-		/// <summary>
-		/// The name of the quest (not necessarily the same as
-		/// the name of the reward).
-		/// </summary>
-		public override string Name
-		{
-			get { return "Alvarus' Leggings"; }
-		}
-
-		/// <summary>
-		/// The reward for this quest.
-		/// </summary>
-		public override String ArtifactID
-		{
-			get { return "Alvarus's Leggings"; }
 		}
 	}
 }

--- a/GameServer/quests/Atlantis/Artifacts/ArmsOfTheWinds.cs
+++ b/GameServer/quests/Atlantis/Artifacts/ArmsOfTheWinds.cs
@@ -33,6 +33,43 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 	/// <author>Aredhel</author>
 	class ArmsOfTheWinds : ArtifactQuest
 	{
+		/// <summary>
+		/// The name of the quest (not necessarily the same as
+		/// the name of the reward).
+		/// </summary>
+		public override string Name
+		{
+			get { return "Arms of the Winds"; }
+		}
+
+		/// <summary>
+		/// The reward for this quest.
+		/// </summary>
+		private static String m_artifactID = "Arms of the Winds";
+		public override String ArtifactID
+		{
+			get { return m_artifactID; }
+		}
+
+		/// <summary>
+		/// Description for the current step.
+		/// </summary>
+		public override string Description
+		{
+			get
+			{
+				switch (Step)
+				{
+					case 1:
+						return "Defeat Raging Tornado.";
+					case 2:
+						return "Turn in Anthos' Fish Skin in the Hall of Heroes or in the Oceanus Haven.";
+					default:
+						return base.Description;
+				}
+			}
+		}
+
 		public ArmsOfTheWinds()
 			: base() { }
 
@@ -52,7 +89,7 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		public static void Init()
 		{
-			ArtifactQuest.Init("Arms of the Winds", typeof(ArmsOfTheWinds));
+			ArtifactQuest.Init(m_artifactID, typeof(ArmsOfTheWinds));
 		}
 
         /// <summary>
@@ -157,42 +194,6 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			}
 
 			return false;
-		}
-
-		/// <summary>
-		/// Description for the current step.
-		/// </summary>
-		public override string Description
-		{
-			get
-			{
-				switch (Step)
-				{
-					case 1:
-						return "Defeat Raging Tornado.";
-					case 2:
-						return "Turn in Anthos' Fish Skin in the Hall of Heroes or in the Oceanus Haven.";
-					default:
-						return base.Description;
-				}
-			}
-		}
-
-		/// <summary>
-		/// The name of the quest (not necessarily the same as
-		/// the name of the reward).
-		/// </summary>
-		public override string Name
-		{
-			get { return "Arms of the Winds"; }
-		}
-
-		/// <summary>
-		/// The reward for this quest.
-		/// </summary>
-		public override String ArtifactID
-		{
-			get { return "Arms of the Winds"; }
 		}
 	}
 }

--- a/GameServer/quests/Atlantis/Artifacts/AtensShield.cs
+++ b/GameServer/quests/Atlantis/Artifacts/AtensShield.cs
@@ -33,6 +33,43 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 	/// <author>Aredhel</author>
 	class AtensShield : ArtifactQuest
 	{
+		/// <summary>
+		/// The name of the quest (not necessarily the same as
+		/// the name of the reward).
+		/// </summary>
+		public override string Name
+		{
+			get { return "Aten's Shield"; }
+		}
+
+		/// <summary>
+		/// The reward for this quest.
+		/// </summary>
+		private static String m_artifactID = "Aten's Shield";
+		public override String ArtifactID
+		{
+			get { return m_artifactID; }
+		}
+
+		/// <summary>
+		/// Description for the current step.
+		/// </summary>
+		public override string Description
+		{
+			get
+			{
+				switch (Step)
+				{
+					case 1:
+						return "Find the right chest.";
+					case 2:
+						return "Turn in the notes about Remus and the Aten Shield.";
+					default:
+						return base.Description;
+				}
+			}
+		}
+
 		public AtensShield()
 			: base() { }
 
@@ -52,7 +89,7 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		public static void Init()
 		{
-			ArtifactQuest.Init("Aten's Shield", typeof(AtensShield));
+			ArtifactQuest.Init(m_artifactID, typeof(AtensShield));
 		}
 
         /// <summary>
@@ -141,42 +178,6 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			}
 
 			return false;
-		}
-
-		/// <summary>
-		/// Description for the current step.
-		/// </summary>
-		public override string Description
-		{
-			get
-			{
-				switch (Step)
-				{
-					case 1:
-						return "Find the right chest.";
-					case 2:
-						return "Turn in the notes about Remus and the Aten Shield.";
-					default:
-						return base.Description;
-				}
-			}
-		}
-
-		/// <summary>
-		/// The name of the quest (not necessarily the same as
-		/// the name of the reward).
-		/// </summary>
-		public override string Name
-		{
-			get { return "Aten's Shield"; }
-		}
-
-		/// <summary>
-		/// The reward for this quest.
-		/// </summary>
-		public override String ArtifactID
-		{
-			get { return "Aten's Shield"; }
 		}
 	}
 }

--- a/GameServer/quests/Atlantis/Artifacts/BandOfStars.cs
+++ b/GameServer/quests/Atlantis/Artifacts/BandOfStars.cs
@@ -33,6 +33,43 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 	/// <author>Aredhel</author>
 	class BandOfStars : ArtifactQuest
 	{
+		/// <summary>
+		/// The name of the quest (not necessarily the same as
+		/// the name of the reward).
+		/// </summary>
+		public override string Name
+		{
+			get { return "Band of Stars"; }
+		}
+
+		/// <summary>
+		/// The reward for this quest.
+		/// </summary>
+		private static String m_artifactID = "Band of Stars";
+		public override String ArtifactID
+		{
+			get { return m_artifactID; }
+		}
+
+		/// <summary>
+		/// Description for the current step.
+		/// </summary>
+		public override string Description
+		{
+			get
+			{
+				switch (Step)
+				{
+					case 1:
+						return "Defeat Chisisi.";
+					case 2:
+						return "Turn in the King's Vase in the Stygia Haven or in the Hall of Heroes.";
+					default:
+						return base.Description;
+				}
+			}
+		}
+
 		public BandOfStars()
 			: base() { }
 
@@ -52,7 +89,7 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		public static void Init()
 		{
-			ArtifactQuest.Init("Band of Stars", typeof(BandOfStars));
+			ArtifactQuest.Init(m_artifactID, typeof(BandOfStars));
 		}
 
         /// <summary>
@@ -143,42 +180,6 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			}
 
 			return false;
-		}
-
-		/// <summary>
-		/// Description for the current step.
-		/// </summary>
-		public override string Description
-		{
-			get
-			{
-				switch (Step)
-				{
-					case 1:
-						return "Defeat Chisisi.";
-					case 2:
-						return "Turn in the King's Vase in the Stygia Haven or in the Hall of Heroes.";
-					default:
-						return base.Description;
-				}
-			}
-		}
-
-		/// <summary>
-		/// The name of the quest (not necessarily the same as
-		/// the name of the reward).
-		/// </summary>
-		public override string Name
-		{
-			get { return "Band of Stars"; }
-		}
-
-		/// <summary>
-		/// The reward for this quest.
-		/// </summary>
-		public override String ArtifactID
-		{
-			get { return "Band of Stars"; }
 		}
 	}
 }

--- a/GameServer/quests/Atlantis/Artifacts/Battler.cs
+++ b/GameServer/quests/Atlantis/Artifacts/Battler.cs
@@ -36,6 +36,48 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 	public class Battler : ArtifactQuest
 	{
 		/// <summary>
+		/// The name of the quest (not necessarily the same as
+		/// the name of the reward).
+		/// </summary>
+		public override string Name
+		{
+			get { return "Battler"; }
+		}
+
+		/// <summary>
+		/// The artifact ID.
+		/// </summary>
+		private static String m_artifactID = "Battler";
+		public override String ArtifactID
+		{
+			get { return m_artifactID; }
+		}
+
+		/// <summary>
+		/// Description for the current step.
+		/// </summary>
+		public override string Description
+		{
+			// TODO: Get correct journal entries!
+			get
+			{
+				switch (Step)
+				{
+					case 1:
+						return "Defeat Battler.";
+					case 2:
+						return "Turn in the completed book.";
+					case 3:
+						return "Choose between a [slashing] version of Battler or a [crushing] one. Both one-handed and two-handed versions are available for both.";
+					case 4:
+						return "Choose between one handed or two handed versions.";
+					default:
+						return base.Description;
+				}
+			}
+		}
+
+		/// <summary>
 		/// Defines a logger for this class.
 		/// </summary>
 		private static readonly ILog log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
@@ -53,8 +95,6 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// <param name="dbQuest"></param>
 		public Battler(GamePlayer questingPlayer, DBQuest dbQuest)
 			: base(questingPlayer, dbQuest) { }
-
-		private static String m_artifactID = "Battler";
 
 		/// <summary>
 		/// Quest initialisation.
@@ -192,47 +232,6 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			}
 
 			return false;
-		}
-
-		/// <summary>
-		/// Description for the current step.
-		/// </summary>
-		public override string Description
-		{
-			// TODO: Get correct journal entries!
-			get
-			{
-				switch (Step)
-				{
-					case 1:
-						return "Defeat Battler.";
-					case 2:
-						return "Turn in the completed book.";
-					case 3:
-						return "Choose between a [slashing] version of Battler or a [crushing] one. Both one-handed and two-handed versions are available for both.";
-					case 4:
-						return "Choose between one handed or two handed versions.";
-					default:
-						return base.Description;
-				}
-			}
-		}
-
-		/// <summary>
-		/// The name of the quest (not necessarily the same as
-		/// the name of the reward).
-		/// </summary>
-		public override string Name
-		{
-			get { return "Battler"; }
-		}
-
-		/// <summary>
-		/// The artifact ID.
-		/// </summary>
-		public override String ArtifactID
-		{
-			get { return m_artifactID; }
 		}
 	}
 }

--- a/GameServer/quests/Atlantis/Artifacts/BeltofOglidarsh.cs
+++ b/GameServer/quests/Atlantis/Artifacts/BeltofOglidarsh.cs
@@ -33,6 +33,43 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 	/// <author>Aredhel</author>
 	class BeltofOglidarsh : ArtifactQuest
 	{
+		/// <summary>
+		/// The name of the quest (not necessarily the same as
+		/// the name of the reward).
+		/// </summary>
+		public override string Name
+		{
+			get { return "Belt of Oglidarsh"; }
+		}
+
+		/// <summary>
+		/// The reward for this quest.
+		/// </summary>
+		private static String m_artifactID = "Belt of Oglidarsh";
+		public override String ArtifactID
+		{
+			get { return m_artifactID; }
+		}
+
+		/// <summary>
+		/// Description for the current step.
+		/// </summary>
+		public override string Description
+		{
+			get
+			{
+				switch (Step)
+				{
+					case 1:
+						return "Defeat Snatcher.";
+					case 2:
+						return "Turn in the completed book.";
+					default:
+						return base.Description;
+				}
+			}
+		}
+
 		public BeltofOglidarsh()
 			: base() { }
 
@@ -52,7 +89,7 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		public static void Init()
 		{
-            ArtifactQuest.Init("Belt of Oglidarsh", typeof(BeltofOglidarsh));
+            ArtifactQuest.Init(m_artifactID, typeof(BeltofOglidarsh));
 		}
 
         /// <summary>
@@ -135,42 +172,6 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			}
 
 			return false;
-		}
-
-		/// <summary>
-		/// Description for the current step.
-		/// </summary>
-		public override string Description
-		{
-			get
-			{
-				switch (Step)
-				{
-					case 1:
-						return "Defeat Snatcher.";
-					case 2:
-						return "Turn in the completed book.";
-					default:
-						return base.Description;
-				}
-			}
-		}
-
-		/// <summary>
-		/// The name of the quest (not necessarily the same as
-		/// the name of the reward).
-		/// </summary>
-		public override string Name
-		{
-            get { return "Belt of Oglidarsh"; }
-		}
-
-		/// <summary>
-		/// The reward for this quest.
-		/// </summary>
-		public override String ArtifactID
-		{
-            get { return "Belt of Oglidarsh"; }
 		}
 	}
 }

--- a/GameServer/quests/Atlantis/Artifacts/BeltoftheMoon.cs
+++ b/GameServer/quests/Atlantis/Artifacts/BeltoftheMoon.cs
@@ -33,6 +33,43 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 	/// <author>Aredhel</author>
 	class BeltoftheMoon : ArtifactQuest
 	{
+		/// <summary>
+		/// The name of the quest (not necessarily the same as
+		/// the name of the reward).
+		/// </summary>
+		public override string Name
+		{
+			get { return "Belt of the Moon"; }
+		}
+
+		/// <summary>
+		/// The reward for this quest.
+		/// </summary>
+		private static String m_artifactID = "Belt of the Moon";
+		public override String ArtifactID
+		{
+			get { return m_artifactID; }
+		}
+
+		/// <summary>
+		/// Description for the current step.
+		/// </summary>
+		public override string Description
+		{
+			get
+			{
+				switch (Step)
+				{
+					case 1:
+						return "Defeat the protectors.";
+					case 2:
+						return "Turn in the completed book.";
+					default:
+						return base.Description;
+				}
+			}
+		}
+
 		public BeltoftheMoon()
 			: base() { }
 
@@ -52,7 +89,7 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		public static void Init()
 		{
-            ArtifactQuest.Init("Belt of the Moon", typeof(BeltoftheMoon));
+            ArtifactQuest.Init(m_artifactID, typeof(BeltoftheMoon));
 		}
 
         /// <summary>
@@ -135,42 +172,6 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			}
 
 			return false;
-		}
-
-		/// <summary>
-		/// Description for the current step.
-		/// </summary>
-		public override string Description
-		{
-			get
-			{
-				switch (Step)
-				{
-					case 1:
-						return "Defeat the protectors.";
-					case 2:
-						return "Turn in the completed book.";
-					default:
-						return base.Description;
-				}
-			}
-		}
-
-		/// <summary>
-		/// The name of the quest (not necessarily the same as
-		/// the name of the reward).
-		/// </summary>
-		public override string Name
-		{
-            get { return "Belt of the Moon"; }
-		}
-
-		/// <summary>
-		/// The reward for this quest.
-		/// </summary>
-		public override String ArtifactID
-		{
-            get { return "Belt of the Moon"; }
 		}
 	}
 }

--- a/GameServer/quests/Atlantis/Artifacts/BeltoftheSun.cs
+++ b/GameServer/quests/Atlantis/Artifacts/BeltoftheSun.cs
@@ -33,6 +33,43 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 	/// <author>Aredhel</author>
 	class BeltoftheSun : ArtifactQuest
 	{
+		/// <summary>
+		/// The name of the quest (not necessarily the same as
+		/// the name of the reward).
+		/// </summary>
+		public override string Name
+		{
+			get { return "Belt of the Sun"; }
+		}
+
+		/// <summary>
+		/// The reward for this quest.
+		/// </summary>
+		private static String m_artifactID = "Belt of the Sun";
+		public override String ArtifactID
+		{
+			get { return m_artifactID; }
+		}
+
+		/// <summary>
+		/// Description for the current step.
+		/// </summary>
+		public override string Description
+		{
+			get
+			{
+				switch (Step)
+				{
+					case 1:
+						return "Defeat the protectors.";
+					case 2:
+						return "Turn in the completed book.";
+					default:
+						return base.Description;
+				}
+			}
+		}
+
 		public BeltoftheSun()
 			: base() { }
 
@@ -52,7 +89,7 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		public static void Init()
 		{
-            ArtifactQuest.Init("Belt of the Sun", typeof(BeltoftheSun));
+            ArtifactQuest.Init(m_artifactID, typeof(BeltoftheSun));
 		}
 
         /// <summary>
@@ -135,42 +172,6 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			}
 
 			return false;
-		}
-
-		/// <summary>
-		/// Description for the current step.
-		/// </summary>
-		public override string Description
-		{
-			get
-			{
-				switch (Step)
-				{
-					case 1:
-						return "Defeat the protectors.";
-					case 2:
-						return "Turn in the completed book.";
-					default:
-						return base.Description;
-				}
-			}
-		}
-
-		/// <summary>
-		/// The name of the quest (not necessarily the same as
-		/// the name of the reward).
-		/// </summary>
-		public override string Name
-		{
-            get { return "Belt of the Sun"; }
-		}
-
-		/// <summary>
-		/// The reward for this quest.
-		/// </summary>
-		public override String ArtifactID
-		{
-            get { return "Belt of the Sun"; }
 		}
 	}
 }

--- a/GameServer/quests/Atlantis/Artifacts/BracerofZoarkat.cs
+++ b/GameServer/quests/Atlantis/Artifacts/BracerofZoarkat.cs
@@ -33,6 +33,43 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 	/// <author>Aredhel</author>
 	class BraceletofZoarkat : ArtifactQuest
 	{
+		/// <summary>
+		/// The name of the quest (not necessarily the same as
+		/// the name of the reward).
+		/// </summary>
+		public override string Name
+		{
+			get { return "Bracelet of Zo'arkat"; }
+		}
+
+		/// <summary>
+		/// The reward for this quest.
+		/// </summary>
+		private static String m_artifactID = "Bracelet of Zo'arkat";
+		public override String ArtifactID
+		{
+			get { return m_artifactID; }
+		}
+
+		/// <summary>
+		/// Description for the current step.
+		/// </summary>
+		public override string Description
+		{
+			get
+			{
+				switch (Step)
+				{
+					case 1:
+						return "Defeat the champion.";
+					case 2:
+						return "Turn in the completed book.";
+					default:
+						return base.Description;
+				}
+			}
+		}
+
 		public BraceletofZoarkat()
 			: base() { }
 
@@ -52,7 +89,7 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		public static void Init()
 		{
-            ArtifactQuest.Init("Bracelet of Zo'arkat", typeof(BraceletofZoarkat));
+            ArtifactQuest.Init(m_artifactID, typeof(BraceletofZoarkat));
 		}
 
         /// <summary>
@@ -135,42 +172,6 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			}
 
 			return false;
-		}
-
-		/// <summary>
-		/// Description for the current step.
-		/// </summary>
-		public override string Description
-		{
-			get
-			{
-				switch (Step)
-				{
-					case 1:
-						return "Defeat the champion.";
-					case 2:
-						return "Turn in the completed book.";
-					default:
-						return base.Description;
-				}
-			}
-		}
-
-		/// <summary>
-		/// The name of the quest (not necessarily the same as
-		/// the name of the reward).
-		/// </summary>
-		public override string Name
-		{
-            get { return "Bracelet of Zo'arkat"; }
-		}
-
-		/// <summary>
-		/// The reward for this quest.
-		/// </summary>
-		public override String ArtifactID
-		{
-            get { return "Bracelet of Zo'arkat"; }
 		}
 	}
 }

--- a/GameServer/quests/Atlantis/Artifacts/Bruiser.cs
+++ b/GameServer/quests/Atlantis/Artifacts/Bruiser.cs
@@ -36,6 +36,45 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 	public class Bruiser : ArtifactQuest
 	{
 		/// <summary>
+		/// The name of the quest (not necessarily the same as
+		/// the name of the reward).
+		/// </summary>
+		public override string Name
+		{
+			get { return "Bruiser"; }
+		}
+
+		/// <summary>
+		/// The artifact ID.
+		/// </summary>
+		private static String m_artifactID = "Bruiser";
+		public override String ArtifactID
+		{
+			get { return m_artifactID; }
+		}
+
+		/// <summary>
+		/// Description for the current step.
+		/// </summary>
+		public override string Description
+		{
+			get
+			{
+				switch (Step)
+				{
+					case 1:
+						return "Kill Taur Warlord.";
+					case 2:
+						return "Turn in the completed book.";
+					case 3:
+						return "Do you want a [single] or [double] handed version?";
+					default:
+						return base.Description;
+				}
+			}
+		}
+
+		/// <summary>
 		/// Defines a logger for this class.
 		/// </summary>
 		private static readonly ILog log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
@@ -53,8 +92,6 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// <param name="dbQuest"></param>
 		public Bruiser(GamePlayer questingPlayer, DBQuest dbQuest)
 			: base(questingPlayer, dbQuest) { }
-
-		private static String m_artifactID = "Bruiser";
 
 		/// <summary>
 		/// Quest initialisation.
@@ -187,44 +224,6 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			}
 
 			return false;
-		}
-
-		/// <summary>
-		/// Description for the current step.
-		/// </summary>
-		public override string Description
-		{
-			get
-			{
-				switch (Step)
-				{
-					case 1:
-						return "Kill Taur Warlord.";
-					case 2:
-						return "Turn in the completed book.";
-					case 3:
-						return "Do you want a [single] or [double] handed version?";
-					default:
-						return base.Description;
-				}
-			}
-		}
-
-		/// <summary>
-		/// The name of the quest (not necessarily the same as
-		/// the name of the reward).
-		/// </summary>
-		public override string Name
-		{
-			get { return "Bruiser"; }
-		}
-
-		/// <summary>
-		/// The artifact ID.
-		/// </summary>
-		public override String ArtifactID
-		{
-			get { return m_artifactID; }
 		}
 	}
 }

--- a/GameServer/quests/Atlantis/Artifacts/CeremonialBracers.cs
+++ b/GameServer/quests/Atlantis/Artifacts/CeremonialBracers.cs
@@ -36,6 +36,45 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 	public class CeremonialBracers : ArtifactQuest
 	{
 		/// <summary>
+		/// The name of the quest (not necessarily the same as
+		/// the name of the reward).
+		/// </summary>
+		public override string Name
+		{
+			get { return "Bracers"; }
+		}
+
+		/// <summary>
+		/// The artifact ID.
+		/// </summary>
+		private static String m_artifactID = "Ceremonial Bracers";
+		public override String ArtifactID
+		{
+			get { return m_artifactID; }
+		}
+
+		/// <summary>
+		/// Description for the current step.
+		/// </summary>
+		public override string Description
+		{
+			get
+			{
+				switch (Step)
+				{
+					case 1:
+						return "Defeat a wavelord.";
+					case 2:
+						return "Turn in the completed book.";
+					case 3: // TODO: Get correct journal entry.
+						return "Choose between a [strength], [constitution], [dexterity], [quickness] or [casting] version of the Ceremonial Bracers.";
+					default:
+						return base.Description;
+				}
+			}
+		}
+
+		/// <summary>
 		/// Defines a logger for this class.
 		/// </summary>
 		private static readonly ILog log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
@@ -53,8 +92,6 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// <param name="dbQuest"></param>
 		public CeremonialBracers(GamePlayer questingPlayer, DBQuest dbQuest)
 			: base(questingPlayer, dbQuest) { }
-
-		private static String m_artifactID = "Ceremonial Bracers";
 
 		/// <summary>
 		/// Quest initialisation.
@@ -178,44 +215,6 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			}
 
 			return false;
-		}
-
-		/// <summary>
-		/// Description for the current step.
-		/// </summary>
-		public override string Description
-		{
-			get
-			{
-				switch (Step)
-				{
-					case 1:
-						return "Defeat a wavelord.";
-					case 2:
-						return "Turn in the completed book.";
-					case 3: // TODO: Get correct journal entry.
-						return "Choose between a [strength], [constitution], [dexterity], [quickness] or [casting] version of the Ceremonial Bracers.";
-					default:
-						return base.Description;
-				}
-			}
-		}
-
-		/// <summary>
-		/// The name of the quest (not necessarily the same as
-		/// the name of the reward).
-		/// </summary>
-		public override string Name
-		{
-			get { return "Bracers"; }
-		}
-
-		/// <summary>
-		/// The artifact ID.
-		/// </summary>
-		public override String ArtifactID
-		{
-			get { return m_artifactID; }
 		}
 	}
 }

--- a/GameServer/quests/Atlantis/Artifacts/Cloudsong.cs
+++ b/GameServer/quests/Atlantis/Artifacts/Cloudsong.cs
@@ -33,6 +33,43 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 	/// <author>Aredhel</author>
 	class Cloudsong : ArtifactQuest
 	{
+		/// <summary>
+		/// The name of the quest (not necessarily the same as
+		/// the name of the reward).
+		/// </summary>
+		public override string Name
+		{
+			get { return "Cloudsong"; }
+		}
+
+		/// <summary>
+		/// The reward for this quest.
+		/// </summary>
+		private static String m_artifactID = "Cloudsong";
+		public override String ArtifactID
+		{
+			get { return m_artifactID; }
+		}
+
+		/// <summary>
+		/// Description for the current step.
+		/// </summary>
+		public override string Description
+		{
+			get
+			{
+				switch (Step)
+				{
+					case 1:
+						return "Defeat Eramai.";
+					case 2:
+						return "Turn in the completed book.";
+					default:
+						return base.Description;
+				}
+			}
+		}
+
 		public Cloudsong()
 			: base() { }
 
@@ -52,7 +89,7 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		public static void Init()
 		{
-			ArtifactQuest.Init("Cloudsong", typeof(Cloudsong));
+			ArtifactQuest.Init(m_artifactID, typeof(Cloudsong));
 		}
 
         /// <summary>
@@ -147,42 +184,6 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
             }
 
 			return false;
-		}
-
-		/// <summary>
-		/// Description for the current step.
-		/// </summary>
-		public override string Description
-		{
-			get
-			{
-				switch (Step)
-				{
-					case 1:
-						return "Defeat Eramai.";
-					case 2:
-						return "Turn in the completed book.";
-					default:
-						return base.Description;
-				}
-			}
-		}
-
-		/// <summary>
-		/// The name of the quest (not necessarily the same as
-		/// the name of the reward).
-		/// </summary>
-		public override string Name
-		{
-			get { return "Cloudsong"; }
-		}
-
-		/// <summary>
-		/// The reward for this quest.
-		/// </summary>
-		public override String ArtifactID
-		{
-			get { return "Cloudsong"; }
 		}
 
 		public override void Notify(DOLEvent e, object sender, EventArgs args)

--- a/GameServer/quests/Atlantis/Artifacts/CrocodileTearRing.cs
+++ b/GameServer/quests/Atlantis/Artifacts/CrocodileTearRing.cs
@@ -33,6 +33,43 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 	/// <author>Aredhel</author>
 	class CrocodileTearRing : ArtifactQuest
 	{
+		/// <summary>
+		/// The name of the quest (not necessarily the same as
+		/// the name of the reward).
+		/// </summary>
+		public override string Name
+		{
+			get { return "Crocodile Tear Ring"; }
+		}
+
+		/// <summary>
+		/// The reward for this quest.
+		/// </summary>
+		private static String m_artifactID = "Crocodile Tear Ring";
+		public override String ArtifactID
+		{
+			get { return m_artifactID; }
+		}
+
+		/// <summary>
+		/// Description for the current step.
+		/// </summary>
+		public override string Description
+		{
+			get
+			{
+				switch (Step)
+				{
+					case 1:
+						return "Defeat Cynere.";
+					case 2:
+						return "Turn in the completed book.";
+					default:
+						return base.Description;
+				}
+			}
+		}
+
 		public CrocodileTearRing()
 			: base() { }
 
@@ -52,7 +89,7 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		public static void Init()
 		{
-            ArtifactQuest.Init("Crocodile Tear Ring", typeof(CrocodileTearRing));
+            ArtifactQuest.Init(m_artifactID, typeof(CrocodileTearRing));
 		}
 
         /// <summary>
@@ -135,42 +172,6 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			}
 
 			return false;
-		}
-
-		/// <summary>
-		/// Description for the current step.
-		/// </summary>
-		public override string Description
-		{
-			get
-			{
-				switch (Step)
-				{
-					case 1:
-						return "Defeat Cynere.";
-					case 2:
-						return "Turn in the completed book.";
-					default:
-						return base.Description;
-				}
-			}
-		}
-
-		/// <summary>
-		/// The name of the quest (not necessarily the same as
-		/// the name of the reward).
-		/// </summary>
-		public override string Name
-		{
-            get { return "Crocodile Tear Ring"; }
-		}
-
-		/// <summary>
-		/// The reward for this quest.
-		/// </summary>
-		public override String ArtifactID
-		{
-            get { return "Crocodile Tear Ring"; }
 		}
 	}
 }

--- a/GameServer/quests/Atlantis/Artifacts/DreamSphere.cs
+++ b/GameServer/quests/Atlantis/Artifacts/DreamSphere.cs
@@ -33,6 +33,43 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 	/// <author>Aredhel</author>
 	class DreamSphere : ArtifactQuest
 	{
+		/// <summary>
+		/// The name of the quest (not necessarily the same as
+		/// the name of the reward).
+		/// </summary>
+		public override string Name
+		{
+			get { return "Dream Sphere"; }
+		}
+
+		/// <summary>
+		/// The reward for this quest.
+		/// </summary>
+		private static String m_artifactID = "Dream Sphere";
+		public override String ArtifactID
+		{
+			get { return m_artifactID; }
+		}
+
+		/// <summary>
+		/// Description for the current step.
+		/// </summary>
+		public override string Description
+		{
+			get
+			{
+				switch (Step)
+				{
+					case 1:
+						return "Defeat the attackers and end Torih's dream.";
+					case 2:
+						return "Turn in the completed book.";
+					default:
+						return base.Description;
+				}
+			}
+		}
+
 		public DreamSphere()
 			: base() { }
 
@@ -52,7 +89,7 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		public static void Init()
 		{
-            ArtifactQuest.Init("Dream Sphere", typeof(DreamSphere));
+            ArtifactQuest.Init(m_artifactID, typeof(DreamSphere));
 		}
 
         /// <summary>
@@ -135,42 +172,6 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			}
 
 			return false;
-		}
-
-		/// <summary>
-		/// Description for the current step.
-		/// </summary>
-		public override string Description
-		{
-			get
-			{
-				switch (Step)
-				{
-					case 1:
-						return "Defeat the attackers and end Torih's dream.";
-					case 2:
-						return "Turn in the completed book.";
-					default:
-						return base.Description;
-				}
-			}
-		}
-
-		/// <summary>
-		/// The name of the quest (not necessarily the same as
-		/// the name of the reward).
-		/// </summary>
-		public override string Name
-		{
-            get { return "Dream Sphere"; }
-		}
-
-		/// <summary>
-		/// The reward for this quest.
-		/// </summary>
-		public override String ArtifactID
-		{
-            get { return "Dream Sphere"; }
 		}
 	}
 }

--- a/GameServer/quests/Atlantis/Artifacts/EerieDarknessStone.cs
+++ b/GameServer/quests/Atlantis/Artifacts/EerieDarknessStone.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * DAWN OF LIGHT - The first free open source DAoC server emulator
  * 
  * This program is free software; you can redistribute it and/or
@@ -28,24 +28,27 @@ using System.Collections;
 namespace DOL.GS.Quests.Atlantis.Artifacts
 {
 	/// <summary>
-	/// Quest for the Harpy Feather Cloak artifact.
+	/// Quest for the A Flask artifact.
 	/// </summary>
 	/// <author>Aredhel</author>
-	class HarpyFeatherCloak : ArtifactQuest
+	class EerieDarknessStone : ArtifactQuest
 	{
+		private static int m_requiredLevel = 45;
+
 		/// <summary>
 		/// The name of the quest (not necessarily the same as
 		/// the name of the reward).
 		/// </summary>
-		public override string Name
+		private const String m_Name = "Eerie Darkness Stone";
+		public override String Name
 		{
-			get { return "Harpy Feather Cloak"; }
+			get { return m_Name; }
 		}
 
 		/// <summary>
 		/// The reward for this quest.
 		/// </summary>
-		private static String m_artifactID = "Harpy Feather Cloak";
+		private static String m_artifactID = "Eerie Darkness Stone";
 		public override String ArtifactID
 		{
 			get { return m_artifactID; }
@@ -60,20 +63,16 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			{
 				switch (Step)
 				{
-					case 1:
-						return "Defeat the Harpies.";
-					case 2:
-						return "Turn in the completed book.";
 					default:
 						return base.Description;
 				}
 			}
 		}
 
-		public HarpyFeatherCloak()
+		public EerieDarknessStone()
 			: base() { }
 
-		public HarpyFeatherCloak(GamePlayer questingPlayer)
+		public EerieDarknessStone(GamePlayer questingPlayer)
 			: base(questingPlayer) { }
 
 		/// <summary>
@@ -81,7 +80,7 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		/// <param name="questingPlayer"></param>
 		/// <param name="dbQuest"></param>
-        public HarpyFeatherCloak(GamePlayer questingPlayer, DBQuest dbQuest)
+		public EerieDarknessStone(GamePlayer questingPlayer, DBQuest dbQuest)
 			: base(questingPlayer, dbQuest) { }
 
 		/// <summary>
@@ -89,22 +88,22 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		public static void Init()
 		{
-            ArtifactQuest.Init(m_artifactID, typeof(HarpyFeatherCloak));
+			ArtifactQuest.Init(m_artifactID, typeof(EerieDarknessStone));
 		}
 
-        /// <summary>
-        /// Check if player is eligible for this quest.
-        /// </summary>
-        /// <param name="player"></param>
-        /// <returns></returns>
-        public override bool CheckQuestQualification(GamePlayer player)
-        {
-            if (!base.CheckQuestQualification(player))
-                return false;
+		/// <summary>
+		/// Check if player is eligible for this quest.
+		/// </summary>
+		/// <param name="player"></param>
+		/// <returns></returns>
+		public override bool CheckQuestQualification(GamePlayer player)
+		{
+			if (!base.CheckQuestQualification(player))
+				return false;
 
-            // TODO: Check if this is the correct level for the quest.
-            return (player.Level >= 45);
-        }
+			// TODO: Check if this is the correct level for the quest.
+			return (player.Level >= m_requiredLevel);
+		}
 
 		/// <summary>
 		/// Handle an item given to the scholar.
@@ -123,18 +122,21 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			if (player == null || scholar == null)
 				return false;
 
-			if (Step == 2 && ArtifactMgr.GetArtifactID(item.Name) == ArtifactID)
+			if (Step > -1 && ArtifactMgr.GetArtifactID(item.Name) == ArtifactID)
 			{
 				Dictionary<String, ItemTemplate> versions = ArtifactMgr.GetArtifactVersions(ArtifactID,
 					(eCharacterClass)player.CharacterClass.ID, (eRealm)player.Realm);
-				
+
 				if (versions.Count > 0 && RemoveItem(player, item))
 				{
 					GiveItem(scholar, player, ArtifactID, versions[";;"]);
-					String reply = String.Format("Brilliant, thank you! Here, take the artifact. {0} {1} {2}",
-						"I've unlocked its powers for you. As I've said before, I'm more interested",
-						"in the stories and the history behind these artifacts than the actual items",
-						"themselves.");
+					String reply = String.Format("Here is the {0}, {1} {2} {3} {4}, {5}!",
+						"restored to its original power. It is a fine item and I wish I could keep",
+						"it, but it is for you and you alone. Do not destroy it because you will never",
+						"have access to its full power again. Take care of it and it shall aid you in",
+						"the trials",
+						ArtifactID,
+						player.CharacterClass.Name);
 					scholar.TurnTo(player);
 					scholar.SayTo(player, eChatLoc.CL_PopupWindow, reply);
 					FinishQuest();
@@ -162,16 +164,25 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			if (player == null || scholar == null)
 				return false;
 
-			if (Step == 1 && text.ToLower() == ArtifactID.ToLower())
+			if (Step > -1 && text.ToLower() == ArtifactID.ToLower())
 			{
-                String reply = "Oh, the mysterious Harpy Feather Cloak. Do you have the scrolls on it? I've found a few that allude to its true nature, but haven't found anything with any detail.";
+				/* Commenting out to give a template for future development
+				String reply = String.Format("Vara was a very skilled healer and she put her skills {0} {1} {2}",
+					"into the Healer's Embrace cloak. It would help me to unlock them if I was to read",
+					"her Medical Log. Please give me Vara's Medical Log now so that I may awaken the",
+					"magic within the Cloak for you.");
 				scholar.TurnTo(player);
 				scholar.SayTo(player, eChatLoc.CL_PopupWindow, reply);
 				Step = 2;
-				return true;
+				return true;*/
 			}
 
 			return false;
+		}
+
+		public override void Notify(DOLEvent e, object sender, EventArgs args)
+		{
+			// Need to do anything here?
 		}
 	}
 }

--- a/GameServer/quests/Atlantis/Artifacts/EggofYouth.cs
+++ b/GameServer/quests/Atlantis/Artifacts/EggofYouth.cs
@@ -33,6 +33,42 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 	/// <author>Aredhel</author>
 	class EggofYouth : ArtifactQuest
 	{
+		/// <summary>
+		/// The name of the quest (not necessarily the same as
+		/// the name of the reward).
+		/// </summary>
+		public override string Name
+		{
+			get { return "Egg of Youth"; }
+		}
+
+		/// <summary>
+		/// The reward for this quest.
+		/// </summary>
+		private static String m_artifactID = "Egg of Youth";
+		public override String ArtifactID
+		{
+			get { return m_artifactID; }
+		}
+
+		/// <summary>
+		/// Description for the current step.
+		/// </summary>
+		public override string Description
+		{
+			get
+			{
+				switch (Step)
+				{
+					case 1:
+						return "Defeat Sililia.";
+					case 2:
+						return "Turn in the completed book.";
+					default:
+						return base.Description;
+				}
+			}
+		}
 		public EggofYouth()
 			: base() { }
 
@@ -52,7 +88,7 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		public static void Init()
 		{
-            ArtifactQuest.Init("Egg of Youth", typeof(EggofYouth));
+            ArtifactQuest.Init(m_artifactID, typeof(EggofYouth));
 		}
 
         /// <summary>
@@ -135,42 +171,6 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			}
 
 			return false;
-		}
-
-		/// <summary>
-		/// Description for the current step.
-		/// </summary>
-		public override string Description
-		{
-			get
-			{
-				switch (Step)
-				{
-					case 1:
-						return "Defeat Sililia.";
-					case 2:
-						return "Turn in the completed book.";
-					default:
-						return base.Description;
-				}
-			}
-		}
-
-		/// <summary>
-		/// The name of the quest (not necessarily the same as
-		/// the name of the reward).
-		/// </summary>
-		public override string Name
-		{
-            get { return "Egg of Youth"; }
-		}
-
-		/// <summary>
-		/// The reward for this quest.
-		/// </summary>
-		public override String ArtifactID
-		{
-            get { return "Egg of Youth"; }
 		}
 	}
 }

--- a/GameServer/quests/Atlantis/Artifacts/EirenesHauberk.cs
+++ b/GameServer/quests/Atlantis/Artifacts/EirenesHauberk.cs
@@ -34,11 +34,49 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 	class EirenesHauberk : ArtifactQuest
 	{
 		/// <summary>
+		/// The name of the quest (not necessarily the same as
+		/// the name of the reward).
+		/// </summary>
+		public override string Name
+		{
+			get { return "Eirene's Hauberk"; }
+		}
+
+		/// <summary>
+		/// The reward for this quest.
+		/// </summary>
+		private static String m_artifactID = "Eirene's Chestpiece";
+		public override String ArtifactID
+		{
+			get { return m_artifactID; }
+		}
+
+		/// <summary>
+		/// Description for the current step.
+		/// </summary>
+		public override string Description
+		{
+			get
+			{
+				switch (Step)
+				{
+					case 1:
+						return "Defeat Linos.";
+					case 2:
+						return "Turn in Eirene's Journal in the Hall of Heroes or the Oceanus Haven.";
+					case 3:
+						return "Choose the version of Eirene's Chestpiece you would like to have.";
+					default:
+						return base.Description;
+				}
+			}
+		}
+
+		/// <summary>
 		/// Defines a logger for this class.
 		/// </summary>
 		private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
-
-
+		
 		public EirenesHauberk()
 			: base() { }
 
@@ -58,7 +96,7 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		public static void Init()
 		{
-			ArtifactQuest.Init("Eirene's Chestpiece", typeof(EirenesHauberk));
+			ArtifactQuest.Init(m_artifactID, typeof(EirenesHauberk));
 		}
 
         /// <summary>
@@ -214,44 +252,6 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			}
 
 			return false;
-		}
-
-		/// <summary>
-		/// Description for the current step.
-		/// </summary>
-		public override string Description
-		{
-			get
-			{
-				switch (Step)
-				{
-					case 1:
-						return "Defeat Linos.";
-					case 2:
-						return "Turn in Eirene's Journal in the Hall of Heroes or the Oceanus Haven.";
-					case 3:
-						return "Choose the version of Eirene's Chestpiece you would like to have.";
-					default:
-						return base.Description;
-				}
-			}
-		}
-
-		/// <summary>
-		/// The name of the quest (not necessarily the same as
-		/// the name of the reward).
-		/// </summary>
-		public override string Name
-		{
-			get { return "Eirene's Hauberk"; }
-		}
-
-		/// <summary>
-		/// The reward for this quest.
-		/// </summary>
-		public override String ArtifactID
-		{
-			get { return "Eirene's Chestpiece"; }
 		}
 	}
 }

--- a/GameServer/quests/Atlantis/Artifacts/EnyaliosBoots.cs
+++ b/GameServer/quests/Atlantis/Artifacts/EnyaliosBoots.cs
@@ -33,6 +33,43 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 	/// <author>Aredhel</author>
 	class EnyaliosBoots : ArtifactQuest
 	{
+		/// <summary>
+		/// The name of the quest (not necessarily the same as
+		/// the name of the reward).
+		/// </summary>
+		public override string Name
+		{
+			get { return "Enyalios' Boots"; }
+		}
+
+		/// <summary>
+		/// The reward for this quest.
+		/// </summary>
+		private static String m_artifactID = "Enyalio's Boots";
+		public override String ArtifactID
+		{
+			get { return m_artifactID; }
+		}
+
+		/// <summary>
+		/// Description for the current step.
+		/// </summary>
+		public override string Description
+		{
+			get
+			{
+				switch (Step)
+				{
+					case 1:
+						return "Defeat Behrooz.";
+					case 2:
+						return "Turn in the completed book.";
+					default:
+						return base.Description;
+				}
+			}
+		}
+
 		public EnyaliosBoots()
 			: base() { }
 
@@ -52,7 +89,7 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		public static void Init()
 		{
-			ArtifactQuest.Init("Enyalio's Boots", typeof(EnyaliosBoots));
+			ArtifactQuest.Init(m_artifactID, typeof(EnyaliosBoots));
 		}
 
         /// <summary>
@@ -148,42 +185,6 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			}
 
 			return false;
-		}
-
-		/// <summary>
-		/// Description for the current step.
-		/// </summary>
-		public override string Description
-		{
-			get
-			{
-				switch (Step)
-				{
-					case 1:
-						return "Defeat Behrooz.";
-					case 2:
-						return "Turn in the completed book.";
-					default:
-						return base.Description;
-				}
-			}
-		}
-
-		/// <summary>
-		/// The name of the quest (not necessarily the same as
-		/// the name of the reward).
-		/// </summary>
-		public override string Name
-		{
-			get { return "Enyalios' Boots"; }
-		}
-
-		/// <summary>
-		/// The reward for this quest.
-		/// </summary>
-		public override String ArtifactID
-		{
-			get { return "Enyalio's Boots"; }
 		}
 	}
 }

--- a/GameServer/quests/Atlantis/Artifacts/ErinysCharm.cs
+++ b/GameServer/quests/Atlantis/Artifacts/ErinysCharm.cs
@@ -33,6 +33,43 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 	/// <author>Aredhel</author>
 	class ErinysCharm : ArtifactQuest
 	{
+		/// <summary>
+		/// The name of the quest (not necessarily the same as
+		/// the name of the reward).
+		/// </summary>
+		public override string Name
+		{
+			get { return "Erinys Charm"; }
+		}
+
+		/// <summary>
+		/// The reward for this quest.
+		/// </summary>
+		private static String m_artifactID = "Erinys Charm";
+		public override String ArtifactID
+		{
+			get { return m_artifactID; }
+		}
+
+		/// <summary>
+		/// Description for the current step.
+		/// </summary>
+		public override string Description
+		{
+			get
+			{
+				switch (Step)
+				{
+					case 1:
+						return "Defeat Samut.";
+					case 2:
+						return "Turn in the completed book.";
+					default:
+						return base.Description;
+				}
+			}
+		}
+
 		public ErinysCharm()
 			: base() { }
 
@@ -52,7 +89,7 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		public static void Init()
 		{
-            ArtifactQuest.Init("Erinys Charm", typeof(ErinysCharm));
+            ArtifactQuest.Init(m_artifactID, typeof(ErinysCharm));
 		}
 
         /// <summary>
@@ -135,42 +172,6 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			}
 
 			return false;
-		}
-
-		/// <summary>
-		/// Description for the current step.
-		/// </summary>
-		public override string Description
-		{
-			get
-			{
-				switch (Step)
-				{
-					case 1:
-						return "Defeat Samut.";
-					case 2:
-						return "Turn in the completed book.";
-					default:
-						return base.Description;
-				}
-			}
-		}
-
-		/// <summary>
-		/// The name of the quest (not necessarily the same as
-		/// the name of the reward).
-		/// </summary>
-		public override string Name
-		{
-            get { return "Erinys Charm"; }
-		}
-
-		/// <summary>
-		/// The reward for this quest.
-		/// </summary>
-		public override String ArtifactID
-		{
-            get { return "Erinys Charm"; }
 		}
 	}
 }

--- a/GameServer/quests/Atlantis/Artifacts/EternalPlant.cs
+++ b/GameServer/quests/Atlantis/Artifacts/EternalPlant.cs
@@ -33,6 +33,43 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 	/// <author>Aredhel</author>
 	class EternalPlant : ArtifactQuest
 	{
+		/// <summary>
+		/// The name of the quest (not necessarily the same as
+		/// the name of the reward).
+		/// </summary>
+		public override string Name
+		{
+			get { return "Eternal Plant"; }
+		}
+
+		/// <summary>
+		/// The reward for this quest.
+		/// </summary>
+		private static String m_artifactID = "Eternal Plant";
+		public override String ArtifactID
+		{
+			get { return m_artifactID; }
+		}
+
+		/// <summary>
+		/// Description for the current step.
+		/// </summary>
+		public override string Description
+		{
+			get
+			{
+				switch (Step)
+				{
+					case 1:
+						return "Defeat Sobekhotep.";
+					case 2:
+						return "Turn in the completed book.";
+					default:
+						return base.Description;
+				}
+			}
+		}
+
 		public EternalPlant()
 			: base() { }
 
@@ -52,7 +89,7 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		public static void Init()
 		{
-            ArtifactQuest.Init("Eternal Plant", typeof(EternalPlant));
+            ArtifactQuest.Init(m_artifactID, typeof(EternalPlant));
 		}
 
         /// <summary>
@@ -135,42 +172,6 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			}
 
 			return false;
-		}
-
-		/// <summary>
-		/// Description for the current step.
-		/// </summary>
-		public override string Description
-		{
-			get
-			{
-				switch (Step)
-				{
-					case 1:
-						return "Defeat Sobekhotep.";
-					case 2:
-						return "Turn in the completed book.";
-					default:
-						return base.Description;
-				}
-			}
-		}
-
-		/// <summary>
-		/// The name of the quest (not necessarily the same as
-		/// the name of the reward).
-		/// </summary>
-		public override string Name
-		{
-            get { return "Eternal Plant"; }
-		}
-
-		/// <summary>
-		/// The reward for this quest.
-		/// </summary>
-		public override String ArtifactID
-		{
-            get { return "Eternal Plant"; }
 		}
 	}
 }

--- a/GameServer/quests/Atlantis/Artifacts/FlamedancersBoots.cs
+++ b/GameServer/quests/Atlantis/Artifacts/FlamedancersBoots.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * DAWN OF LIGHT - The first free open source DAoC server emulator
  * 
  * This program is free software; you can redistribute it and/or
@@ -28,24 +28,26 @@ using System.Collections;
 namespace DOL.GS.Quests.Atlantis.Artifacts
 {
 	/// <summary>
-	/// Quest for the Harpy Feather Cloak artifact.
+	/// Quest for the A Flask artifact.
 	/// </summary>
 	/// <author>Aredhel</author>
-	class HarpyFeatherCloak : ArtifactQuest
+		class FlamedancersBoots : ArtifactQuest
 	{
+		private static int m_requiredLevel = 45;
+
 		/// <summary>
 		/// The name of the quest (not necessarily the same as
 		/// the name of the reward).
 		/// </summary>
-		public override string Name
+		public override String Name
 		{
-			get { return "Harpy Feather Cloak"; }
+			get { return "Flamedancer's Boots"; }
 		}
 
 		/// <summary>
 		/// The reward for this quest.
 		/// </summary>
-		private static String m_artifactID = "Harpy Feather Cloak";
+		private const String m_artifactID = "Flamedancer's Boots";
 		public override String ArtifactID
 		{
 			get { return m_artifactID; }
@@ -60,20 +62,16 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			{
 				switch (Step)
 				{
-					case 1:
-						return "Defeat the Harpies.";
-					case 2:
-						return "Turn in the completed book.";
 					default:
 						return base.Description;
 				}
 			}
 		}
 
-		public HarpyFeatherCloak()
+		public FlamedancersBoots()
 			: base() { }
 
-		public HarpyFeatherCloak(GamePlayer questingPlayer)
+		public FlamedancersBoots(GamePlayer questingPlayer)
 			: base(questingPlayer) { }
 
 		/// <summary>
@@ -81,7 +79,7 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		/// <param name="questingPlayer"></param>
 		/// <param name="dbQuest"></param>
-        public HarpyFeatherCloak(GamePlayer questingPlayer, DBQuest dbQuest)
+		public FlamedancersBoots(GamePlayer questingPlayer, DBQuest dbQuest)
 			: base(questingPlayer, dbQuest) { }
 
 		/// <summary>
@@ -89,22 +87,22 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		public static void Init()
 		{
-            ArtifactQuest.Init(m_artifactID, typeof(HarpyFeatherCloak));
+			ArtifactQuest.Init(m_artifactID, typeof(FlamedancersBoots));
 		}
 
-        /// <summary>
-        /// Check if player is eligible for this quest.
-        /// </summary>
-        /// <param name="player"></param>
-        /// <returns></returns>
-        public override bool CheckQuestQualification(GamePlayer player)
-        {
-            if (!base.CheckQuestQualification(player))
-                return false;
+		/// <summary>
+		/// Check if player is eligible for this quest.
+		/// </summary>
+		/// <param name="player"></param>
+		/// <returns></returns>
+		public override bool CheckQuestQualification(GamePlayer player)
+		{
+			if (!base.CheckQuestQualification(player))
+				return false;
 
-            // TODO: Check if this is the correct level for the quest.
-            return (player.Level >= 45);
-        }
+			// TODO: Check if this is the correct level for the quest.
+			return (player.Level >= m_requiredLevel);
+		}
 
 		/// <summary>
 		/// Handle an item given to the scholar.
@@ -123,18 +121,21 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			if (player == null || scholar == null)
 				return false;
 
-			if (Step == 2 && ArtifactMgr.GetArtifactID(item.Name) == ArtifactID)
+			if (Step > -1 && ArtifactMgr.GetArtifactID(item.Name) == ArtifactID)
 			{
 				Dictionary<String, ItemTemplate> versions = ArtifactMgr.GetArtifactVersions(ArtifactID,
 					(eCharacterClass)player.CharacterClass.ID, (eRealm)player.Realm);
-				
+
 				if (versions.Count > 0 && RemoveItem(player, item))
 				{
 					GiveItem(scholar, player, ArtifactID, versions[";;"]);
-					String reply = String.Format("Brilliant, thank you! Here, take the artifact. {0} {1} {2}",
-						"I've unlocked its powers for you. As I've said before, I'm more interested",
-						"in the stories and the history behind these artifacts than the actual items",
-						"themselves.");
+					String reply = String.Format("Here is the {0}, {1} {2} {3} {4}, {5}!",
+						"restored to its original power. It is a fine item and I wish I could keep",
+						"it, but it is for you and you alone. Do not destroy it because you will never",
+						"have access to its full power again. Take care of it and it shall aid you in",
+						"the trials",
+						ArtifactID,
+						player.CharacterClass.Name);
 					scholar.TurnTo(player);
 					scholar.SayTo(player, eChatLoc.CL_PopupWindow, reply);
 					FinishQuest();
@@ -162,16 +163,25 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			if (player == null || scholar == null)
 				return false;
 
-			if (Step == 1 && text.ToLower() == ArtifactID.ToLower())
+			if (Step > -1 && text.ToLower() == ArtifactID.ToLower())
 			{
-                String reply = "Oh, the mysterious Harpy Feather Cloak. Do you have the scrolls on it? I've found a few that allude to its true nature, but haven't found anything with any detail.";
+				/* Commenting out to give a template for future development
+				String reply = String.Format("Vara was a very skilled healer and she put her skills {0} {1} {2}",
+					"into the Healer's Embrace cloak. It would help me to unlock them if I was to read",
+					"her Medical Log. Please give me Vara's Medical Log now so that I may awaken the",
+					"magic within the Cloak for you.");
 				scholar.TurnTo(player);
 				scholar.SayTo(player, eChatLoc.CL_PopupWindow, reply);
 				Step = 2;
-				return true;
+				return true;*/
 			}
 
 			return false;
+		}
+
+		public override void Notify(DOLEvent e, object sender, EventArgs args)
+		{
+			// Need to do anything here?
 		}
 	}
 }

--- a/GameServer/quests/Atlantis/Artifacts/FoolsBow.cs
+++ b/GameServer/quests/Atlantis/Artifacts/FoolsBow.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * DAWN OF LIGHT - The first free open source DAoC server emulator
  * 
  * This program is free software; you can redistribute it and/or
@@ -28,24 +28,27 @@ using System.Collections;
 namespace DOL.GS.Quests.Atlantis.Artifacts
 {
 	/// <summary>
-	/// Quest for the Harpy Feather Cloak artifact.
+	/// Quest for the A Flask artifact.
 	/// </summary>
 	/// <author>Aredhel</author>
-	class HarpyFeatherCloak : ArtifactQuest
+	class FoolsBow : ArtifactQuest
 	{
+		private static int m_requiredLevel = 45;
+
 		/// <summary>
 		/// The name of the quest (not necessarily the same as
 		/// the name of the reward).
 		/// </summary>
-		public override string Name
+		private const String m_Name = "Fools Bow";
+		public override String Name
 		{
-			get { return "Harpy Feather Cloak"; }
+			get { return m_Name; }
 		}
 
 		/// <summary>
 		/// The reward for this quest.
 		/// </summary>
-		private static String m_artifactID = "Harpy Feather Cloak";
+		private const String m_artifactID = "Fools Bow";
 		public override String ArtifactID
 		{
 			get { return m_artifactID; }
@@ -60,20 +63,16 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			{
 				switch (Step)
 				{
-					case 1:
-						return "Defeat the Harpies.";
-					case 2:
-						return "Turn in the completed book.";
 					default:
 						return base.Description;
 				}
 			}
 		}
 
-		public HarpyFeatherCloak()
+		public FoolsBow()
 			: base() { }
 
-		public HarpyFeatherCloak(GamePlayer questingPlayer)
+		public FoolsBow(GamePlayer questingPlayer)
 			: base(questingPlayer) { }
 
 		/// <summary>
@@ -81,7 +80,7 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		/// <param name="questingPlayer"></param>
 		/// <param name="dbQuest"></param>
-        public HarpyFeatherCloak(GamePlayer questingPlayer, DBQuest dbQuest)
+		public FoolsBow(GamePlayer questingPlayer, DBQuest dbQuest)
 			: base(questingPlayer, dbQuest) { }
 
 		/// <summary>
@@ -89,22 +88,22 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		public static void Init()
 		{
-            ArtifactQuest.Init(m_artifactID, typeof(HarpyFeatherCloak));
+			ArtifactQuest.Init(m_artifactID, typeof(FoolsBow));
 		}
 
-        /// <summary>
-        /// Check if player is eligible for this quest.
-        /// </summary>
-        /// <param name="player"></param>
-        /// <returns></returns>
-        public override bool CheckQuestQualification(GamePlayer player)
-        {
-            if (!base.CheckQuestQualification(player))
-                return false;
+		/// <summary>
+		/// Check if player is eligible for this quest.
+		/// </summary>
+		/// <param name="player"></param>
+		/// <returns></returns>
+		public override bool CheckQuestQualification(GamePlayer player)
+		{
+			if (!base.CheckQuestQualification(player))
+				return false;
 
-            // TODO: Check if this is the correct level for the quest.
-            return (player.Level >= 45);
-        }
+			// TODO: Check if this is the correct level for the quest.
+			return (player.Level >= m_requiredLevel);
+		}
 
 		/// <summary>
 		/// Handle an item given to the scholar.
@@ -123,18 +122,21 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			if (player == null || scholar == null)
 				return false;
 
-			if (Step == 2 && ArtifactMgr.GetArtifactID(item.Name) == ArtifactID)
+			if (Step > -1 && ArtifactMgr.GetArtifactID(item.Name) == ArtifactID)
 			{
 				Dictionary<String, ItemTemplate> versions = ArtifactMgr.GetArtifactVersions(ArtifactID,
 					(eCharacterClass)player.CharacterClass.ID, (eRealm)player.Realm);
-				
+
 				if (versions.Count > 0 && RemoveItem(player, item))
 				{
 					GiveItem(scholar, player, ArtifactID, versions[";;"]);
-					String reply = String.Format("Brilliant, thank you! Here, take the artifact. {0} {1} {2}",
-						"I've unlocked its powers for you. As I've said before, I'm more interested",
-						"in the stories and the history behind these artifacts than the actual items",
-						"themselves.");
+					String reply = String.Format("Here is the {0}, {1} {2} {3} {4}, {5}!",
+						"restored to its original power. It is a fine item and I wish I could keep",
+						"it, but it is for you and you alone. Do not destroy it because you will never",
+						"have access to its full power again. Take care of it and it shall aid you in",
+						"the trials",
+						ArtifactID,
+						player.CharacterClass.Name);
 					scholar.TurnTo(player);
 					scholar.SayTo(player, eChatLoc.CL_PopupWindow, reply);
 					FinishQuest();
@@ -162,16 +164,25 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			if (player == null || scholar == null)
 				return false;
 
-			if (Step == 1 && text.ToLower() == ArtifactID.ToLower())
+			if (Step > -1 && text.ToLower() == ArtifactID.ToLower())
 			{
-                String reply = "Oh, the mysterious Harpy Feather Cloak. Do you have the scrolls on it? I've found a few that allude to its true nature, but haven't found anything with any detail.";
+				/* Commenting out to give a template for future development
+				String reply = String.Format("Vara was a very skilled healer and she put her skills {0} {1} {2}",
+					"into the Healer's Embrace cloak. It would help me to unlock them if I was to read",
+					"her Medical Log. Please give me Vara's Medical Log now so that I may awaken the",
+					"magic within the Cloak for you.");
 				scholar.TurnTo(player);
 				scholar.SayTo(player, eChatLoc.CL_PopupWindow, reply);
 				Step = 2;
-				return true;
+				return true;*/
 			}
 
 			return false;
+		}
+
+		public override void Notify(DOLEvent e, object sender, EventArgs args)
+		{
+			// Need to do anything here?
 		}
 	}
 }

--- a/GameServer/quests/Atlantis/Artifacts/FoppishSleeves.cs
+++ b/GameServer/quests/Atlantis/Artifacts/FoppishSleeves.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * DAWN OF LIGHT - The first free open source DAoC server emulator
  * 
  * This program is free software; you can redistribute it and/or
@@ -28,24 +28,27 @@ using System.Collections;
 namespace DOL.GS.Quests.Atlantis.Artifacts
 {
 	/// <summary>
-	/// Quest for the Harpy Feather Cloak artifact.
+	/// Quest for the A Flask artifact.
 	/// </summary>
 	/// <author>Aredhel</author>
-	class HarpyFeatherCloak : ArtifactQuest
+	class FoppishSleeves : ArtifactQuest
 	{
+		private static int m_requiredLevel = 45;
+
 		/// <summary>
 		/// The name of the quest (not necessarily the same as
 		/// the name of the reward).
 		/// </summary>
-		public override string Name
+		private const String m_Name = "Foppish Sleeves";
+		public override String Name
 		{
-			get { return "Harpy Feather Cloak"; }
+			get { return m_Name; }
 		}
 
 		/// <summary>
 		/// The reward for this quest.
 		/// </summary>
-		private static String m_artifactID = "Harpy Feather Cloak";
+		private const String m_artifactID = "Foppish Sleeves";
 		public override String ArtifactID
 		{
 			get { return m_artifactID; }
@@ -60,20 +63,16 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			{
 				switch (Step)
 				{
-					case 1:
-						return "Defeat the Harpies.";
-					case 2:
-						return "Turn in the completed book.";
 					default:
 						return base.Description;
 				}
 			}
 		}
 
-		public HarpyFeatherCloak()
+		public FoppishSleeves()
 			: base() { }
 
-		public HarpyFeatherCloak(GamePlayer questingPlayer)
+		public FoppishSleeves(GamePlayer questingPlayer)
 			: base(questingPlayer) { }
 
 		/// <summary>
@@ -81,7 +80,7 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		/// <param name="questingPlayer"></param>
 		/// <param name="dbQuest"></param>
-        public HarpyFeatherCloak(GamePlayer questingPlayer, DBQuest dbQuest)
+		public FoppishSleeves(GamePlayer questingPlayer, DBQuest dbQuest)
 			: base(questingPlayer, dbQuest) { }
 
 		/// <summary>
@@ -89,22 +88,22 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		public static void Init()
 		{
-            ArtifactQuest.Init(m_artifactID, typeof(HarpyFeatherCloak));
+			ArtifactQuest.Init(m_artifactID, typeof(FoppishSleeves));
 		}
 
-        /// <summary>
-        /// Check if player is eligible for this quest.
-        /// </summary>
-        /// <param name="player"></param>
-        /// <returns></returns>
-        public override bool CheckQuestQualification(GamePlayer player)
-        {
-            if (!base.CheckQuestQualification(player))
-                return false;
+		/// <summary>
+		/// Check if player is eligible for this quest.
+		/// </summary>
+		/// <param name="player"></param>
+		/// <returns></returns>
+		public override bool CheckQuestQualification(GamePlayer player)
+		{
+			if (!base.CheckQuestQualification(player))
+				return false;
 
-            // TODO: Check if this is the correct level for the quest.
-            return (player.Level >= 45);
-        }
+			// TODO: Check if this is the correct level for the quest.
+			return (player.Level >= m_requiredLevel);
+		}
 
 		/// <summary>
 		/// Handle an item given to the scholar.
@@ -123,18 +122,21 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			if (player == null || scholar == null)
 				return false;
 
-			if (Step == 2 && ArtifactMgr.GetArtifactID(item.Name) == ArtifactID)
+			if (Step > -1 && ArtifactMgr.GetArtifactID(item.Name) == ArtifactID)
 			{
 				Dictionary<String, ItemTemplate> versions = ArtifactMgr.GetArtifactVersions(ArtifactID,
 					(eCharacterClass)player.CharacterClass.ID, (eRealm)player.Realm);
-				
+
 				if (versions.Count > 0 && RemoveItem(player, item))
 				{
 					GiveItem(scholar, player, ArtifactID, versions[";;"]);
-					String reply = String.Format("Brilliant, thank you! Here, take the artifact. {0} {1} {2}",
-						"I've unlocked its powers for you. As I've said before, I'm more interested",
-						"in the stories and the history behind these artifacts than the actual items",
-						"themselves.");
+					String reply = String.Format("Here is the {0}, {1} {2} {3} {4}, {5}!",
+						"restored to its original power. It is a fine item and I wish I could keep",
+						"it, but it is for you and you alone. Do not destroy it because you will never",
+						"have access to its full power again. Take care of it and it shall aid you in",
+						"the trials",
+						ArtifactID,
+						player.CharacterClass.Name);
 					scholar.TurnTo(player);
 					scholar.SayTo(player, eChatLoc.CL_PopupWindow, reply);
 					FinishQuest();
@@ -162,16 +164,25 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			if (player == null || scholar == null)
 				return false;
 
-			if (Step == 1 && text.ToLower() == ArtifactID.ToLower())
+			if (Step > -1 && text.ToLower() == ArtifactID.ToLower())
 			{
-                String reply = "Oh, the mysterious Harpy Feather Cloak. Do you have the scrolls on it? I've found a few that allude to its true nature, but haven't found anything with any detail.";
+				/* Commenting out to give a template for future development
+				String reply = String.Format("Vara was a very skilled healer and she put her skills {0} {1} {2}",
+					"into the Healer's Embrace cloak. It would help me to unlock them if I was to read",
+					"her Medical Log. Please give me Vara's Medical Log now so that I may awaken the",
+					"magic within the Cloak for you.");
 				scholar.TurnTo(player);
 				scholar.SayTo(player, eChatLoc.CL_PopupWindow, reply);
 				Step = 2;
-				return true;
+				return true;*/
 			}
 
 			return false;
+		}
+
+		public override void Notify(DOLEvent e, object sender, EventArgs args)
+		{
+			// Need to do anything here?
 		}
 	}
 }

--- a/GameServer/quests/Atlantis/Artifacts/GemofLostMemories.cs
+++ b/GameServer/quests/Atlantis/Artifacts/GemofLostMemories.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * DAWN OF LIGHT - The first free open source DAoC server emulator
  * 
  * This program is free software; you can redistribute it and/or
@@ -28,24 +28,26 @@ using System.Collections;
 namespace DOL.GS.Quests.Atlantis.Artifacts
 {
 	/// <summary>
-	/// Quest for the Harpy Feather Cloak artifact.
+	/// Quest for the A Flask artifact.
 	/// </summary>
 	/// <author>Aredhel</author>
-	class HarpyFeatherCloak : ArtifactQuest
+	class GemofLostMemories : ArtifactQuest
 	{
+		private static int m_requiredLevel = 30;
+
 		/// <summary>
 		/// The name of the quest (not necessarily the same as
 		/// the name of the reward).
 		/// </summary>
-		public override string Name
+		public override String Name
 		{
-			get { return "Harpy Feather Cloak"; }
+			get { return "Gem of Lost Memories"; }
 		}
 
 		/// <summary>
 		/// The reward for this quest.
 		/// </summary>
-		private static String m_artifactID = "Harpy Feather Cloak";
+		private const String m_artifactID = "Gem of Lost Memories";
 		public override String ArtifactID
 		{
 			get { return m_artifactID; }
@@ -60,20 +62,16 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			{
 				switch (Step)
 				{
-					case 1:
-						return "Defeat the Harpies.";
-					case 2:
-						return "Turn in the completed book.";
 					default:
 						return base.Description;
 				}
 			}
 		}
 
-		public HarpyFeatherCloak()
+		public GemofLostMemories()
 			: base() { }
 
-		public HarpyFeatherCloak(GamePlayer questingPlayer)
+		public GemofLostMemories(GamePlayer questingPlayer)
 			: base(questingPlayer) { }
 
 		/// <summary>
@@ -81,7 +79,7 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		/// <param name="questingPlayer"></param>
 		/// <param name="dbQuest"></param>
-        public HarpyFeatherCloak(GamePlayer questingPlayer, DBQuest dbQuest)
+		public GemofLostMemories(GamePlayer questingPlayer, DBQuest dbQuest)
 			: base(questingPlayer, dbQuest) { }
 
 		/// <summary>
@@ -89,22 +87,22 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		public static void Init()
 		{
-            ArtifactQuest.Init(m_artifactID, typeof(HarpyFeatherCloak));
+			ArtifactQuest.Init(m_artifactID, typeof(GemofLostMemories));
 		}
 
-        /// <summary>
-        /// Check if player is eligible for this quest.
-        /// </summary>
-        /// <param name="player"></param>
-        /// <returns></returns>
-        public override bool CheckQuestQualification(GamePlayer player)
-        {
-            if (!base.CheckQuestQualification(player))
-                return false;
+		/// <summary>
+		/// Check if player is eligible for this quest.
+		/// </summary>
+		/// <param name="player"></param>
+		/// <returns></returns>
+		public override bool CheckQuestQualification(GamePlayer player)
+		{
+			if (!base.CheckQuestQualification(player))
+				return false;
 
-            // TODO: Check if this is the correct level for the quest.
-            return (player.Level >= 45);
-        }
+			// TODO: Check if this is the correct level for the quest.
+			return (player.Level >= m_requiredLevel);
+		}
 
 		/// <summary>
 		/// Handle an item given to the scholar.
@@ -123,18 +121,21 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			if (player == null || scholar == null)
 				return false;
 
-			if (Step == 2 && ArtifactMgr.GetArtifactID(item.Name) == ArtifactID)
+			if (Step > -1 && ArtifactMgr.GetArtifactID(item.Name) == ArtifactID)
 			{
 				Dictionary<String, ItemTemplate> versions = ArtifactMgr.GetArtifactVersions(ArtifactID,
 					(eCharacterClass)player.CharacterClass.ID, (eRealm)player.Realm);
-				
+
 				if (versions.Count > 0 && RemoveItem(player, item))
 				{
 					GiveItem(scholar, player, ArtifactID, versions[";;"]);
-					String reply = String.Format("Brilliant, thank you! Here, take the artifact. {0} {1} {2}",
-						"I've unlocked its powers for you. As I've said before, I'm more interested",
-						"in the stories and the history behind these artifacts than the actual items",
-						"themselves.");
+					String reply = String.Format("Here is the {0}, {1} {2} {3} {4}, {5}!",
+						"restored to its original power. It is a fine item and I wish I could keep",
+						"it, but it is for you and you alone. Do not destroy it because you will never",
+						"have access to its full power again. Take care of it and it shall aid you in",
+						"the trials",
+						ArtifactID,
+						player.CharacterClass.Name);
 					scholar.TurnTo(player);
 					scholar.SayTo(player, eChatLoc.CL_PopupWindow, reply);
 					FinishQuest();
@@ -162,16 +163,25 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			if (player == null || scholar == null)
 				return false;
 
-			if (Step == 1 && text.ToLower() == ArtifactID.ToLower())
+			if (Step > -1 && text.ToLower() == ArtifactID.ToLower())
 			{
-                String reply = "Oh, the mysterious Harpy Feather Cloak. Do you have the scrolls on it? I've found a few that allude to its true nature, but haven't found anything with any detail.";
+				/* Commenting out to give a template for future development
+				String reply = String.Format("Vara was a very skilled healer and she put her skills {0} {1} {2}",
+					"into the Healer's Embrace cloak. It would help me to unlock them if I was to read",
+					"her Medical Log. Please give me Vara's Medical Log now so that I may awaken the",
+					"magic within the Cloak for you.");
 				scholar.TurnTo(player);
 				scholar.SayTo(player, eChatLoc.CL_PopupWindow, reply);
 				Step = 2;
-				return true;
+				return true;*/
 			}
 
 			return false;
+		}
+
+		public override void Notify(DOLEvent e, object sender, EventArgs args)
+		{
+			// Need to do anything here?
 		}
 	}
 }

--- a/GameServer/quests/Atlantis/Artifacts/GoddessNecklace.cs
+++ b/GameServer/quests/Atlantis/Artifacts/GoddessNecklace.cs
@@ -33,6 +33,43 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 	/// <author>Aredhel</author>
 	class GoddessNecklace : ArtifactQuest
 	{
+		/// <summary>
+		/// The name of the quest (not necessarily the same as
+		/// the name of the reward).
+		/// </summary>
+		public override string Name
+		{
+			get { return "Goddess Necklace"; }
+		}
+
+		/// <summary>
+		/// The reward for this quest.
+		/// </summary>
+		private static String m_artifactID = "Goddess Necklace";
+		public override String ArtifactID
+		{
+			get { return m_artifactID; }
+		}
+
+		/// <summary>
+		/// Description for the current step.
+		/// </summary>
+		public override string Description
+		{
+			get
+			{
+				switch (Step)
+				{
+					case 1:
+						return "Keep the sister alive and get the treasure.";
+					case 2:
+						return "Turn in the completed book.";
+					default:
+						return base.Description;
+				}
+			}
+		}
+
 		public GoddessNecklace()
 			: base() { }
 
@@ -52,7 +89,7 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		public static void Init()
 		{
-            ArtifactQuest.Init("Goddess Necklace", typeof(GoddessNecklace));
+            ArtifactQuest.Init(m_artifactID, typeof(GoddessNecklace));
 		}
 
         /// <summary>
@@ -135,42 +172,6 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			}
 
 			return false;
-		}
-
-		/// <summary>
-		/// Description for the current step.
-		/// </summary>
-		public override string Description
-		{
-			get
-			{
-				switch (Step)
-				{
-					case 1:
-						return "Keep the sister alive and get the treasure.";
-					case 2:
-						return "Turn in the completed book.";
-					default:
-						return base.Description;
-				}
-			}
-		}
-
-		/// <summary>
-		/// The name of the quest (not necessarily the same as
-		/// the name of the reward).
-		/// </summary>
-		public override string Name
-		{
-            get { return "Goddess Necklace"; }
-		}
-
-		/// <summary>
-		/// The reward for this quest.
-		/// </summary>
-		public override String ArtifactID
-		{
-            get { return "Goddess Necklace"; }
 		}
 	}
 }

--- a/GameServer/quests/Atlantis/Artifacts/GoldenScarabVest.cs
+++ b/GameServer/quests/Atlantis/Artifacts/GoldenScarabVest.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * DAWN OF LIGHT - The first free open source DAoC server emulator
  * 
  * This program is free software; you can redistribute it and/or
@@ -28,24 +28,26 @@ using System.Collections;
 namespace DOL.GS.Quests.Atlantis.Artifacts
 {
 	/// <summary>
-	/// Quest for the Harpy Feather Cloak artifact.
+	/// Quest for the A Flask artifact.
 	/// </summary>
 	/// <author>Aredhel</author>
-	class HarpyFeatherCloak : ArtifactQuest
+	class GoldenScarabVest : ArtifactQuest
 	{
+		private static int m_requiredLevel = 45;
+
 		/// <summary>
 		/// The name of the quest (not necessarily the same as
 		/// the name of the reward).
 		/// </summary>
-		public override string Name
+		public override String Name
 		{
-			get { return "Harpy Feather Cloak"; }
+			get { return "Golden Scarab Vest"; }
 		}
 
 		/// <summary>
 		/// The reward for this quest.
 		/// </summary>
-		private static String m_artifactID = "Harpy Feather Cloak";
+		private const String m_artifactID = "Golden Scarab Vest";
 		public override String ArtifactID
 		{
 			get { return m_artifactID; }
@@ -60,20 +62,16 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			{
 				switch (Step)
 				{
-					case 1:
-						return "Defeat the Harpies.";
-					case 2:
-						return "Turn in the completed book.";
 					default:
 						return base.Description;
 				}
 			}
 		}
 
-		public HarpyFeatherCloak()
+		public GoldenScarabVest()
 			: base() { }
 
-		public HarpyFeatherCloak(GamePlayer questingPlayer)
+		public GoldenScarabVest(GamePlayer questingPlayer)
 			: base(questingPlayer) { }
 
 		/// <summary>
@@ -81,7 +79,7 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		/// <param name="questingPlayer"></param>
 		/// <param name="dbQuest"></param>
-        public HarpyFeatherCloak(GamePlayer questingPlayer, DBQuest dbQuest)
+		public GoldenScarabVest(GamePlayer questingPlayer, DBQuest dbQuest)
 			: base(questingPlayer, dbQuest) { }
 
 		/// <summary>
@@ -89,22 +87,22 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		public static void Init()
 		{
-            ArtifactQuest.Init(m_artifactID, typeof(HarpyFeatherCloak));
+			ArtifactQuest.Init(m_artifactID, typeof(GoldenScarabVest));
 		}
 
-        /// <summary>
-        /// Check if player is eligible for this quest.
-        /// </summary>
-        /// <param name="player"></param>
-        /// <returns></returns>
-        public override bool CheckQuestQualification(GamePlayer player)
-        {
-            if (!base.CheckQuestQualification(player))
-                return false;
+		/// <summary>
+		/// Check if player is eligible for this quest.
+		/// </summary>
+		/// <param name="player"></param>
+		/// <returns></returns>
+		public override bool CheckQuestQualification(GamePlayer player)
+		{
+			if (!base.CheckQuestQualification(player))
+				return false;
 
-            // TODO: Check if this is the correct level for the quest.
-            return (player.Level >= 45);
-        }
+			// TODO: Check if this is the correct level for the quest.
+			return (player.Level >= m_requiredLevel);
+		}
 
 		/// <summary>
 		/// Handle an item given to the scholar.
@@ -123,18 +121,21 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			if (player == null || scholar == null)
 				return false;
 
-			if (Step == 2 && ArtifactMgr.GetArtifactID(item.Name) == ArtifactID)
+			if (Step > -1 && ArtifactMgr.GetArtifactID(item.Name) == ArtifactID)
 			{
 				Dictionary<String, ItemTemplate> versions = ArtifactMgr.GetArtifactVersions(ArtifactID,
 					(eCharacterClass)player.CharacterClass.ID, (eRealm)player.Realm);
-				
+
 				if (versions.Count > 0 && RemoveItem(player, item))
 				{
 					GiveItem(scholar, player, ArtifactID, versions[";;"]);
-					String reply = String.Format("Brilliant, thank you! Here, take the artifact. {0} {1} {2}",
-						"I've unlocked its powers for you. As I've said before, I'm more interested",
-						"in the stories and the history behind these artifacts than the actual items",
-						"themselves.");
+					String reply = String.Format("Here is the {0}, {1} {2} {3} {4}, {5}!",
+						"restored to its original power. It is a fine item and I wish I could keep",
+						"it, but it is for you and you alone. Do not destroy it because you will never",
+						"have access to its full power again. Take care of it and it shall aid you in",
+						"the trials",
+						ArtifactID,
+						player.CharacterClass.Name);
 					scholar.TurnTo(player);
 					scholar.SayTo(player, eChatLoc.CL_PopupWindow, reply);
 					FinishQuest();
@@ -162,16 +163,25 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			if (player == null || scholar == null)
 				return false;
 
-			if (Step == 1 && text.ToLower() == ArtifactID.ToLower())
+			if (Step > -1 && text.ToLower() == ArtifactID.ToLower())
 			{
-                String reply = "Oh, the mysterious Harpy Feather Cloak. Do you have the scrolls on it? I've found a few that allude to its true nature, but haven't found anything with any detail.";
+				/* Commenting out to give a template for future development
+				String reply = String.Format("Vara was a very skilled healer and she put her skills {0} {1} {2}",
+					"into the Healer's Embrace cloak. It would help me to unlock them if I was to read",
+					"her Medical Log. Please give me Vara's Medical Log now so that I may awaken the",
+					"magic within the Cloak for you.");
 				scholar.TurnTo(player);
 				scholar.SayTo(player, eChatLoc.CL_PopupWindow, reply);
 				Step = 2;
-				return true;
+				return true;*/
 			}
 
 			return false;
+		}
+
+		public override void Notify(DOLEvent e, object sender, EventArgs args)
+		{
+			// Need to do anything here?
 		}
 	}
 }

--- a/GameServer/quests/Atlantis/Artifacts/GoldenSpear.cs
+++ b/GameServer/quests/Atlantis/Artifacts/GoldenSpear.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * DAWN OF LIGHT - The first free open source DAoC server emulator
  * 
  * This program is free software; you can redistribute it and/or
@@ -28,24 +28,26 @@ using System.Collections;
 namespace DOL.GS.Quests.Atlantis.Artifacts
 {
 	/// <summary>
-	/// Quest for the Harpy Feather Cloak artifact.
+	/// Quest for the A Flask artifact.
 	/// </summary>
 	/// <author>Aredhel</author>
-	class HarpyFeatherCloak : ArtifactQuest
+	class GoldenSpear : ArtifactQuest
 	{
+		private static int m_requiredLevel = 45;
+
 		/// <summary>
 		/// The name of the quest (not necessarily the same as
 		/// the name of the reward).
 		/// </summary>
-		public override string Name
+		public override String Name
 		{
-			get { return "Harpy Feather Cloak"; }
+			get { return "Golden Spear"; }
 		}
 
 		/// <summary>
 		/// The reward for this quest.
 		/// </summary>
-		private static String m_artifactID = "Harpy Feather Cloak";
+		private const String m_artifactID = "Golden Spear";
 		public override String ArtifactID
 		{
 			get { return m_artifactID; }
@@ -60,20 +62,16 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			{
 				switch (Step)
 				{
-					case 1:
-						return "Defeat the Harpies.";
-					case 2:
-						return "Turn in the completed book.";
 					default:
 						return base.Description;
 				}
 			}
 		}
 
-		public HarpyFeatherCloak()
+		public GoldenSpear()
 			: base() { }
 
-		public HarpyFeatherCloak(GamePlayer questingPlayer)
+		public GoldenSpear(GamePlayer questingPlayer)
 			: base(questingPlayer) { }
 
 		/// <summary>
@@ -81,7 +79,7 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		/// <param name="questingPlayer"></param>
 		/// <param name="dbQuest"></param>
-        public HarpyFeatherCloak(GamePlayer questingPlayer, DBQuest dbQuest)
+		public GoldenSpear(GamePlayer questingPlayer, DBQuest dbQuest)
 			: base(questingPlayer, dbQuest) { }
 
 		/// <summary>
@@ -89,22 +87,22 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		public static void Init()
 		{
-            ArtifactQuest.Init(m_artifactID, typeof(HarpyFeatherCloak));
+			ArtifactQuest.Init(m_artifactID, typeof(GoldenSpear));
 		}
 
-        /// <summary>
-        /// Check if player is eligible for this quest.
-        /// </summary>
-        /// <param name="player"></param>
-        /// <returns></returns>
-        public override bool CheckQuestQualification(GamePlayer player)
-        {
-            if (!base.CheckQuestQualification(player))
-                return false;
+		/// <summary>
+		/// Check if player is eligible for this quest.
+		/// </summary>
+		/// <param name="player"></param>
+		/// <returns></returns>
+		public override bool CheckQuestQualification(GamePlayer player)
+		{
+			if (!base.CheckQuestQualification(player))
+				return false;
 
-            // TODO: Check if this is the correct level for the quest.
-            return (player.Level >= 45);
-        }
+			// TODO: Check if this is the correct level for the quest.
+			return (player.Level >= m_requiredLevel);
+		}
 
 		/// <summary>
 		/// Handle an item given to the scholar.
@@ -123,18 +121,21 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			if (player == null || scholar == null)
 				return false;
 
-			if (Step == 2 && ArtifactMgr.GetArtifactID(item.Name) == ArtifactID)
+			if (Step > -1 && ArtifactMgr.GetArtifactID(item.Name) == ArtifactID)
 			{
 				Dictionary<String, ItemTemplate> versions = ArtifactMgr.GetArtifactVersions(ArtifactID,
 					(eCharacterClass)player.CharacterClass.ID, (eRealm)player.Realm);
-				
+
 				if (versions.Count > 0 && RemoveItem(player, item))
 				{
 					GiveItem(scholar, player, ArtifactID, versions[";;"]);
-					String reply = String.Format("Brilliant, thank you! Here, take the artifact. {0} {1} {2}",
-						"I've unlocked its powers for you. As I've said before, I'm more interested",
-						"in the stories and the history behind these artifacts than the actual items",
-						"themselves.");
+					String reply = String.Format("Here is the {0}, {1} {2} {3} {4}, {5}!",
+						"restored to its original power. It is a fine item and I wish I could keep",
+						"it, but it is for you and you alone. Do not destroy it because you will never",
+						"have access to its full power again. Take care of it and it shall aid you in",
+						"the trials",
+						ArtifactID,
+						player.CharacterClass.Name);
 					scholar.TurnTo(player);
 					scholar.SayTo(player, eChatLoc.CL_PopupWindow, reply);
 					FinishQuest();
@@ -162,16 +163,25 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			if (player == null || scholar == null)
 				return false;
 
-			if (Step == 1 && text.ToLower() == ArtifactID.ToLower())
+			if (Step > -1 && text.ToLower() == ArtifactID.ToLower())
 			{
-                String reply = "Oh, the mysterious Harpy Feather Cloak. Do you have the scrolls on it? I've found a few that allude to its true nature, but haven't found anything with any detail.";
+				/* Commenting out to give a template for future development
+				String reply = String.Format("Vara was a very skilled healer and she put her skills {0} {1} {2}",
+					"into the Healer's Embrace cloak. It would help me to unlock them if I was to read",
+					"her Medical Log. Please give me Vara's Medical Log now so that I may awaken the",
+					"magic within the Cloak for you.");
 				scholar.TurnTo(player);
 				scholar.SayTo(player, eChatLoc.CL_PopupWindow, reply);
 				Step = 2;
-				return true;
+				return true;*/
 			}
 
 			return false;
+		}
+
+		public override void Notify(DOLEvent e, object sender, EventArgs args)
+		{
+			// Need to do anything here?
 		}
 	}
 }

--- a/GameServer/quests/Atlantis/Artifacts/GuardOfValor.cs
+++ b/GameServer/quests/Atlantis/Artifacts/GuardOfValor.cs
@@ -36,6 +36,44 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 	public class GuardOfValor : ArtifactQuest
 	{
 		/// <summary>
+		/// The name of the quest (not necessarily the same as
+		/// the name of the reward).
+		/// </summary>
+		public override string Name
+		{
+			get { return "A Gift of Love"; }
+		}
+
+		/// <summary>
+		/// The artifact ID.
+		/// </summary>
+		private static String m_artifactID = "Guard of Valor";
+		public override String ArtifactID
+		{
+			get { return m_artifactID; }
+		}
+
+		/// <summary>
+		/// Description for the current step.
+		/// </summary>
+		public override string Description
+		{
+			get
+			{
+				switch (Step)
+				{
+					case 1:
+						return "Defeat Danos.";
+					case 2:
+						// TODO: Get correct description.
+						return "Turn in the complete Love Story.";
+					default:
+						return base.Description;
+				}
+			}
+		}
+
+		/// <summary>
 		/// Defines a logger for this class.
 		/// </summary>
 		private static readonly ILog log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
@@ -53,8 +91,6 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// <param name="dbQuest"></param>
 		public GuardOfValor(GamePlayer questingPlayer, DBQuest dbQuest)
 			: base(questingPlayer, dbQuest) { }
-
-		private static String m_artifactID = "Guard of Valor";
 
 		/// <summary>
 		/// Quest initialisation.
@@ -154,43 +190,6 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			}
 
 			return false;
-		}
-
-		/// <summary>
-		/// Description for the current step.
-		/// </summary>
-		public override string Description
-		{
-			get
-			{
-				switch (Step)
-				{
-					case 1:
-						return "Defeat Danos.";
-					case 2 :
-						// TODO: Get correct description.
-						return "Turn in the complete Love Story.";
-					default :
-						return base.Description;
-				}
-			}
-		}
-
-		/// <summary>
-		/// The name of the quest (not necessarily the same as
-		/// the name of the reward).
-		/// </summary>
-		public override string Name
-		{
-			get { return "A Gift of Love"; }
-		}
-
-		/// <summary>
-		/// The artifact ID.
-		/// </summary>
-		public override String ArtifactID
-		{
-			get { return m_artifactID; }
 		}
 	}
 }

--- a/GameServer/quests/Atlantis/Artifacts/JacinasSash.cs
+++ b/GameServer/quests/Atlantis/Artifacts/JacinasSash.cs
@@ -33,6 +33,43 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 	/// <author>Aredhel</author>
 	class JacinasSash : ArtifactQuest
 	{
+		/// <summary>
+		/// The name of the quest (not necessarily the same as
+		/// the name of the reward).
+		/// </summary>
+		public override string Name
+		{
+			get { return "Jacina's Sash"; }
+		}
+
+		/// <summary>
+		/// The reward for this quest.
+		/// </summary>
+		private static String m_artifactID = "Jacina's Sash";
+		public override String ArtifactID
+		{
+			get { return m_artifactID; }
+		}
+
+		/// <summary>
+		/// Description for the current step.
+		/// </summary>
+		public override string Description
+		{
+			get
+			{
+				switch (Step)
+				{
+					case 1:
+						return "Defeat Cyrek.";
+					case 2:
+						return "Turn in the completed book.";
+					default:
+						return base.Description;
+				}
+			}
+		}
+
 		public JacinasSash()
 			: base() { }
 
@@ -52,7 +89,7 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		public static void Init()
 		{
-            ArtifactQuest.Init("Jacina's Sash", typeof(JacinasSash));
+            ArtifactQuest.Init(m_artifactID, typeof(JacinasSash));
 		}
 
         /// <summary>
@@ -135,42 +172,6 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			}
 
 			return false;
-		}
-
-		/// <summary>
-		/// Description for the current step.
-		/// </summary>
-		public override string Description
-		{
-			get
-			{
-				switch (Step)
-				{
-					case 1:
-						return "Defeat Cyrek.";
-					case 2:
-						return "Turn in the completed book.";
-					default:
-						return base.Description;
-				}
-			}
-		}
-
-		/// <summary>
-		/// The name of the quest (not necessarily the same as
-		/// the name of the reward).
-		/// </summary>
-		public override string Name
-		{
-            get { return "Jacina's Sash"; }
-		}
-
-		/// <summary>
-		/// The reward for this quest.
-		/// </summary>
-		public override String ArtifactID
-		{
-            get { return "Jacina's Sash"; }
 		}
 	}
 }

--- a/GameServer/quests/Atlantis/Artifacts/KalaresNecklace.cs
+++ b/GameServer/quests/Atlantis/Artifacts/KalaresNecklace.cs
@@ -33,6 +33,43 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 	/// <author>Aredhel</author>
 	class KalaresNecklace : ArtifactQuest
 	{
+		/// <summary>
+		/// The name of the quest (not necessarily the same as
+		/// the name of the reward).
+		/// </summary>
+		public override string Name
+		{
+			get { return "Kalare's Necklace"; }
+		}
+
+		/// <summary>
+		/// The reward for this quest.
+		/// </summary>
+		private static String m_artifactID = "Kalare's Necklace";
+		public override String ArtifactID
+		{
+			get { return m_artifactID; }
+		}
+
+		/// <summary>
+		/// Description for the current step.
+		/// </summary>
+		public override string Description
+		{
+			get
+			{
+				switch (Step)
+				{
+					case 1:
+						return "Defeat the Warrior of Stone and escape with the necklace.";
+					case 2:
+						return "Turn in the completed book.";
+					default:
+						return base.Description;
+				}
+			}
+		}
+
 		public KalaresNecklace()
 			: base() { }
 
@@ -52,7 +89,7 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		public static void Init()
 		{
-            ArtifactQuest.Init("Kalare's Necklace", typeof(KalaresNecklace));
+            ArtifactQuest.Init(m_artifactID, typeof(KalaresNecklace));
 		}
 
         /// <summary>
@@ -135,42 +172,6 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			}
 
 			return false;
-		}
-
-		/// <summary>
-		/// Description for the current step.
-		/// </summary>
-		public override string Description
-		{
-			get
-			{
-				switch (Step)
-				{
-					case 1:
-						return "Defeat the Warrior of Stone and escape with the necklace.";
-					case 2:
-						return "Turn in the completed book.";
-					default:
-						return base.Description;
-				}
-			}
-		}
-
-		/// <summary>
-		/// The name of the quest (not necessarily the same as
-		/// the name of the reward).
-		/// </summary>
-		public override string Name
-		{
-            get { return "Kalare's Necklace"; }
-		}
-
-		/// <summary>
-		/// The reward for this quest.
-		/// </summary>
-		public override String ArtifactID
-		{
-            get { return "Kalare's Necklace"; }
 		}
 	}
 }

--- a/GameServer/quests/Atlantis/Artifacts/MaddeningScalars.cs
+++ b/GameServer/quests/Atlantis/Artifacts/MaddeningScalars.cs
@@ -31,7 +31,44 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
     /// <author>Aredhel</author>
     public class MaddeningScalars : ArtifactQuest
     {
-        public MaddeningScalars()
+		/// <summary>
+		/// The name of the quest (not necessarily the same as
+		/// the name of the reward).
+		/// </summary>
+		public override string Name
+		{
+			get { return "Maddening Scalars"; }
+		}
+
+		/// <summary>
+		/// The reward for this quest.
+		/// </summary>
+		private static String m_artifactID = "Maddening Scalars";
+		public override String ArtifactID
+		{
+			get { return m_artifactID; }
+		}
+
+		/// <summary>
+		/// Description for the current step.
+		/// </summary>
+		public override string Description
+		{
+			get
+			{
+				switch (Step)
+				{
+					case 1:
+						return "Defeat Ylyssan.";
+					case 2:
+						return "Turn in the completed book.";
+					default:
+						return base.Description;
+				}
+			}
+		}
+
+		public MaddeningScalars()
 			: base() { }
 
 		public MaddeningScalars(GamePlayer questingPlayer)
@@ -50,7 +87,7 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		public static void Init()
 		{
-            ArtifactQuest.Init("Maddening Scalars", typeof(MaddeningScalars));
+            ArtifactQuest.Init(m_artifactID, typeof(MaddeningScalars));
 		}
 
         /// <summary>
@@ -134,42 +171,6 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			}
 
 			return false;
-		}
-
-		/// <summary>
-		/// Description for the current step.
-		/// </summary>
-		public override string Description
-		{
-			get
-			{
-				switch (Step)
-				{
-					case 1:
-						return "Defeat Ylyssan.";
-					case 2:
-						return "Turn in the completed book.";
-					default:
-						return base.Description;
-				}
-			}
-		}
-
-		/// <summary>
-		/// The name of the quest (not necessarily the same as
-		/// the name of the reward).
-		/// </summary>
-		public override string Name
-		{
-            get { return "Maddening Scalars"; }
-		}
-
-		/// <summary>
-		/// The reward for this quest.
-		/// </summary>
-		public override String ArtifactID
-		{
-            get { return "Maddening Scalars"; }
 		}
     }
 }

--- a/GameServer/quests/Atlantis/Artifacts/MalicesAxe.cs
+++ b/GameServer/quests/Atlantis/Artifacts/MalicesAxe.cs
@@ -36,6 +36,47 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 	public class MalicesAxe : ArtifactQuest
 	{
 		/// <summary>
+		/// The name of the quest (not necessarily the same as
+		/// the name of the reward).
+		/// </summary>
+		public override string Name
+		{
+			get { return "Malice's Axe"; }
+		}
+
+		/// <summary>
+		/// The artifact ID.
+		/// </summary>
+		private static String m_artifactID = "Malice's Axe";
+		public override String ArtifactID
+		{
+			get { return m_artifactID; }
+		}
+
+		/// <summary>
+		/// Description for the current step.
+		/// </summary>
+		public override string Description
+		{
+			get
+			{
+				switch (Step)
+				{
+					case 1:
+						return "Defeat Malamis.";
+					case 2:
+						return "Turn in the completed book.";
+					case 3:
+						return "Choose between a [slashing] version of Malice's Axe or a [crushing] one. Both one-handed and two-handed versions are available for both.";
+					case 4:
+						return "Choose between one handed or two handed versions.";
+					default:
+						return base.Description;
+				}
+			}
+		}
+
+		/// <summary>
 		/// Defines a logger for this class.
 		/// </summary>
 		private static readonly ILog log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
@@ -53,8 +94,6 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// <param name="dbQuest"></param>
 		public MalicesAxe(GamePlayer questingPlayer, DBQuest dbQuest)
 			: base(questingPlayer, dbQuest) { }
-
-		private static String m_artifactID = "Malice's Axe";
 
 		/// <summary>
 		/// Quest initialisation.
@@ -194,46 +233,6 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			}
 
 			return false;
-		}
-
-		/// <summary>
-		/// Description for the current step.
-		/// </summary>
-		public override string Description
-		{
-			get
-			{
-				switch (Step)
-				{
-					case 1:
-						return "Defeat Malamis.";
-					case 2:
-						return "Turn in the completed book.";
-					case 3:
-						return "Choose between a [slashing] version of Malice's Axe or a [crushing] one. Both one-handed and two-handed versions are available for both.";
-					case 4:
-						return "Choose between one handed or two handed versions.";
-					default:
-						return base.Description;
-				}
-			}
-		}
-
-		/// <summary>
-		/// The name of the quest (not necessarily the same as
-		/// the name of the reward).
-		/// </summary>
-		public override string Name
-		{
-			get { return "Malice's Axe"; }
-		}
-
-		/// <summary>
-		/// The artifact ID.
-		/// </summary>
-		public override String ArtifactID
-		{
-			get { return m_artifactID; }
 		}
 	}
 }

--- a/GameServer/quests/Atlantis/Artifacts/MariashasSharkskinGloves.cs
+++ b/GameServer/quests/Atlantis/Artifacts/MariashasSharkskinGloves.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * DAWN OF LIGHT - The first free open source DAoC server emulator
  * 
  * This program is free software; you can redistribute it and/or
@@ -28,24 +28,26 @@ using System.Collections;
 namespace DOL.GS.Quests.Atlantis.Artifacts
 {
 	/// <summary>
-	/// Quest for the Harpy Feather Cloak artifact.
+	/// Quest for the A Flask artifact.
 	/// </summary>
 	/// <author>Aredhel</author>
-	class HarpyFeatherCloak : ArtifactQuest
+	class MariashasSharkskinGloves : ArtifactQuest
 	{
+		private static int m_requiredLevel = 40;
+
 		/// <summary>
 		/// The name of the quest (not necessarily the same as
 		/// the name of the reward).
 		/// </summary>
-		public override string Name
+		public override String Name
 		{
-			get { return "Harpy Feather Cloak"; }
+			get { return "Mariasha's Sharkskin Gloves"; }
 		}
 
 		/// <summary>
 		/// The reward for this quest.
 		/// </summary>
-		private static String m_artifactID = "Harpy Feather Cloak";
+		private const String m_artifactID = "Mariasha's Sharkskin Gloves";
 		public override String ArtifactID
 		{
 			get { return m_artifactID; }
@@ -60,20 +62,16 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			{
 				switch (Step)
 				{
-					case 1:
-						return "Defeat the Harpies.";
-					case 2:
-						return "Turn in the completed book.";
 					default:
 						return base.Description;
 				}
 			}
 		}
 
-		public HarpyFeatherCloak()
+		public MariashasSharkskinGloves()
 			: base() { }
 
-		public HarpyFeatherCloak(GamePlayer questingPlayer)
+		public MariashasSharkskinGloves(GamePlayer questingPlayer)
 			: base(questingPlayer) { }
 
 		/// <summary>
@@ -81,7 +79,7 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		/// <param name="questingPlayer"></param>
 		/// <param name="dbQuest"></param>
-        public HarpyFeatherCloak(GamePlayer questingPlayer, DBQuest dbQuest)
+		public MariashasSharkskinGloves(GamePlayer questingPlayer, DBQuest dbQuest)
 			: base(questingPlayer, dbQuest) { }
 
 		/// <summary>
@@ -89,22 +87,22 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		public static void Init()
 		{
-            ArtifactQuest.Init(m_artifactID, typeof(HarpyFeatherCloak));
+			ArtifactQuest.Init(m_artifactID, typeof(MariashasSharkskinGloves));
 		}
 
-        /// <summary>
-        /// Check if player is eligible for this quest.
-        /// </summary>
-        /// <param name="player"></param>
-        /// <returns></returns>
-        public override bool CheckQuestQualification(GamePlayer player)
-        {
-            if (!base.CheckQuestQualification(player))
-                return false;
+		/// <summary>
+		/// Check if player is eligible for this quest.
+		/// </summary>
+		/// <param name="player"></param>
+		/// <returns></returns>
+		public override bool CheckQuestQualification(GamePlayer player)
+		{
+			if (!base.CheckQuestQualification(player))
+				return false;
 
-            // TODO: Check if this is the correct level for the quest.
-            return (player.Level >= 45);
-        }
+			// TODO: Check if this is the correct level for the quest.
+			return (player.Level >= m_requiredLevel);
+		}
 
 		/// <summary>
 		/// Handle an item given to the scholar.
@@ -123,18 +121,21 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			if (player == null || scholar == null)
 				return false;
 
-			if (Step == 2 && ArtifactMgr.GetArtifactID(item.Name) == ArtifactID)
+			if (Step > -1 && ArtifactMgr.GetArtifactID(item.Name) == ArtifactID)
 			{
 				Dictionary<String, ItemTemplate> versions = ArtifactMgr.GetArtifactVersions(ArtifactID,
 					(eCharacterClass)player.CharacterClass.ID, (eRealm)player.Realm);
-				
+
 				if (versions.Count > 0 && RemoveItem(player, item))
 				{
 					GiveItem(scholar, player, ArtifactID, versions[";;"]);
-					String reply = String.Format("Brilliant, thank you! Here, take the artifact. {0} {1} {2}",
-						"I've unlocked its powers for you. As I've said before, I'm more interested",
-						"in the stories and the history behind these artifacts than the actual items",
-						"themselves.");
+					String reply = String.Format("Here is the {0}, {1} {2} {3} {4}, {5}!",
+						"restored to its original power. It is a fine item and I wish I could keep",
+						"it, but it is for you and you alone. Do not destroy it because you will never",
+						"have access to its full power again. Take care of it and it shall aid you in",
+						"the trials",
+						ArtifactID,
+						player.CharacterClass.Name);
 					scholar.TurnTo(player);
 					scholar.SayTo(player, eChatLoc.CL_PopupWindow, reply);
 					FinishQuest();
@@ -162,16 +163,25 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			if (player == null || scholar == null)
 				return false;
 
-			if (Step == 1 && text.ToLower() == ArtifactID.ToLower())
+			if (Step > -1 && text.ToLower() == ArtifactID.ToLower())
 			{
-                String reply = "Oh, the mysterious Harpy Feather Cloak. Do you have the scrolls on it? I've found a few that allude to its true nature, but haven't found anything with any detail.";
+				/* Commenting out to give a template for future development
+				String reply = String.Format("Vara was a very skilled healer and she put her skills {0} {1} {2}",
+					"into the Healer's Embrace cloak. It would help me to unlock them if I was to read",
+					"her Medical Log. Please give me Vara's Medical Log now so that I may awaken the",
+					"magic within the Cloak for you.");
 				scholar.TurnTo(player);
 				scholar.SayTo(player, eChatLoc.CL_PopupWindow, reply);
 				Step = 2;
-				return true;
+				return true;*/
 			}
 
 			return false;
+		}
+
+		public override void Notify(DOLEvent e, object sender, EventArgs args)
+		{
+			// Need to do anything here?
 		}
 	}
 }

--- a/GameServer/quests/Atlantis/Artifacts/NailahsRobes.cs
+++ b/GameServer/quests/Atlantis/Artifacts/NailahsRobes.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * DAWN OF LIGHT - The first free open source DAoC server emulator
  * 
  * This program is free software; you can redistribute it and/or
@@ -28,24 +28,26 @@ using System.Collections;
 namespace DOL.GS.Quests.Atlantis.Artifacts
 {
 	/// <summary>
-	/// Quest for the Harpy Feather Cloak artifact.
+	/// Quest for the A Flask artifact.
 	/// </summary>
 	/// <author>Aredhel</author>
-	class HarpyFeatherCloak : ArtifactQuest
+	class NailahsRobes : ArtifactQuest
 	{
+		private static int m_requiredLevel = 45;
+
 		/// <summary>
 		/// The name of the quest (not necessarily the same as
 		/// the name of the reward).
 		/// </summary>
-		public override string Name
+		public override String Name
 		{
-			get { return "Harpy Feather Cloak"; }
+			get { return "Nailahs Robes"; }
 		}
 
 		/// <summary>
 		/// The reward for this quest.
 		/// </summary>
-		private static String m_artifactID = "Harpy Feather Cloak";
+		private const String m_artifactID = "Nailahs Robes";
 		public override String ArtifactID
 		{
 			get { return m_artifactID; }
@@ -60,20 +62,16 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			{
 				switch (Step)
 				{
-					case 1:
-						return "Defeat the Harpies.";
-					case 2:
-						return "Turn in the completed book.";
 					default:
 						return base.Description;
 				}
 			}
 		}
 
-		public HarpyFeatherCloak()
+		public NailahsRobes()
 			: base() { }
 
-		public HarpyFeatherCloak(GamePlayer questingPlayer)
+		public NailahsRobes(GamePlayer questingPlayer)
 			: base(questingPlayer) { }
 
 		/// <summary>
@@ -81,7 +79,7 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		/// <param name="questingPlayer"></param>
 		/// <param name="dbQuest"></param>
-        public HarpyFeatherCloak(GamePlayer questingPlayer, DBQuest dbQuest)
+		public NailahsRobes(GamePlayer questingPlayer, DBQuest dbQuest)
 			: base(questingPlayer, dbQuest) { }
 
 		/// <summary>
@@ -89,22 +87,22 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		public static void Init()
 		{
-            ArtifactQuest.Init(m_artifactID, typeof(HarpyFeatherCloak));
+			ArtifactQuest.Init(m_artifactID, typeof(NailahsRobes));
 		}
 
-        /// <summary>
-        /// Check if player is eligible for this quest.
-        /// </summary>
-        /// <param name="player"></param>
-        /// <returns></returns>
-        public override bool CheckQuestQualification(GamePlayer player)
-        {
-            if (!base.CheckQuestQualification(player))
-                return false;
+		/// <summary>
+		/// Check if player is eligible for this quest.
+		/// </summary>
+		/// <param name="player"></param>
+		/// <returns></returns>
+		public override bool CheckQuestQualification(GamePlayer player)
+		{
+			if (!base.CheckQuestQualification(player))
+				return false;
 
-            // TODO: Check if this is the correct level for the quest.
-            return (player.Level >= 45);
-        }
+			// TODO: Check if this is the correct level for the quest.
+			return (player.Level >= m_requiredLevel);
+		}
 
 		/// <summary>
 		/// Handle an item given to the scholar.
@@ -123,18 +121,21 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			if (player == null || scholar == null)
 				return false;
 
-			if (Step == 2 && ArtifactMgr.GetArtifactID(item.Name) == ArtifactID)
+			if (Step > -1 && ArtifactMgr.GetArtifactID(item.Name) == ArtifactID)
 			{
 				Dictionary<String, ItemTemplate> versions = ArtifactMgr.GetArtifactVersions(ArtifactID,
 					(eCharacterClass)player.CharacterClass.ID, (eRealm)player.Realm);
-				
+
 				if (versions.Count > 0 && RemoveItem(player, item))
 				{
 					GiveItem(scholar, player, ArtifactID, versions[";;"]);
-					String reply = String.Format("Brilliant, thank you! Here, take the artifact. {0} {1} {2}",
-						"I've unlocked its powers for you. As I've said before, I'm more interested",
-						"in the stories and the history behind these artifacts than the actual items",
-						"themselves.");
+					String reply = String.Format("Here is the {0}, {1} {2} {3} {4}, {5}!",
+						"restored to its original power. It is a fine item and I wish I could keep",
+						"it, but it is for you and you alone. Do not destroy it because you will never",
+						"have access to its full power again. Take care of it and it shall aid you in",
+						"the trials",
+						ArtifactID,
+						player.CharacterClass.Name);
 					scholar.TurnTo(player);
 					scholar.SayTo(player, eChatLoc.CL_PopupWindow, reply);
 					FinishQuest();
@@ -162,16 +163,25 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			if (player == null || scholar == null)
 				return false;
 
-			if (Step == 1 && text.ToLower() == ArtifactID.ToLower())
+			if (Step > -1 && text.ToLower() == ArtifactID.ToLower())
 			{
-                String reply = "Oh, the mysterious Harpy Feather Cloak. Do you have the scrolls on it? I've found a few that allude to its true nature, but haven't found anything with any detail.";
+				/* Commenting out to give a template for future development
+				String reply = String.Format("Vara was a very skilled healer and she put her skills {0} {1} {2}",
+					"into the Healer's Embrace cloak. It would help me to unlock them if I was to read",
+					"her Medical Log. Please give me Vara's Medical Log now so that I may awaken the",
+					"magic within the Cloak for you.");
 				scholar.TurnTo(player);
 				scholar.SayTo(player, eChatLoc.CL_PopupWindow, reply);
 				Step = 2;
-				return true;
+				return true;*/
 			}
 
 			return false;
+		}
+
+		public override void Notify(DOLEvent e, object sender, EventArgs args)
+		{
+			// Need to do anything here?
 		}
 	}
 }

--- a/GameServer/quests/Atlantis/Artifacts/NightsShroudBracelet.cs
+++ b/GameServer/quests/Atlantis/Artifacts/NightsShroudBracelet.cs
@@ -33,6 +33,43 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 	/// <author>Aredhel</author>
 	class NightsShroudBracelet : ArtifactQuest
 	{
+		/// <summary>
+		/// The name of the quest (not necessarily the same as
+		/// the name of the reward).
+		/// </summary>
+		public override string Name
+		{
+			get { return "Night's Shroud Bracelet"; }
+		}
+
+		/// <summary>
+		/// The reward for this quest.
+		/// </summary>
+		private static String m_artifactID = "Night's Shroud Bracelet";
+		public override String ArtifactID
+		{
+			get { return m_artifactID; }
+		}
+
+		/// <summary>
+		/// Description for the current step.
+		/// </summary>
+		public override string Description
+		{
+			get
+			{
+				switch (Step)
+				{
+					case 1:
+						return "Defeat Kythera.";
+					case 2:
+						return "Turn in the completed book.";
+					default:
+						return base.Description;
+				}
+			}
+		}
+
 		public NightsShroudBracelet()
 			: base() { }
 
@@ -52,7 +89,7 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		public static void Init()
 		{
-            ArtifactQuest.Init("Night's Shroud Bracelet", typeof(NightsShroudBracelet));
+            ArtifactQuest.Init("m_artifactID", typeof(NightsShroudBracelet));
 		}
 
         /// <summary>
@@ -135,42 +172,6 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			}
 
 			return false;
-		}
-
-		/// <summary>
-		/// Description for the current step.
-		/// </summary>
-		public override string Description
-		{
-			get
-			{
-				switch (Step)
-				{
-					case 1:
-						return "Defeat Kythera.";
-					case 2:
-						return "Turn in the completed book.";
-					default:
-						return base.Description;
-				}
-			}
-		}
-
-		/// <summary>
-		/// The name of the quest (not necessarily the same as
-		/// the name of the reward).
-		/// </summary>
-		public override string Name
-		{
-            get { return "Night's Shroud Bracelet"; }
-		}
-
-		/// <summary>
-		/// The reward for this quest.
-		/// </summary>
-		public override String ArtifactID
-		{
-            get { return "Night's Shroud Bracelet"; }
 		}
 	}
 }

--- a/GameServer/quests/Atlantis/Artifacts/OrionsBelt.cs
+++ b/GameServer/quests/Atlantis/Artifacts/OrionsBelt.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * DAWN OF LIGHT - The first free open source DAoC server emulator
  * 
  * This program is free software; you can redistribute it and/or
@@ -28,24 +28,26 @@ using System.Collections;
 namespace DOL.GS.Quests.Atlantis.Artifacts
 {
 	/// <summary>
-	/// Quest for the Harpy Feather Cloak artifact.
+	/// Quest for the A Flask artifact.
 	/// </summary>
 	/// <author>Aredhel</author>
-	class HarpyFeatherCloak : ArtifactQuest
+	class OrionsBelt : ArtifactQuest
 	{
+		private static int m_requiredLevel = 30;
+
 		/// <summary>
 		/// The name of the quest (not necessarily the same as
 		/// the name of the reward).
 		/// </summary>
-		public override string Name
+		public override String Name
 		{
-			get { return "Harpy Feather Cloak"; }
+			get { return "Orion's Belt"; }
 		}
 
 		/// <summary>
 		/// The reward for this quest.
 		/// </summary>
-		private static String m_artifactID = "Harpy Feather Cloak";
+		private const String m_artifactID = "Orion's Belt";
 		public override String ArtifactID
 		{
 			get { return m_artifactID; }
@@ -60,20 +62,16 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			{
 				switch (Step)
 				{
-					case 1:
-						return "Defeat the Harpies.";
-					case 2:
-						return "Turn in the completed book.";
 					default:
 						return base.Description;
 				}
 			}
 		}
 
-		public HarpyFeatherCloak()
+		public OrionsBelt()
 			: base() { }
 
-		public HarpyFeatherCloak(GamePlayer questingPlayer)
+		public OrionsBelt(GamePlayer questingPlayer)
 			: base(questingPlayer) { }
 
 		/// <summary>
@@ -81,7 +79,7 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		/// <param name="questingPlayer"></param>
 		/// <param name="dbQuest"></param>
-        public HarpyFeatherCloak(GamePlayer questingPlayer, DBQuest dbQuest)
+		public OrionsBelt(GamePlayer questingPlayer, DBQuest dbQuest)
 			: base(questingPlayer, dbQuest) { }
 
 		/// <summary>
@@ -89,22 +87,22 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		public static void Init()
 		{
-            ArtifactQuest.Init(m_artifactID, typeof(HarpyFeatherCloak));
+			ArtifactQuest.Init(m_artifactID, typeof(OrionsBelt));
 		}
 
-        /// <summary>
-        /// Check if player is eligible for this quest.
-        /// </summary>
-        /// <param name="player"></param>
-        /// <returns></returns>
-        public override bool CheckQuestQualification(GamePlayer player)
-        {
-            if (!base.CheckQuestQualification(player))
-                return false;
+		/// <summary>
+		/// Check if player is eligible for this quest.
+		/// </summary>
+		/// <param name="player"></param>
+		/// <returns></returns>
+		public override bool CheckQuestQualification(GamePlayer player)
+		{
+			if (!base.CheckQuestQualification(player))
+				return false;
 
-            // TODO: Check if this is the correct level for the quest.
-            return (player.Level >= 45);
-        }
+			// TODO: Check if this is the correct level for the quest.
+			return (player.Level >= m_requiredLevel);
+		}
 
 		/// <summary>
 		/// Handle an item given to the scholar.
@@ -123,18 +121,21 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			if (player == null || scholar == null)
 				return false;
 
-			if (Step == 2 && ArtifactMgr.GetArtifactID(item.Name) == ArtifactID)
+			if (Step > -1 && ArtifactMgr.GetArtifactID(item.Name) == ArtifactID)
 			{
 				Dictionary<String, ItemTemplate> versions = ArtifactMgr.GetArtifactVersions(ArtifactID,
 					(eCharacterClass)player.CharacterClass.ID, (eRealm)player.Realm);
-				
+
 				if (versions.Count > 0 && RemoveItem(player, item))
 				{
 					GiveItem(scholar, player, ArtifactID, versions[";;"]);
-					String reply = String.Format("Brilliant, thank you! Here, take the artifact. {0} {1} {2}",
-						"I've unlocked its powers for you. As I've said before, I'm more interested",
-						"in the stories and the history behind these artifacts than the actual items",
-						"themselves.");
+					String reply = String.Format("Here is the {0}, {1} {2} {3} {4}, {5}!",
+						"restored to its original power. It is a fine item and I wish I could keep",
+						"it, but it is for you and you alone. Do not destroy it because you will never",
+						"have access to its full power again. Take care of it and it shall aid you in",
+						"the trials",
+						ArtifactID,
+						player.CharacterClass.Name);
 					scholar.TurnTo(player);
 					scholar.SayTo(player, eChatLoc.CL_PopupWindow, reply);
 					FinishQuest();
@@ -162,16 +163,25 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			if (player == null || scholar == null)
 				return false;
 
-			if (Step == 1 && text.ToLower() == ArtifactID.ToLower())
+			if (Step > -1 && text.ToLower() == ArtifactID.ToLower())
 			{
-                String reply = "Oh, the mysterious Harpy Feather Cloak. Do you have the scrolls on it? I've found a few that allude to its true nature, but haven't found anything with any detail.";
+				/* Commenting out to give a template for future development
+				String reply = String.Format("Vara was a very skilled healer and she put her skills {0} {1} {2}",
+					"into the Healer's Embrace cloak. It would help me to unlock them if I was to read",
+					"her Medical Log. Please give me Vara's Medical Log now so that I may awaken the",
+					"magic within the Cloak for you.");
 				scholar.TurnTo(player);
 				scholar.SayTo(player, eChatLoc.CL_PopupWindow, reply);
 				Step = 2;
-				return true;
+				return true;*/
 			}
 
 			return false;
+		}
+
+		public override void Notify(DOLEvent e, object sender, EventArgs args)
+		{
+			// Need to do anything here?
 		}
 	}
 }

--- a/GameServer/quests/Atlantis/Artifacts/PhoebusHarp.cs
+++ b/GameServer/quests/Atlantis/Artifacts/PhoebusHarp.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * DAWN OF LIGHT - The first free open source DAoC server emulator
  * 
  * This program is free software; you can redistribute it and/or
@@ -28,24 +28,26 @@ using System.Collections;
 namespace DOL.GS.Quests.Atlantis.Artifacts
 {
 	/// <summary>
-	/// Quest for the Harpy Feather Cloak artifact.
+	/// Quest for the A Flask artifact.
 	/// </summary>
 	/// <author>Aredhel</author>
-	class HarpyFeatherCloak : ArtifactQuest
+	class PhoebusHarp : ArtifactQuest
 	{
+		private static int m_requiredLevel = 45;
+
 		/// <summary>
 		/// The name of the quest (not necessarily the same as
 		/// the name of the reward).
 		/// </summary>
-		public override string Name
+		public override String Name
 		{
-			get { return "Harpy Feather Cloak"; }
+			get { return "Phoebus' Harp"; }
 		}
 
 		/// <summary>
 		/// The reward for this quest.
 		/// </summary>
-		private static String m_artifactID = "Harpy Feather Cloak";
+		private const String m_artifactID = "Phoebus' Harp";
 		public override String ArtifactID
 		{
 			get { return m_artifactID; }
@@ -60,20 +62,16 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			{
 				switch (Step)
 				{
-					case 1:
-						return "Defeat the Harpies.";
-					case 2:
-						return "Turn in the completed book.";
 					default:
 						return base.Description;
 				}
 			}
 		}
 
-		public HarpyFeatherCloak()
+		public PhoebusHarp()
 			: base() { }
 
-		public HarpyFeatherCloak(GamePlayer questingPlayer)
+		public PhoebusHarp(GamePlayer questingPlayer)
 			: base(questingPlayer) { }
 
 		/// <summary>
@@ -81,7 +79,7 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		/// <param name="questingPlayer"></param>
 		/// <param name="dbQuest"></param>
-        public HarpyFeatherCloak(GamePlayer questingPlayer, DBQuest dbQuest)
+		public PhoebusHarp(GamePlayer questingPlayer, DBQuest dbQuest)
 			: base(questingPlayer, dbQuest) { }
 
 		/// <summary>
@@ -89,22 +87,22 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		public static void Init()
 		{
-            ArtifactQuest.Init(m_artifactID, typeof(HarpyFeatherCloak));
+			ArtifactQuest.Init(m_artifactID, typeof(PhoebusHarp));
 		}
 
-        /// <summary>
-        /// Check if player is eligible for this quest.
-        /// </summary>
-        /// <param name="player"></param>
-        /// <returns></returns>
-        public override bool CheckQuestQualification(GamePlayer player)
-        {
-            if (!base.CheckQuestQualification(player))
-                return false;
+		/// <summary>
+		/// Check if player is eligible for this quest.
+		/// </summary>
+		/// <param name="player"></param>
+		/// <returns></returns>
+		public override bool CheckQuestQualification(GamePlayer player)
+		{
+			if (!base.CheckQuestQualification(player))
+				return false;
 
-            // TODO: Check if this is the correct level for the quest.
-            return (player.Level >= 45);
-        }
+			// TODO: Check if this is the correct level for the quest.
+			return (player.Level >= m_requiredLevel);
+		}
 
 		/// <summary>
 		/// Handle an item given to the scholar.
@@ -123,18 +121,21 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			if (player == null || scholar == null)
 				return false;
 
-			if (Step == 2 && ArtifactMgr.GetArtifactID(item.Name) == ArtifactID)
+			if (Step > -1 && ArtifactMgr.GetArtifactID(item.Name) == ArtifactID)
 			{
 				Dictionary<String, ItemTemplate> versions = ArtifactMgr.GetArtifactVersions(ArtifactID,
 					(eCharacterClass)player.CharacterClass.ID, (eRealm)player.Realm);
-				
+
 				if (versions.Count > 0 && RemoveItem(player, item))
 				{
 					GiveItem(scholar, player, ArtifactID, versions[";;"]);
-					String reply = String.Format("Brilliant, thank you! Here, take the artifact. {0} {1} {2}",
-						"I've unlocked its powers for you. As I've said before, I'm more interested",
-						"in the stories and the history behind these artifacts than the actual items",
-						"themselves.");
+					String reply = String.Format("Here is the {0}, {1} {2} {3} {4}, {5}!",
+						"restored to its original power. It is a fine item and I wish I could keep",
+						"it, but it is for you and you alone. Do not destroy it because you will never",
+						"have access to its full power again. Take care of it and it shall aid you in",
+						"the trials",
+						ArtifactID,
+						player.CharacterClass.Name);
 					scholar.TurnTo(player);
 					scholar.SayTo(player, eChatLoc.CL_PopupWindow, reply);
 					FinishQuest();
@@ -162,16 +163,25 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			if (player == null || scholar == null)
 				return false;
 
-			if (Step == 1 && text.ToLower() == ArtifactID.ToLower())
+			if (Step > -1 && text.ToLower() == ArtifactID.ToLower())
 			{
-                String reply = "Oh, the mysterious Harpy Feather Cloak. Do you have the scrolls on it? I've found a few that allude to its true nature, but haven't found anything with any detail.";
+				/* Commenting out to give a template for future development
+				String reply = String.Format("Vara was a very skilled healer and she put her skills {0} {1} {2}",
+					"into the Healer's Embrace cloak. It would help me to unlock them if I was to read",
+					"her Medical Log. Please give me Vara's Medical Log now so that I may awaken the",
+					"magic within the Cloak for you.");
 				scholar.TurnTo(player);
 				scholar.SayTo(player, eChatLoc.CL_PopupWindow, reply);
 				Step = 2;
-				return true;
+				return true;*/
 			}
 
 			return false;
+		}
+
+		public override void Notify(DOLEvent e, object sender, EventArgs args)
+		{
+			// Need to do anything here?
 		}
 	}
 }

--- a/GameServer/quests/Atlantis/Artifacts/RingofDances.cs
+++ b/GameServer/quests/Atlantis/Artifacts/RingofDances.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * DAWN OF LIGHT - The first free open source DAoC server emulator
  * 
  * This program is free software; you can redistribute it and/or
@@ -28,24 +28,26 @@ using System.Collections;
 namespace DOL.GS.Quests.Atlantis.Artifacts
 {
 	/// <summary>
-	/// Quest for the Harpy Feather Cloak artifact.
+	/// Quest for the A Flask artifact.
 	/// </summary>
 	/// <author>Aredhel</author>
-	class HarpyFeatherCloak : ArtifactQuest
+	class RingofDances : ArtifactQuest
 	{
+		private static int m_requiredLevel = 45;
+
 		/// <summary>
 		/// The name of the quest (not necessarily the same as
 		/// the name of the reward).
 		/// </summary>
-		public override string Name
+		public override String Name
 		{
-			get { return "Harpy Feather Cloak"; }
+			get { return "Ring of Dances"; }
 		}
 
 		/// <summary>
 		/// The reward for this quest.
 		/// </summary>
-		private static String m_artifactID = "Harpy Feather Cloak";
+		private const String m_artifactID = "Ring of Dances";
 		public override String ArtifactID
 		{
 			get { return m_artifactID; }
@@ -60,20 +62,16 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			{
 				switch (Step)
 				{
-					case 1:
-						return "Defeat the Harpies.";
-					case 2:
-						return "Turn in the completed book.";
 					default:
 						return base.Description;
 				}
 			}
 		}
 
-		public HarpyFeatherCloak()
+		public RingofDances()
 			: base() { }
 
-		public HarpyFeatherCloak(GamePlayer questingPlayer)
+		public RingofDances(GamePlayer questingPlayer)
 			: base(questingPlayer) { }
 
 		/// <summary>
@@ -81,7 +79,7 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		/// <param name="questingPlayer"></param>
 		/// <param name="dbQuest"></param>
-        public HarpyFeatherCloak(GamePlayer questingPlayer, DBQuest dbQuest)
+		public RingofDances(GamePlayer questingPlayer, DBQuest dbQuest)
 			: base(questingPlayer, dbQuest) { }
 
 		/// <summary>
@@ -89,22 +87,22 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		public static void Init()
 		{
-            ArtifactQuest.Init(m_artifactID, typeof(HarpyFeatherCloak));
+			ArtifactQuest.Init(m_artifactID, typeof(RingofDances));
 		}
 
-        /// <summary>
-        /// Check if player is eligible for this quest.
-        /// </summary>
-        /// <param name="player"></param>
-        /// <returns></returns>
-        public override bool CheckQuestQualification(GamePlayer player)
-        {
-            if (!base.CheckQuestQualification(player))
-                return false;
+		/// <summary>
+		/// Check if player is eligible for this quest.
+		/// </summary>
+		/// <param name="player"></param>
+		/// <returns></returns>
+		public override bool CheckQuestQualification(GamePlayer player)
+		{
+			if (!base.CheckQuestQualification(player))
+				return false;
 
-            // TODO: Check if this is the correct level for the quest.
-            return (player.Level >= 45);
-        }
+			// TODO: Check if this is the correct level for the quest.
+			return (player.Level >= m_requiredLevel);
+		}
 
 		/// <summary>
 		/// Handle an item given to the scholar.
@@ -123,18 +121,21 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			if (player == null || scholar == null)
 				return false;
 
-			if (Step == 2 && ArtifactMgr.GetArtifactID(item.Name) == ArtifactID)
+			if (Step > -1 && ArtifactMgr.GetArtifactID(item.Name) == ArtifactID)
 			{
 				Dictionary<String, ItemTemplate> versions = ArtifactMgr.GetArtifactVersions(ArtifactID,
 					(eCharacterClass)player.CharacterClass.ID, (eRealm)player.Realm);
-				
+
 				if (versions.Count > 0 && RemoveItem(player, item))
 				{
 					GiveItem(scholar, player, ArtifactID, versions[";;"]);
-					String reply = String.Format("Brilliant, thank you! Here, take the artifact. {0} {1} {2}",
-						"I've unlocked its powers for you. As I've said before, I'm more interested",
-						"in the stories and the history behind these artifacts than the actual items",
-						"themselves.");
+					String reply = String.Format("Here is the {0}, {1} {2} {3} {4}, {5}!",
+						"restored to its original power. It is a fine item and I wish I could keep",
+						"it, but it is for you and you alone. Do not destroy it because you will never",
+						"have access to its full power again. Take care of it and it shall aid you in",
+						"the trials",
+						ArtifactID,
+						player.CharacterClass.Name);
 					scholar.TurnTo(player);
 					scholar.SayTo(player, eChatLoc.CL_PopupWindow, reply);
 					FinishQuest();
@@ -162,16 +163,25 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			if (player == null || scholar == null)
 				return false;
 
-			if (Step == 1 && text.ToLower() == ArtifactID.ToLower())
+			if (Step > -1 && text.ToLower() == ArtifactID.ToLower())
 			{
-                String reply = "Oh, the mysterious Harpy Feather Cloak. Do you have the scrolls on it? I've found a few that allude to its true nature, but haven't found anything with any detail.";
+				/* Commenting out to give a template for future development
+				String reply = String.Format("Vara was a very skilled healer and she put her skills {0} {1} {2}",
+					"into the Healer's Embrace cloak. It would help me to unlock them if I was to read",
+					"her Medical Log. Please give me Vara's Medical Log now so that I may awaken the",
+					"magic within the Cloak for you.");
 				scholar.TurnTo(player);
 				scholar.SayTo(player, eChatLoc.CL_PopupWindow, reply);
 				Step = 2;
-				return true;
+				return true;*/
 			}
 
 			return false;
+		}
+
+		public override void Notify(DOLEvent e, object sender, EventArgs args)
+		{
+			// Need to do anything here?
 		}
 	}
 }

--- a/GameServer/quests/Atlantis/Artifacts/RingofFire.cs
+++ b/GameServer/quests/Atlantis/Artifacts/RingofFire.cs
@@ -33,6 +33,43 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 	/// <author>Aredhel</author>
 	class RingofFire : ArtifactQuest
 	{
+		/// <summary>
+		/// The name of the quest (not necessarily the same as
+		/// the name of the reward).
+		/// </summary>
+		public override string Name
+		{
+			get { return "Ring of Fire"; }
+		}
+
+		/// <summary>
+		/// The reward for this quest.
+		/// </summary>
+		private static String m_artifactID = "Ring of Fire";
+		public override String ArtifactID
+		{
+			get { return m_artifactID; }
+		}
+
+		/// <summary>
+		/// Description for the current step.
+		/// </summary>
+		public override string Description
+		{
+			get
+			{
+				switch (Step)
+				{
+					case 1:
+						return "Win three consecutive rounds of battle with the gladiators.";
+					case 2:
+						return "Turn in the completed book.";
+					default:
+						return base.Description;
+				}
+			}
+		}
+
 		public RingofFire()
 			: base() { }
 
@@ -52,7 +89,7 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		public static void Init()
 		{
-            ArtifactQuest.Init("Ring of Fire", typeof(RingofFire));
+            ArtifactQuest.Init(m_artifactID, typeof(RingofFire));
 		}
 
         /// <summary>
@@ -135,42 +172,6 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			}
 
 			return false;
-		}
-
-		/// <summary>
-		/// Description for the current step.
-		/// </summary>
-		public override string Description
-		{
-			get
-			{
-				switch (Step)
-				{
-					case 1:
-						return "Win three consecutive rounds of battle with the gladiators.";
-					case 2:
-						return "Turn in the completed book.";
-					default:
-						return base.Description;
-				}
-			}
-		}
-
-		/// <summary>
-		/// The name of the quest (not necessarily the same as
-		/// the name of the reward).
-		/// </summary>
-		public override string Name
-		{
-            get { return "Ring of Fire"; }
-		}
-
-		/// <summary>
-		/// The reward for this quest.
-		/// </summary>
-		public override String ArtifactID
-		{
-            get { return "Ring of Fire"; }
 		}
 	}
 }

--- a/GameServer/quests/Atlantis/Artifacts/RingofUnyieldingWill.cs
+++ b/GameServer/quests/Atlantis/Artifacts/RingofUnyieldingWill.cs
@@ -33,6 +33,43 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 	/// <author>Aredhel</author>
 	class RingofUnyieldingWill : ArtifactQuest
 	{
+		/// <summary>
+		/// The name of the quest (not necessarily the same as
+		/// the name of the reward).
+		/// </summary>
+		public override string Name
+		{
+			get { return "Ring of Unyielding Will"; }
+		}
+
+		/// <summary>
+		/// The reward for this quest.
+		/// </summary>
+		private static String m_artifactID = "Ring of Unyielding Will";
+		public override String ArtifactID
+		{
+			get { return m_artifactID; }
+		}
+
+		/// <summary>
+		/// Description for the current step.
+		/// </summary>
+		public override string Description
+		{
+			get
+			{
+				switch (Step)
+				{
+					case 1:
+						return "Defeat Mordom.";
+					case 2:
+						return "Turn in the completed book.";
+					default:
+						return base.Description;
+				}
+			}
+		}
+
 		public RingofUnyieldingWill()
 			: base() { }
 
@@ -52,7 +89,7 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		public static void Init()
 		{
-            ArtifactQuest.Init("Ring of Unyielding Will", typeof(RingofUnyieldingWill));
+            ArtifactQuest.Init(m_artifactID, typeof(RingofUnyieldingWill));
 		}
 
         /// <summary>
@@ -135,42 +172,6 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			}
 
 			return false;
-		}
-
-		/// <summary>
-		/// Description for the current step.
-		/// </summary>
-		public override string Description
-		{
-			get
-			{
-				switch (Step)
-				{
-					case 1:
-						return "Defeat Mordom.";
-					case 2:
-						return "Turn in the completed book.";
-					default:
-						return base.Description;
-				}
-			}
-		}
-
-		/// <summary>
-		/// The name of the quest (not necessarily the same as
-		/// the name of the reward).
-		/// </summary>
-		public override string Name
-		{
-            get { return "Ring of Unyielding Will"; }
-		}
-
-		/// <summary>
-		/// The reward for this quest.
-		/// </summary>
-		public override String ArtifactID
-		{
-            get { return "Ring of Unyielding Will"; }
 		}
 	}
 }

--- a/GameServer/quests/Atlantis/Artifacts/ScepteroftheMeritorious.cs
+++ b/GameServer/quests/Atlantis/Artifacts/ScepteroftheMeritorious.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * DAWN OF LIGHT - The first free open source DAoC server emulator
  * 
  * This program is free software; you can redistribute it and/or
@@ -28,24 +28,26 @@ using System.Collections;
 namespace DOL.GS.Quests.Atlantis.Artifacts
 {
 	/// <summary>
-	/// Quest for the Harpy Feather Cloak artifact.
+	/// Quest for the A Flask artifact.
 	/// </summary>
 	/// <author>Aredhel</author>
-	class HarpyFeatherCloak : ArtifactQuest
+	class ScepteroftheMeritorious : ArtifactQuest
 	{
+		private static int m_requiredLevel = 43;
+
 		/// <summary>
 		/// The name of the quest (not necessarily the same as
 		/// the name of the reward).
 		/// </summary>
-		public override string Name
+		public override String Name
 		{
-			get { return "Harpy Feather Cloak"; }
+			get { return "Scepter of the Meritorious"; }
 		}
 
 		/// <summary>
 		/// The reward for this quest.
 		/// </summary>
-		private static String m_artifactID = "Harpy Feather Cloak";
+		private const String m_artifactID = "Scepter of the Meritorious";
 		public override String ArtifactID
 		{
 			get { return m_artifactID; }
@@ -60,20 +62,16 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			{
 				switch (Step)
 				{
-					case 1:
-						return "Defeat the Harpies.";
-					case 2:
-						return "Turn in the completed book.";
 					default:
 						return base.Description;
 				}
 			}
 		}
 
-		public HarpyFeatherCloak()
+		public ScepteroftheMeritorious()
 			: base() { }
 
-		public HarpyFeatherCloak(GamePlayer questingPlayer)
+		public ScepteroftheMeritorious(GamePlayer questingPlayer)
 			: base(questingPlayer) { }
 
 		/// <summary>
@@ -81,7 +79,7 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		/// <param name="questingPlayer"></param>
 		/// <param name="dbQuest"></param>
-        public HarpyFeatherCloak(GamePlayer questingPlayer, DBQuest dbQuest)
+		public ScepteroftheMeritorious(GamePlayer questingPlayer, DBQuest dbQuest)
 			: base(questingPlayer, dbQuest) { }
 
 		/// <summary>
@@ -89,22 +87,22 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		public static void Init()
 		{
-            ArtifactQuest.Init(m_artifactID, typeof(HarpyFeatherCloak));
+			ArtifactQuest.Init(m_artifactID, typeof(ScepteroftheMeritorious));
 		}
 
-        /// <summary>
-        /// Check if player is eligible for this quest.
-        /// </summary>
-        /// <param name="player"></param>
-        /// <returns></returns>
-        public override bool CheckQuestQualification(GamePlayer player)
-        {
-            if (!base.CheckQuestQualification(player))
-                return false;
+		/// <summary>
+		/// Check if player is eligible for this quest.
+		/// </summary>
+		/// <param name="player"></param>
+		/// <returns></returns>
+		public override bool CheckQuestQualification(GamePlayer player)
+		{
+			if (!base.CheckQuestQualification(player))
+				return false;
 
-            // TODO: Check if this is the correct level for the quest.
-            return (player.Level >= 45);
-        }
+			// TODO: Check if this is the correct level for the quest.
+			return (player.Level >= m_requiredLevel);
+		}
 
 		/// <summary>
 		/// Handle an item given to the scholar.
@@ -123,18 +121,21 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			if (player == null || scholar == null)
 				return false;
 
-			if (Step == 2 && ArtifactMgr.GetArtifactID(item.Name) == ArtifactID)
+			if (Step > -1 && ArtifactMgr.GetArtifactID(item.Name) == ArtifactID)
 			{
 				Dictionary<String, ItemTemplate> versions = ArtifactMgr.GetArtifactVersions(ArtifactID,
 					(eCharacterClass)player.CharacterClass.ID, (eRealm)player.Realm);
-				
+
 				if (versions.Count > 0 && RemoveItem(player, item))
 				{
 					GiveItem(scholar, player, ArtifactID, versions[";;"]);
-					String reply = String.Format("Brilliant, thank you! Here, take the artifact. {0} {1} {2}",
-						"I've unlocked its powers for you. As I've said before, I'm more interested",
-						"in the stories and the history behind these artifacts than the actual items",
-						"themselves.");
+					String reply = String.Format("Here is the {0}, {1} {2} {3} {4}, {5}!",
+						"restored to its original power. It is a fine item and I wish I could keep",
+						"it, but it is for you and you alone. Do not destroy it because you will never",
+						"have access to its full power again. Take care of it and it shall aid you in",
+						"the trials",
+						ArtifactID,
+						player.CharacterClass.Name);
 					scholar.TurnTo(player);
 					scholar.SayTo(player, eChatLoc.CL_PopupWindow, reply);
 					FinishQuest();
@@ -162,16 +163,25 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			if (player == null || scholar == null)
 				return false;
 
-			if (Step == 1 && text.ToLower() == ArtifactID.ToLower())
+			if (Step > -1 && text.ToLower() == ArtifactID.ToLower())
 			{
-                String reply = "Oh, the mysterious Harpy Feather Cloak. Do you have the scrolls on it? I've found a few that allude to its true nature, but haven't found anything with any detail.";
+				/* Commenting out to give a template for future development
+				String reply = String.Format("Vara was a very skilled healer and she put her skills {0} {1} {2}",
+					"into the Healer's Embrace cloak. It would help me to unlock them if I was to read",
+					"her Medical Log. Please give me Vara's Medical Log now so that I may awaken the",
+					"magic within the Cloak for you.");
 				scholar.TurnTo(player);
 				scholar.SayTo(player, eChatLoc.CL_PopupWindow, reply);
 				Step = 2;
-				return true;
+				return true;*/
 			}
 
 			return false;
+		}
+
+		public override void Notify(DOLEvent e, object sender, EventArgs args)
+		{
+			// Need to do anything here?
 		}
 	}
 }

--- a/GameServer/quests/Atlantis/Artifacts/ScorpionsTail.cs
+++ b/GameServer/quests/Atlantis/Artifacts/ScorpionsTail.cs
@@ -33,6 +33,43 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 	/// <author>Aredhel</author>
 	class ScorpionsTail : ArtifactQuest
 	{
+		/// <summary>
+		/// The name of the quest (not necessarily the same as
+		/// the name of the reward).
+		/// </summary>
+		public override string Name
+		{
+			get { return "The Scorpions Tail"; }
+		}
+
+		/// <summary>
+		/// The reward for this quest.
+		/// </summary>
+		private static String m_artifactID = "The Scorpions Tail";
+		public override String ArtifactID
+		{
+			get { return m_artifactID; }
+		}
+
+		/// <summary>
+		/// Description for the current step.
+		/// </summary>
+		public override string Description
+		{
+			get
+			{
+				switch (Step)
+				{
+					case 1:
+						return "Defeat Terkari.";
+					case 2:
+						return "Turn in the completed book.";
+					default:
+						return base.Description;
+				}
+			}
+		}
+
 		public ScorpionsTail()
 			: base() { }
 
@@ -52,7 +89,7 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		public static void Init()
 		{
-            ArtifactQuest.Init("The Scorpions Tail", typeof(ScorpionsTail));
+            ArtifactQuest.Init(m_artifactID, typeof(ScorpionsTail));
 		}
 
         /// <summary>
@@ -135,42 +172,6 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			}
 
 			return false;
-		}
-
-		/// <summary>
-		/// Description for the current step.
-		/// </summary>
-		public override string Description
-		{
-			get
-			{
-				switch (Step)
-				{
-					case 1:
-						return "Defeat Terkari.";
-					case 2:
-						return "Turn in the completed book.";
-					default:
-						return base.Description;
-				}
-			}
-		}
-
-		/// <summary>
-		/// The name of the quest (not necessarily the same as
-		/// the name of the reward).
-		/// </summary>
-		public override string Name
-		{
-            get { return "The Scorpions Tail"; }
-		}
-
-		/// <summary>
-		/// The reward for this quest.
-		/// </summary>
-		public override String ArtifactID
-		{
-            get { return "The Scorpions Tail"; }
 		}
 	}
 }

--- a/GameServer/quests/Atlantis/Artifacts/ShadesOfMist.cs
+++ b/GameServer/quests/Atlantis/Artifacts/ShadesOfMist.cs
@@ -31,7 +31,44 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
     /// <author>Aredhel</author>
     public class ShadesOfMist : ArtifactQuest
     {
-        public ShadesOfMist()
+		/// <summary>
+		/// The name of the quest (not necessarily the same as
+		/// the name of the reward).
+		/// </summary>
+		public override string Name
+		{
+			get { return "Shades of Mist"; }
+		}
+
+		/// <summary>
+		/// The reward for this quest.
+		/// </summary>
+		private static String m_artifactID = "Shades of Mist";
+		public override String ArtifactID
+		{
+			get { return m_artifactID; }
+		}
+
+		/// <summary>
+		/// Description for the current step.
+		/// </summary>
+		public override string Description
+		{
+			get
+			{
+				switch (Step)
+				{
+					case 1:
+						return "Find the Shades of Mist.";
+					case 2:
+						return "Turn in the completed book.";
+					default:
+						return base.Description;
+				}
+			}
+		}
+
+		public ShadesOfMist()
 			: base() { }
 
 		public ShadesOfMist(GamePlayer questingPlayer)
@@ -50,7 +87,7 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		public static void Init()
 		{
-			ArtifactQuest.Init("Shades of Mist", typeof(ShadesOfMist));
+			ArtifactQuest.Init(m_artifactID, typeof(ShadesOfMist));
 		}
 
         /// <summary>
@@ -134,42 +171,6 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			}
 
 			return false;
-		}
-
-		/// <summary>
-		/// Description for the current step.
-		/// </summary>
-		public override string Description
-		{
-			get
-			{
-				switch (Step)
-				{
-					case 1:
-						return "Find the Shades of Mist.";
-					case 2:
-						return "Turn in the completed book.";
-					default:
-						return base.Description;
-				}
-			}
-		}
-
-		/// <summary>
-		/// The name of the quest (not necessarily the same as
-		/// the name of the reward).
-		/// </summary>
-		public override string Name
-		{
-			get { return "Shades of Mist"; }
-		}
-
-		/// <summary>
-		/// The reward for this quest.
-		/// </summary>
-		public override String ArtifactID
-		{
-			get { return "Shades of Mist"; }
 		}
     }
 }

--- a/GameServer/quests/Atlantis/Artifacts/ShieldOfKhaos.cs
+++ b/GameServer/quests/Atlantis/Artifacts/ShieldOfKhaos.cs
@@ -33,6 +33,43 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 	/// <author>Aredhel</author>
 	class ShieldOfKhaos : ArtifactQuest
 	{
+		/// <summary>
+		/// The name of the quest (not necessarily the same as
+		/// the name of the reward).
+		/// </summary>
+		public override string Name
+		{
+			get { return "Shield of Khaos"; }
+		}
+
+		/// <summary>
+		/// The reward for this quest.
+		/// </summary>
+		private static String m_artifactID = "Shield of Khaos";
+		public override String ArtifactID
+		{
+			get { return m_artifactID; }
+		}
+
+		/// <summary>
+		/// Description for the current step.
+		/// </summary>
+		public override string Description
+		{
+			get
+			{
+				switch (Step)
+				{
+					case 1:
+						return "Defeat Chief Creon.";
+					case 2:
+						return "Turn in the completed book.";
+					default:
+						return base.Description;
+				}
+			}
+		}
+
 		public ShieldOfKhaos()
 			: base() { }
 
@@ -52,7 +89,7 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		public static void Init()
 		{
-			ArtifactQuest.Init("Shield of Khaos", typeof(ShieldOfKhaos));
+			ArtifactQuest.Init(m_artifactID, typeof(ShieldOfKhaos));
 		}
 
         /// <summary>
@@ -136,42 +173,6 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			}
 
 			return false;
-		}
-
-		/// <summary>
-		/// Description for the current step.
-		/// </summary>
-		public override string Description
-		{
-			get
-			{
-				switch (Step)
-				{
-					case 1:
-						return "Defeat Chief Creon.";
-					case 2:
-						return "Turn in the completed book.";
-					default:
-						return base.Description;
-				}
-			}
-		}
-
-		/// <summary>
-		/// The name of the quest (not necessarily the same as
-		/// the name of the reward).
-		/// </summary>
-		public override string Name
-		{
-			get { return "Shield of Khaos"; }
-		}
-
-		/// <summary>
-		/// The reward for this quest.
-		/// </summary>
-		public override String ArtifactID
-		{
-			get { return "Shield of Khaos"; }
 		}
 	}
 }

--- a/GameServer/quests/Atlantis/Artifacts/SnakecharmersWeapon.cs
+++ b/GameServer/quests/Atlantis/Artifacts/SnakecharmersWeapon.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * DAWN OF LIGHT - The first free open source DAoC server emulator
  * 
  * This program is free software; you can redistribute it and/or
@@ -28,24 +28,26 @@ using System.Collections;
 namespace DOL.GS.Quests.Atlantis.Artifacts
 {
 	/// <summary>
-	/// Quest for the Harpy Feather Cloak artifact.
+	/// Quest for the A Flask artifact.
 	/// </summary>
 	/// <author>Aredhel</author>
-	class HarpyFeatherCloak : ArtifactQuest
+	class SnakecharmersWeapon : ArtifactQuest
 	{
+		private static int m_requiredLevel = 45;
+
 		/// <summary>
 		/// The name of the quest (not necessarily the same as
 		/// the name of the reward).
 		/// </summary>
-		public override string Name
+		public override String Name
 		{
-			get { return "Harpy Feather Cloak"; }
+			get { return "Scepter of the Meritorious"; }
 		}
 
 		/// <summary>
 		/// The reward for this quest.
 		/// </summary>
-		private static String m_artifactID = "Harpy Feather Cloak";
+		private const String m_artifactID = "Scepter of the Meritorious";
 		public override String ArtifactID
 		{
 			get { return m_artifactID; }
@@ -60,20 +62,16 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			{
 				switch (Step)
 				{
-					case 1:
-						return "Defeat the Harpies.";
-					case 2:
-						return "Turn in the completed book.";
 					default:
 						return base.Description;
 				}
 			}
 		}
 
-		public HarpyFeatherCloak()
+		public SnakecharmersWeapon()
 			: base() { }
 
-		public HarpyFeatherCloak(GamePlayer questingPlayer)
+		public SnakecharmersWeapon(GamePlayer questingPlayer)
 			: base(questingPlayer) { }
 
 		/// <summary>
@@ -81,7 +79,7 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		/// <param name="questingPlayer"></param>
 		/// <param name="dbQuest"></param>
-        public HarpyFeatherCloak(GamePlayer questingPlayer, DBQuest dbQuest)
+		public SnakecharmersWeapon(GamePlayer questingPlayer, DBQuest dbQuest)
 			: base(questingPlayer, dbQuest) { }
 
 		/// <summary>
@@ -89,22 +87,22 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		public static void Init()
 		{
-            ArtifactQuest.Init(m_artifactID, typeof(HarpyFeatherCloak));
+			ArtifactQuest.Init(m_artifactID, typeof(SnakecharmersWeapon));
 		}
 
-        /// <summary>
-        /// Check if player is eligible for this quest.
-        /// </summary>
-        /// <param name="player"></param>
-        /// <returns></returns>
-        public override bool CheckQuestQualification(GamePlayer player)
-        {
-            if (!base.CheckQuestQualification(player))
-                return false;
+		/// <summary>
+		/// Check if player is eligible for this quest.
+		/// </summary>
+		/// <param name="player"></param>
+		/// <returns></returns>
+		public override bool CheckQuestQualification(GamePlayer player)
+		{
+			if (!base.CheckQuestQualification(player))
+				return false;
 
-            // TODO: Check if this is the correct level for the quest.
-            return (player.Level >= 45);
-        }
+			// TODO: Check if this is the correct level for the quest.
+			return (player.Level >= m_requiredLevel);
+		}
 
 		/// <summary>
 		/// Handle an item given to the scholar.
@@ -123,18 +121,21 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			if (player == null || scholar == null)
 				return false;
 
-			if (Step == 2 && ArtifactMgr.GetArtifactID(item.Name) == ArtifactID)
+			if (Step > -1 && ArtifactMgr.GetArtifactID(item.Name) == ArtifactID)
 			{
 				Dictionary<String, ItemTemplate> versions = ArtifactMgr.GetArtifactVersions(ArtifactID,
 					(eCharacterClass)player.CharacterClass.ID, (eRealm)player.Realm);
-				
+
 				if (versions.Count > 0 && RemoveItem(player, item))
 				{
 					GiveItem(scholar, player, ArtifactID, versions[";;"]);
-					String reply = String.Format("Brilliant, thank you! Here, take the artifact. {0} {1} {2}",
-						"I've unlocked its powers for you. As I've said before, I'm more interested",
-						"in the stories and the history behind these artifacts than the actual items",
-						"themselves.");
+					String reply = String.Format("Here is the {0}, {1} {2} {3} {4}, {5}!",
+						"restored to its original power. It is a fine item and I wish I could keep",
+						"it, but it is for you and you alone. Do not destroy it because you will never",
+						"have access to its full power again. Take care of it and it shall aid you in",
+						"the trials",
+						ArtifactID,
+						player.CharacterClass.Name);
 					scholar.TurnTo(player);
 					scholar.SayTo(player, eChatLoc.CL_PopupWindow, reply);
 					FinishQuest();
@@ -162,16 +163,25 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			if (player == null || scholar == null)
 				return false;
 
-			if (Step == 1 && text.ToLower() == ArtifactID.ToLower())
+			if (Step > -1 && text.ToLower() == ArtifactID.ToLower())
 			{
-                String reply = "Oh, the mysterious Harpy Feather Cloak. Do you have the scrolls on it? I've found a few that allude to its true nature, but haven't found anything with any detail.";
+				/* Commenting out to give a template for future development
+				String reply = String.Format("Vara was a very skilled healer and she put her skills {0} {1} {2}",
+					"into the Healer's Embrace cloak. It would help me to unlock them if I was to read",
+					"her Medical Log. Please give me Vara's Medical Log now so that I may awaken the",
+					"magic within the Cloak for you.");
 				scholar.TurnTo(player);
 				scholar.SayTo(player, eChatLoc.CL_PopupWindow, reply);
 				Step = 2;
-				return true;
+				return true;*/
 			}
 
 			return false;
+		}
+
+		public override void Notify(DOLEvent e, object sender, EventArgs args)
+		{
+			// Need to do anything here?
 		}
 	}
 }

--- a/GameServer/quests/Atlantis/Artifacts/Snatcher.cs
+++ b/GameServer/quests/Atlantis/Artifacts/Snatcher.cs
@@ -33,6 +33,43 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 	/// <author>Aredhel</author>
 	class Snatcher : ArtifactQuest
 	{
+		/// <summary>
+		/// The name of the quest (not necessarily the same as
+		/// the name of the reward).
+		/// </summary>
+		public override string Name
+		{
+			get { return "Snatcher"; }
+		}
+
+		/// <summary>
+		/// The reward for this quest.
+		/// </summary>
+		private static String m_artifactID = "Snatcher";
+		public override String ArtifactID
+		{
+			get { return m_artifactID; }
+		}
+
+		/// <summary>
+		/// Description for the current step.
+		/// </summary>
+		public override string Description
+		{
+			get
+			{
+				switch (Step)
+				{
+					case 1:
+						return "Defeat Snatcher.";
+					case 2:
+						return "Turn in the completed book.";
+					default:
+						return base.Description;
+				}
+			}
+		}
+
 		public Snatcher()
 			: base() { }
 
@@ -52,7 +89,7 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		public static void Init()
 		{
-			ArtifactQuest.Init("Snatcher", typeof(Snatcher));
+			ArtifactQuest.Init(m_artifactID, typeof(Snatcher));
 		}
 
         /// <summary>
@@ -135,42 +172,6 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			}
 
 			return false;
-		}
-
-		/// <summary>
-		/// Description for the current step.
-		/// </summary>
-		public override string Description
-		{
-			get
-			{
-				switch (Step)
-				{
-					case 1:
-						return "Defeat Snatcher.";
-					case 2:
-						return "Turn in the completed book.";
-					default:
-						return base.Description;
-				}
-			}
-		}
-
-		/// <summary>
-		/// The name of the quest (not necessarily the same as
-		/// the name of the reward).
-		/// </summary>
-		public override string Name
-		{
-			get { return "Snatcher"; }
-		}
-
-		/// <summary>
-		/// The reward for this quest.
-		/// </summary>
-		public override String ArtifactID
-		{
-			get { return "Snatcher"; }
 		}
 	}
 }

--- a/GameServer/quests/Atlantis/Artifacts/SpearofKings.cs
+++ b/GameServer/quests/Atlantis/Artifacts/SpearofKings.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * DAWN OF LIGHT - The first free open source DAoC server emulator
  * 
  * This program is free software; you can redistribute it and/or
@@ -28,24 +28,26 @@ using System.Collections;
 namespace DOL.GS.Quests.Atlantis.Artifacts
 {
 	/// <summary>
-	/// Quest for the Harpy Feather Cloak artifact.
+	/// Quest for the A Flask artifact.
 	/// </summary>
 	/// <author>Aredhel</author>
-	class HarpyFeatherCloak : ArtifactQuest
+	class SpearofKings : ArtifactQuest
 	{
+		private static int m_requiredLevel = 45;
+
 		/// <summary>
 		/// The name of the quest (not necessarily the same as
 		/// the name of the reward).
 		/// </summary>
-		public override string Name
+		public override String Name
 		{
-			get { return "Harpy Feather Cloak"; }
+			get { return "Spear of Kings"; }
 		}
 
 		/// <summary>
 		/// The reward for this quest.
 		/// </summary>
-		private static String m_artifactID = "Harpy Feather Cloak";
+		private const String m_artifactID = "Spear of Kings";
 		public override String ArtifactID
 		{
 			get { return m_artifactID; }
@@ -60,20 +62,16 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			{
 				switch (Step)
 				{
-					case 1:
-						return "Defeat the Harpies.";
-					case 2:
-						return "Turn in the completed book.";
 					default:
 						return base.Description;
 				}
 			}
 		}
 
-		public HarpyFeatherCloak()
+		public SpearofKings()
 			: base() { }
 
-		public HarpyFeatherCloak(GamePlayer questingPlayer)
+		public SpearofKings(GamePlayer questingPlayer)
 			: base(questingPlayer) { }
 
 		/// <summary>
@@ -81,7 +79,7 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		/// <param name="questingPlayer"></param>
 		/// <param name="dbQuest"></param>
-        public HarpyFeatherCloak(GamePlayer questingPlayer, DBQuest dbQuest)
+		public SpearofKings(GamePlayer questingPlayer, DBQuest dbQuest)
 			: base(questingPlayer, dbQuest) { }
 
 		/// <summary>
@@ -89,22 +87,22 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		public static void Init()
 		{
-            ArtifactQuest.Init(m_artifactID, typeof(HarpyFeatherCloak));
+			ArtifactQuest.Init(m_artifactID, typeof(SpearofKings));
 		}
 
-        /// <summary>
-        /// Check if player is eligible for this quest.
-        /// </summary>
-        /// <param name="player"></param>
-        /// <returns></returns>
-        public override bool CheckQuestQualification(GamePlayer player)
-        {
-            if (!base.CheckQuestQualification(player))
-                return false;
+		/// <summary>
+		/// Check if player is eligible for this quest.
+		/// </summary>
+		/// <param name="player"></param>
+		/// <returns></returns>
+		public override bool CheckQuestQualification(GamePlayer player)
+		{
+			if (!base.CheckQuestQualification(player))
+				return false;
 
-            // TODO: Check if this is the correct level for the quest.
-            return (player.Level >= 45);
-        }
+			// TODO: Check if this is the correct level for the quest.
+			return (player.Level >= m_requiredLevel);
+		}
 
 		/// <summary>
 		/// Handle an item given to the scholar.
@@ -123,18 +121,21 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			if (player == null || scholar == null)
 				return false;
 
-			if (Step == 2 && ArtifactMgr.GetArtifactID(item.Name) == ArtifactID)
+			if (Step > -1 && ArtifactMgr.GetArtifactID(item.Name) == ArtifactID)
 			{
 				Dictionary<String, ItemTemplate> versions = ArtifactMgr.GetArtifactVersions(ArtifactID,
 					(eCharacterClass)player.CharacterClass.ID, (eRealm)player.Realm);
-				
+
 				if (versions.Count > 0 && RemoveItem(player, item))
 				{
 					GiveItem(scholar, player, ArtifactID, versions[";;"]);
-					String reply = String.Format("Brilliant, thank you! Here, take the artifact. {0} {1} {2}",
-						"I've unlocked its powers for you. As I've said before, I'm more interested",
-						"in the stories and the history behind these artifacts than the actual items",
-						"themselves.");
+					String reply = String.Format("Here is the {0}, {1} {2} {3} {4}, {5}!",
+						"restored to its original power. It is a fine item and I wish I could keep",
+						"it, but it is for you and you alone. Do not destroy it because you will never",
+						"have access to its full power again. Take care of it and it shall aid you in",
+						"the trials",
+						ArtifactID,
+						player.CharacterClass.Name);
 					scholar.TurnTo(player);
 					scholar.SayTo(player, eChatLoc.CL_PopupWindow, reply);
 					FinishQuest();
@@ -162,16 +163,25 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			if (player == null || scholar == null)
 				return false;
 
-			if (Step == 1 && text.ToLower() == ArtifactID.ToLower())
+			if (Step > -1 && text.ToLower() == ArtifactID.ToLower())
 			{
-                String reply = "Oh, the mysterious Harpy Feather Cloak. Do you have the scrolls on it? I've found a few that allude to its true nature, but haven't found anything with any detail.";
+				/* Commenting out to give a template for future development
+				String reply = String.Format("Vara was a very skilled healer and she put her skills {0} {1} {2}",
+					"into the Healer's Embrace cloak. It would help me to unlock them if I was to read",
+					"her Medical Log. Please give me Vara's Medical Log now so that I may awaken the",
+					"magic within the Cloak for you.");
 				scholar.TurnTo(player);
 				scholar.SayTo(player, eChatLoc.CL_PopupWindow, reply);
 				Step = 2;
-				return true;
+				return true;*/
 			}
 
 			return false;
+		}
+
+		public override void Notify(DOLEvent e, object sender, EventArgs args)
+		{
+			// Need to do anything here?
 		}
 	}
 }

--- a/GameServer/quests/Atlantis/Artifacts/StaffofGod.cs
+++ b/GameServer/quests/Atlantis/Artifacts/StaffofGod.cs
@@ -31,7 +31,44 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
     /// <author>Aredhel</author>
     public class StaffofGod : ArtifactQuest
     {
-        public StaffofGod()
+		/// <summary>
+		/// The name of the quest (not necessarily the same as
+		/// the name of the reward).
+		/// </summary>
+		public override string Name
+		{
+			get { return "Staff of the God"; }
+		}
+
+		/// <summary>
+		/// The reward for this quest.
+		/// </summary>
+		private static String m_artifactID = "Staff of the God";
+		public override String ArtifactID
+		{
+			get { return m_artifactID; }
+		}
+
+		/// <summary>
+		/// Description for the current step.
+		/// </summary>
+		public override string Description
+		{
+			get
+			{
+				switch (Step)
+				{
+					case 1:
+						return "Obtain the staff, then clean it with the juice of a lemon.";
+					case 2:
+						return "Turn in the completed book.";
+					default:
+						return base.Description;
+				}
+			}
+		}
+
+		public StaffofGod()
 			: base() { }
 
 		public StaffofGod(GamePlayer questingPlayer)
@@ -50,7 +87,7 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		public static void Init()
 		{
-            ArtifactQuest.Init("Staff of the God", typeof(StaffofGod));
+            ArtifactQuest.Init(m_artifactID, typeof(StaffofGod));
 		}
 
         /// <summary>
@@ -134,42 +171,6 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			}
 
 			return false;
-		}
-
-		/// <summary>
-		/// Description for the current step.
-		/// </summary>
-		public override string Description
-		{
-			get
-			{
-				switch (Step)
-				{
-					case 1:
-						return "Obtain the staff, then clean it with the juice of a lemon.";
-					case 2:
-						return "Turn in the completed book.";
-					default:
-						return base.Description;
-				}
-			}
-		}
-
-		/// <summary>
-		/// The name of the quest (not necessarily the same as
-		/// the name of the reward).
-		/// </summary>
-		public override string Name
-		{
-            get { return "Staff of the God"; }
-		}
-
-		/// <summary>
-		/// The reward for this quest.
-		/// </summary>
-		public override String ArtifactID
-		{
-            get { return "Staff of the God"; }
 		}
     }
 }

--- a/GameServer/quests/Atlantis/Artifacts/StoneofAtlantis.cs
+++ b/GameServer/quests/Atlantis/Artifacts/StoneofAtlantis.cs
@@ -33,6 +33,43 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 	/// <author>Aredhel</author>
 	class StoneofAtlantis : ArtifactQuest
 	{
+		/// <summary>
+		/// The name of the quest (not necessarily the same as
+		/// the name of the reward).
+		/// </summary>
+		public override string Name
+		{
+			get { return "Stone of Atlantis"; }
+		}
+
+		/// <summary>
+		/// The reward for this quest.
+		/// </summary>
+		private static String m_artifactID = "Stone of Atlantis";
+		public override String ArtifactID
+		{
+			get { return m_artifactID; }
+		}
+
+		/// <summary>
+		/// Description for the current step.
+		/// </summary>
+		public override string Description
+		{
+			get
+			{
+				switch (Step)
+				{
+					case 1:
+						return "Defeat the Keeper of the Stone.";
+					case 2:
+						return "Turn in the completed book.";
+					default:
+						return base.Description;
+				}
+			}
+		}
+
 		public StoneofAtlantis()
 			: base() { }
 
@@ -52,7 +89,7 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		public static void Init()
 		{
-            ArtifactQuest.Init("Stone of Atlantis", typeof(StoneofAtlantis));
+            ArtifactQuest.Init(m_artifactID, typeof(StoneofAtlantis));
 		}
 
         /// <summary>
@@ -135,42 +172,6 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			}
 
 			return false;
-		}
-
-		/// <summary>
-		/// Description for the current step.
-		/// </summary>
-		public override string Description
-		{
-			get
-			{
-				switch (Step)
-				{
-					case 1:
-						return "Defeat the Keeper of the Stone.";
-					case 2:
-						return "Turn in the completed book.";
-					default:
-						return base.Description;
-				}
-			}
-		}
-
-		/// <summary>
-		/// The name of the quest (not necessarily the same as
-		/// the name of the reward).
-		/// </summary>
-		public override string Name
-		{
-            get { return "Stone of Atlantis"; }
-		}
-
-		/// <summary>
-		/// The reward for this quest.
-		/// </summary>
-		public override String ArtifactID
-		{
-            get { return "Stone of Atlantis"; }
 		}
 	}
 }

--- a/GameServer/quests/Atlantis/Artifacts/TabletofAtlantis.cs
+++ b/GameServer/quests/Atlantis/Artifacts/TabletofAtlantis.cs
@@ -33,6 +33,43 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 	/// <author>Aredhel</author>
 	class TabletofAtlantis : ArtifactQuest
 	{
+		/// <summary>
+		/// The name of the quest (not necessarily the same as
+		/// the name of the reward).
+		/// </summary>
+		public override string Name
+		{
+			get { return "Tablet of Atlantis"; }
+		}
+
+		/// <summary>
+		/// The reward for this quest.
+		/// </summary>
+		private static String m_artifactID = "Tablet of Atlantis";
+		public override String ArtifactID
+		{
+			get { return m_artifactID; }
+		}
+
+		/// <summary>
+		/// Description for the current step.
+		/// </summary>
+		public override string Description
+		{
+			get
+			{
+				switch (Step)
+				{
+					case 1:
+						return "Defeat the Guardian.";
+					case 2:
+						return "Turn in the completed book.";
+					default:
+						return base.Description;
+				}
+			}
+		}
+
 		public TabletofAtlantis()
 			: base() { }
 
@@ -52,7 +89,7 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		public static void Init()
 		{
-            ArtifactQuest.Init("Tablet of Atlantis", typeof(TabletofAtlantis));
+            ArtifactQuest.Init(m_artifactID, typeof(TabletofAtlantis));
 		}
 
         /// <summary>
@@ -135,42 +172,6 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			}
 
 			return false;
-		}
-
-		/// <summary>
-		/// Description for the current step.
-		/// </summary>
-		public override string Description
-		{
-			get
-			{
-				switch (Step)
-				{
-					case 1:
-						return "Defeat the Guardian.";
-					case 2:
-						return "Turn in the completed book.";
-					default:
-						return base.Description;
-				}
-			}
-		}
-
-		/// <summary>
-		/// The name of the quest (not necessarily the same as
-		/// the name of the reward).
-		/// </summary>
-		public override string Name
-		{
-            get { return "Tablet of Atlantis"; }
-		}
-
-		/// <summary>
-		/// The reward for this quest.
-		/// </summary>
-		public override String ArtifactID
-		{
-            get { return "Tablet of Atlantis"; }
 		}
 	}
 }

--- a/GameServer/quests/Atlantis/Artifacts/TartarosStaff.cs
+++ b/GameServer/quests/Atlantis/Artifacts/TartarosStaff.cs
@@ -31,7 +31,44 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
     /// <author>Aredhel</author>
     public class TartarosStaff : ArtifactQuest
     {
-        public TartarosStaff()
+		/// <summary>
+		/// The name of the quest (not necessarily the same as
+		/// the name of the reward).
+		/// </summary>
+		public override string Name
+		{
+			get { return "Tartaros' Gift"; }
+		}
+
+		/// <summary>
+		/// The reward for this quest.
+		/// </summary>
+		private static String m_artifactID = "Tartaros' Gift";
+		public override String ArtifactID
+		{
+			get { return m_artifactID; }
+		}
+
+		/// <summary>
+		/// Description for the current step.
+		/// </summary>
+		public override string Description
+		{
+			get
+			{
+				switch (Step)
+				{
+					case 1:
+						return "Defeat Akil.";
+					case 2:
+						return "Turn in the completed book.";
+					default:
+						return base.Description;
+				}
+			}
+		}
+
+		public TartarosStaff()
 			: base() { }
 
 		public TartarosStaff(GamePlayer questingPlayer)
@@ -50,7 +87,7 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		public static void Init()
 		{
-            ArtifactQuest.Init("Tartaros' Gift", typeof(TartarosStaff));
+            ArtifactQuest.Init(m_artifactID, typeof(TartarosStaff));
 		}
 
         /// <summary>
@@ -134,42 +171,6 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			}
 
 			return false;
-		}
-
-		/// <summary>
-		/// Description for the current step.
-		/// </summary>
-		public override string Description
-		{
-			get
-			{
-				switch (Step)
-				{
-					case 1:
-						return "Defeat Akil.";
-					case 2:
-						return "Turn in the completed book.";
-					default:
-						return base.Description;
-				}
-			}
-		}
-
-		/// <summary>
-		/// The name of the quest (not necessarily the same as
-		/// the name of the reward).
-		/// </summary>
-		public override string Name
-		{
-            get { return "Tartaros' Gift"; }
-		}
-
-		/// <summary>
-		/// The reward for this quest.
-		/// </summary>
-		public override String ArtifactID
-		{
-            get { return "Tartaros' Gift"; }
 		}
     }
 }

--- a/GameServer/quests/Atlantis/Artifacts/TraitorsDagger.cs
+++ b/GameServer/quests/Atlantis/Artifacts/TraitorsDagger.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * DAWN OF LIGHT - The first free open source DAoC server emulator
  * 
  * This program is free software; you can redistribute it and/or
@@ -28,24 +28,26 @@ using System.Collections;
 namespace DOL.GS.Quests.Atlantis.Artifacts
 {
 	/// <summary>
-	/// Quest for the Harpy Feather Cloak artifact.
+	/// Quest for the A Flask artifact.
 	/// </summary>
 	/// <author>Aredhel</author>
-	class HarpyFeatherCloak : ArtifactQuest
+	class TraitorsDagger : ArtifactQuest
 	{
+		private static int m_requiredLevel = 40;
+
 		/// <summary>
 		/// The name of the quest (not necessarily the same as
 		/// the name of the reward).
 		/// </summary>
-		public override string Name
+		public override String Name
 		{
-			get { return "Harpy Feather Cloak"; }
+			get { return "Traitor's Dagger"; }
 		}
 
 		/// <summary>
 		/// The reward for this quest.
 		/// </summary>
-		private static String m_artifactID = "Harpy Feather Cloak";
+		private const String m_artifactID = "Traitor's Dagger";
 		public override String ArtifactID
 		{
 			get { return m_artifactID; }
@@ -60,20 +62,16 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			{
 				switch (Step)
 				{
-					case 1:
-						return "Defeat the Harpies.";
-					case 2:
-						return "Turn in the completed book.";
 					default:
 						return base.Description;
 				}
 			}
 		}
 
-		public HarpyFeatherCloak()
+		public TraitorsDagger()
 			: base() { }
 
-		public HarpyFeatherCloak(GamePlayer questingPlayer)
+		public TraitorsDagger(GamePlayer questingPlayer)
 			: base(questingPlayer) { }
 
 		/// <summary>
@@ -81,7 +79,7 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		/// <param name="questingPlayer"></param>
 		/// <param name="dbQuest"></param>
-        public HarpyFeatherCloak(GamePlayer questingPlayer, DBQuest dbQuest)
+		public TraitorsDagger(GamePlayer questingPlayer, DBQuest dbQuest)
 			: base(questingPlayer, dbQuest) { }
 
 		/// <summary>
@@ -89,22 +87,22 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		public static void Init()
 		{
-            ArtifactQuest.Init(m_artifactID, typeof(HarpyFeatherCloak));
+			ArtifactQuest.Init(m_artifactID, typeof(TraitorsDagger));
 		}
 
-        /// <summary>
-        /// Check if player is eligible for this quest.
-        /// </summary>
-        /// <param name="player"></param>
-        /// <returns></returns>
-        public override bool CheckQuestQualification(GamePlayer player)
-        {
-            if (!base.CheckQuestQualification(player))
-                return false;
+		/// <summary>
+		/// Check if player is eligible for this quest.
+		/// </summary>
+		/// <param name="player"></param>
+		/// <returns></returns>
+		public override bool CheckQuestQualification(GamePlayer player)
+		{
+			if (!base.CheckQuestQualification(player))
+				return false;
 
-            // TODO: Check if this is the correct level for the quest.
-            return (player.Level >= 45);
-        }
+			// TODO: Check if this is the correct level for the quest.
+			return (player.Level >= m_requiredLevel);
+		}
 
 		/// <summary>
 		/// Handle an item given to the scholar.
@@ -123,18 +121,21 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			if (player == null || scholar == null)
 				return false;
 
-			if (Step == 2 && ArtifactMgr.GetArtifactID(item.Name) == ArtifactID)
+			if (Step > -1 && ArtifactMgr.GetArtifactID(item.Name) == ArtifactID)
 			{
 				Dictionary<String, ItemTemplate> versions = ArtifactMgr.GetArtifactVersions(ArtifactID,
 					(eCharacterClass)player.CharacterClass.ID, (eRealm)player.Realm);
-				
+
 				if (versions.Count > 0 && RemoveItem(player, item))
 				{
 					GiveItem(scholar, player, ArtifactID, versions[";;"]);
-					String reply = String.Format("Brilliant, thank you! Here, take the artifact. {0} {1} {2}",
-						"I've unlocked its powers for you. As I've said before, I'm more interested",
-						"in the stories and the history behind these artifacts than the actual items",
-						"themselves.");
+					String reply = String.Format("Here is the {0}, {1} {2} {3} {4}, {5}!",
+						"restored to its original power. It is a fine item and I wish I could keep",
+						"it, but it is for you and you alone. Do not destroy it because you will never",
+						"have access to its full power again. Take care of it and it shall aid you in",
+						"the trials",
+						ArtifactID,
+						player.CharacterClass.Name);
 					scholar.TurnTo(player);
 					scholar.SayTo(player, eChatLoc.CL_PopupWindow, reply);
 					FinishQuest();
@@ -162,16 +163,25 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			if (player == null || scholar == null)
 				return false;
 
-			if (Step == 1 && text.ToLower() == ArtifactID.ToLower())
+			if (Step > -1 && text.ToLower() == ArtifactID.ToLower())
 			{
-                String reply = "Oh, the mysterious Harpy Feather Cloak. Do you have the scrolls on it? I've found a few that allude to its true nature, but haven't found anything with any detail.";
+				/* Commenting out to give a template for future development
+				String reply = String.Format("Vara was a very skilled healer and she put her skills {0} {1} {2}",
+					"into the Healer's Embrace cloak. It would help me to unlock them if I was to read",
+					"her Medical Log. Please give me Vara's Medical Log now so that I may awaken the",
+					"magic within the Cloak for you.");
 				scholar.TurnTo(player);
 				scholar.SayTo(player, eChatLoc.CL_PopupWindow, reply);
 				Step = 2;
-				return true;
+				return true;*/
 			}
 
 			return false;
+		}
+
+		public override void Notify(DOLEvent e, object sender, EventArgs args)
+		{
+			// Need to do anything here?
 		}
 	}
 }

--- a/GameServer/quests/Atlantis/Artifacts/TraldorsOracle.cs
+++ b/GameServer/quests/Atlantis/Artifacts/TraldorsOracle.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * DAWN OF LIGHT - The first free open source DAoC server emulator
  * 
  * This program is free software; you can redistribute it and/or
@@ -28,24 +28,26 @@ using System.Collections;
 namespace DOL.GS.Quests.Atlantis.Artifacts
 {
 	/// <summary>
-	/// Quest for the Harpy Feather Cloak artifact.
+	/// Quest for the A Flask artifact.
 	/// </summary>
 	/// <author>Aredhel</author>
-	class HarpyFeatherCloak : ArtifactQuest
+	class TraldorsOracle : ArtifactQuest
 	{
+		private static int m_requiredLevel = 36;
+
 		/// <summary>
 		/// The name of the quest (not necessarily the same as
 		/// the name of the reward).
 		/// </summary>
-		public override string Name
+		public override String Name
 		{
-			get { return "Harpy Feather Cloak"; }
+			get { return "Traldor's Oracle"; }
 		}
 
 		/// <summary>
 		/// The reward for this quest.
 		/// </summary>
-		private static String m_artifactID = "Harpy Feather Cloak";
+		private const String m_artifactID = "Traldor's Oracle";
 		public override String ArtifactID
 		{
 			get { return m_artifactID; }
@@ -60,20 +62,16 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			{
 				switch (Step)
 				{
-					case 1:
-						return "Defeat the Harpies.";
-					case 2:
-						return "Turn in the completed book.";
 					default:
 						return base.Description;
 				}
 			}
 		}
 
-		public HarpyFeatherCloak()
+		public TraldorsOracle()
 			: base() { }
 
-		public HarpyFeatherCloak(GamePlayer questingPlayer)
+		public TraldorsOracle(GamePlayer questingPlayer)
 			: base(questingPlayer) { }
 
 		/// <summary>
@@ -81,7 +79,7 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		/// <param name="questingPlayer"></param>
 		/// <param name="dbQuest"></param>
-        public HarpyFeatherCloak(GamePlayer questingPlayer, DBQuest dbQuest)
+		public TraldorsOracle(GamePlayer questingPlayer, DBQuest dbQuest)
 			: base(questingPlayer, dbQuest) { }
 
 		/// <summary>
@@ -89,22 +87,22 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		public static void Init()
 		{
-            ArtifactQuest.Init(m_artifactID, typeof(HarpyFeatherCloak));
+			ArtifactQuest.Init(m_artifactID, typeof(TraldorsOracle));
 		}
 
-        /// <summary>
-        /// Check if player is eligible for this quest.
-        /// </summary>
-        /// <param name="player"></param>
-        /// <returns></returns>
-        public override bool CheckQuestQualification(GamePlayer player)
-        {
-            if (!base.CheckQuestQualification(player))
-                return false;
+		/// <summary>
+		/// Check if player is eligible for this quest.
+		/// </summary>
+		/// <param name="player"></param>
+		/// <returns></returns>
+		public override bool CheckQuestQualification(GamePlayer player)
+		{
+			if (!base.CheckQuestQualification(player))
+				return false;
 
-            // TODO: Check if this is the correct level for the quest.
-            return (player.Level >= 45);
-        }
+			// TODO: Check if this is the correct level for the quest.
+			return (player.Level >= m_requiredLevel);
+		}
 
 		/// <summary>
 		/// Handle an item given to the scholar.
@@ -123,18 +121,21 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			if (player == null || scholar == null)
 				return false;
 
-			if (Step == 2 && ArtifactMgr.GetArtifactID(item.Name) == ArtifactID)
+			if (Step > -1 && ArtifactMgr.GetArtifactID(item.Name) == ArtifactID)
 			{
 				Dictionary<String, ItemTemplate> versions = ArtifactMgr.GetArtifactVersions(ArtifactID,
 					(eCharacterClass)player.CharacterClass.ID, (eRealm)player.Realm);
-				
+
 				if (versions.Count > 0 && RemoveItem(player, item))
 				{
 					GiveItem(scholar, player, ArtifactID, versions[";;"]);
-					String reply = String.Format("Brilliant, thank you! Here, take the artifact. {0} {1} {2}",
-						"I've unlocked its powers for you. As I've said before, I'm more interested",
-						"in the stories and the history behind these artifacts than the actual items",
-						"themselves.");
+					String reply = String.Format("Here is the {0}, {1} {2} {3} {4}, {5}!",
+						"restored to its original power. It is a fine item and I wish I could keep",
+						"it, but it is for you and you alone. Do not destroy it because you will never",
+						"have access to its full power again. Take care of it and it shall aid you in",
+						"the trials",
+						ArtifactID,
+						player.CharacterClass.Name);
 					scholar.TurnTo(player);
 					scholar.SayTo(player, eChatLoc.CL_PopupWindow, reply);
 					FinishQuest();
@@ -162,16 +163,25 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			if (player == null || scholar == null)
 				return false;
 
-			if (Step == 1 && text.ToLower() == ArtifactID.ToLower())
+			if (Step > -1 && text.ToLower() == ArtifactID.ToLower())
 			{
-                String reply = "Oh, the mysterious Harpy Feather Cloak. Do you have the scrolls on it? I've found a few that allude to its true nature, but haven't found anything with any detail.";
+				/* Commenting out to give a template for future development
+				String reply = String.Format("Vara was a very skilled healer and she put her skills {0} {1} {2}",
+					"into the Healer's Embrace cloak. It would help me to unlock them if I was to read",
+					"her Medical Log. Please give me Vara's Medical Log now so that I may awaken the",
+					"magic within the Cloak for you.");
 				scholar.TurnTo(player);
 				scholar.SayTo(player, eChatLoc.CL_PopupWindow, reply);
 				Step = 2;
-				return true;
+				return true;*/
 			}
 
 			return false;
+		}
+
+		public override void Notify(DOLEvent e, object sender, EventArgs args)
+		{
+			// Need to do anything here?
 		}
 	}
 }

--- a/GameServer/quests/Atlantis/Artifacts/WingedHelm.cs
+++ b/GameServer/quests/Atlantis/Artifacts/WingedHelm.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * DAWN OF LIGHT - The first free open source DAoC server emulator
  * 
  * This program is free software; you can redistribute it and/or
@@ -28,24 +28,26 @@ using System.Collections;
 namespace DOL.GS.Quests.Atlantis.Artifacts
 {
 	/// <summary>
-	/// Quest for the Harpy Feather Cloak artifact.
+	/// Quest for the A Flask artifact.
 	/// </summary>
 	/// <author>Aredhel</author>
-	class HarpyFeatherCloak : ArtifactQuest
+	class WingedHelm : ArtifactQuest
 	{
+		private static int m_requiredLevel = 45;
+
 		/// <summary>
 		/// The name of the quest (not necessarily the same as
 		/// the name of the reward).
 		/// </summary>
-		public override string Name
+		public override String Name
 		{
-			get { return "Harpy Feather Cloak"; }
+			get { return "Winged Helm"; }
 		}
 
 		/// <summary>
 		/// The reward for this quest.
 		/// </summary>
-		private static String m_artifactID = "Harpy Feather Cloak";
+		private const String m_artifactID = "Winged Helm";
 		public override String ArtifactID
 		{
 			get { return m_artifactID; }
@@ -60,20 +62,16 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			{
 				switch (Step)
 				{
-					case 1:
-						return "Defeat the Harpies.";
-					case 2:
-						return "Turn in the completed book.";
 					default:
 						return base.Description;
 				}
 			}
 		}
 
-		public HarpyFeatherCloak()
+		public WingedHelm()
 			: base() { }
 
-		public HarpyFeatherCloak(GamePlayer questingPlayer)
+		public WingedHelm(GamePlayer questingPlayer)
 			: base(questingPlayer) { }
 
 		/// <summary>
@@ -81,7 +79,7 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		/// <param name="questingPlayer"></param>
 		/// <param name="dbQuest"></param>
-        public HarpyFeatherCloak(GamePlayer questingPlayer, DBQuest dbQuest)
+		public WingedHelm(GamePlayer questingPlayer, DBQuest dbQuest)
 			: base(questingPlayer, dbQuest) { }
 
 		/// <summary>
@@ -89,22 +87,22 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		public static void Init()
 		{
-            ArtifactQuest.Init(m_artifactID, typeof(HarpyFeatherCloak));
+			ArtifactQuest.Init(m_artifactID, typeof(WingedHelm));
 		}
 
-        /// <summary>
-        /// Check if player is eligible for this quest.
-        /// </summary>
-        /// <param name="player"></param>
-        /// <returns></returns>
-        public override bool CheckQuestQualification(GamePlayer player)
-        {
-            if (!base.CheckQuestQualification(player))
-                return false;
+		/// <summary>
+		/// Check if player is eligible for this quest.
+		/// </summary>
+		/// <param name="player"></param>
+		/// <returns></returns>
+		public override bool CheckQuestQualification(GamePlayer player)
+		{
+			if (!base.CheckQuestQualification(player))
+				return false;
 
-            // TODO: Check if this is the correct level for the quest.
-            return (player.Level >= 45);
-        }
+			// TODO: Check if this is the correct level for the quest.
+			return (player.Level >= m_requiredLevel);
+		}
 
 		/// <summary>
 		/// Handle an item given to the scholar.
@@ -123,18 +121,21 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			if (player == null || scholar == null)
 				return false;
 
-			if (Step == 2 && ArtifactMgr.GetArtifactID(item.Name) == ArtifactID)
+			if (Step > -1 && ArtifactMgr.GetArtifactID(item.Name) == ArtifactID)
 			{
 				Dictionary<String, ItemTemplate> versions = ArtifactMgr.GetArtifactVersions(ArtifactID,
 					(eCharacterClass)player.CharacterClass.ID, (eRealm)player.Realm);
-				
+
 				if (versions.Count > 0 && RemoveItem(player, item))
 				{
 					GiveItem(scholar, player, ArtifactID, versions[";;"]);
-					String reply = String.Format("Brilliant, thank you! Here, take the artifact. {0} {1} {2}",
-						"I've unlocked its powers for you. As I've said before, I'm more interested",
-						"in the stories and the history behind these artifacts than the actual items",
-						"themselves.");
+					String reply = String.Format("Here is the {0}, {1} {2} {3} {4}, {5}!",
+						"restored to its original power. It is a fine item and I wish I could keep",
+						"it, but it is for you and you alone. Do not destroy it because you will never",
+						"have access to its full power again. Take care of it and it shall aid you in",
+						"the trials",
+						ArtifactID,
+						player.CharacterClass.Name);
 					scholar.TurnTo(player);
 					scholar.SayTo(player, eChatLoc.CL_PopupWindow, reply);
 					FinishQuest();
@@ -162,16 +163,25 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			if (player == null || scholar == null)
 				return false;
 
-			if (Step == 1 && text.ToLower() == ArtifactID.ToLower())
+			if (Step > -1 && text.ToLower() == ArtifactID.ToLower())
 			{
-                String reply = "Oh, the mysterious Harpy Feather Cloak. Do you have the scrolls on it? I've found a few that allude to its true nature, but haven't found anything with any detail.";
+				/* Commenting out to give a template for future development
+				String reply = String.Format("Vara was a very skilled healer and she put her skills {0} {1} {2}",
+					"into the Healer's Embrace cloak. It would help me to unlock them if I was to read",
+					"her Medical Log. Please give me Vara's Medical Log now so that I may awaken the",
+					"magic within the Cloak for you.");
 				scholar.TurnTo(player);
 				scholar.SayTo(player, eChatLoc.CL_PopupWindow, reply);
 				Step = 2;
-				return true;
+				return true;*/
 			}
 
 			return false;
+		}
+
+		public override void Notify(DOLEvent e, object sender, EventArgs args)
+		{
+			// Need to do anything here?
 		}
 	}
 }

--- a/GameServer/quests/Atlantis/Artifacts/WingsDive.cs
+++ b/GameServer/quests/Atlantis/Artifacts/WingsDive.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * DAWN OF LIGHT - The first free open source DAoC server emulator
  * 
  * This program is free software; you can redistribute it and/or
@@ -28,24 +28,26 @@ using System.Collections;
 namespace DOL.GS.Quests.Atlantis.Artifacts
 {
 	/// <summary>
-	/// Quest for the Harpy Feather Cloak artifact.
+	/// Quest for the A Flask artifact.
 	/// </summary>
 	/// <author>Aredhel</author>
-	class HarpyFeatherCloak : ArtifactQuest
+	class WingsDive : ArtifactQuest
 	{
+		private static int m_requiredLevel = 45;
+
 		/// <summary>
 		/// The name of the quest (not necessarily the same as
 		/// the name of the reward).
 		/// </summary>
-		public override string Name
+		public override String Name
 		{
-			get { return "Harpy Feather Cloak"; }
+			get { return "Wings Dive"; }
 		}
 
 		/// <summary>
 		/// The reward for this quest.
 		/// </summary>
-		private static String m_artifactID = "Harpy Feather Cloak";
+		private const String m_artifactID = "Wings Dive";
 		public override String ArtifactID
 		{
 			get { return m_artifactID; }
@@ -60,20 +62,16 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			{
 				switch (Step)
 				{
-					case 1:
-						return "Defeat the Harpies.";
-					case 2:
-						return "Turn in the completed book.";
 					default:
 						return base.Description;
 				}
 			}
 		}
 
-		public HarpyFeatherCloak()
+		public WingsDive()
 			: base() { }
 
-		public HarpyFeatherCloak(GamePlayer questingPlayer)
+		public WingsDive(GamePlayer questingPlayer)
 			: base(questingPlayer) { }
 
 		/// <summary>
@@ -81,7 +79,7 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		/// <param name="questingPlayer"></param>
 		/// <param name="dbQuest"></param>
-        public HarpyFeatherCloak(GamePlayer questingPlayer, DBQuest dbQuest)
+		public WingsDive(GamePlayer questingPlayer, DBQuest dbQuest)
 			: base(questingPlayer, dbQuest) { }
 
 		/// <summary>
@@ -89,22 +87,22 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 		/// </summary>
 		public static void Init()
 		{
-            ArtifactQuest.Init(m_artifactID, typeof(HarpyFeatherCloak));
+			ArtifactQuest.Init(m_artifactID, typeof(WingsDive));
 		}
 
-        /// <summary>
-        /// Check if player is eligible for this quest.
-        /// </summary>
-        /// <param name="player"></param>
-        /// <returns></returns>
-        public override bool CheckQuestQualification(GamePlayer player)
-        {
-            if (!base.CheckQuestQualification(player))
-                return false;
+		/// <summary>
+		/// Check if player is eligible for this quest.
+		/// </summary>
+		/// <param name="player"></param>
+		/// <returns></returns>
+		public override bool CheckQuestQualification(GamePlayer player)
+		{
+			if (!base.CheckQuestQualification(player))
+				return false;
 
-            // TODO: Check if this is the correct level for the quest.
-            return (player.Level >= 45);
-        }
+			// TODO: Check if this is the correct level for the quest.
+			return (player.Level >= m_requiredLevel);
+		}
 
 		/// <summary>
 		/// Handle an item given to the scholar.
@@ -123,18 +121,21 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			if (player == null || scholar == null)
 				return false;
 
-			if (Step == 2 && ArtifactMgr.GetArtifactID(item.Name) == ArtifactID)
+			if (Step > -1 && ArtifactMgr.GetArtifactID(item.Name) == ArtifactID)
 			{
 				Dictionary<String, ItemTemplate> versions = ArtifactMgr.GetArtifactVersions(ArtifactID,
 					(eCharacterClass)player.CharacterClass.ID, (eRealm)player.Realm);
-				
+
 				if (versions.Count > 0 && RemoveItem(player, item))
 				{
 					GiveItem(scholar, player, ArtifactID, versions[";;"]);
-					String reply = String.Format("Brilliant, thank you! Here, take the artifact. {0} {1} {2}",
-						"I've unlocked its powers for you. As I've said before, I'm more interested",
-						"in the stories and the history behind these artifacts than the actual items",
-						"themselves.");
+					String reply = String.Format("Here is the {0}, {1} {2} {3} {4}, {5}!",
+						"restored to its original power. It is a fine item and I wish I could keep",
+						"it, but it is for you and you alone. Do not destroy it because you will never",
+						"have access to its full power again. Take care of it and it shall aid you in",
+						"the trials",
+						ArtifactID,
+						player.CharacterClass.Name);
 					scholar.TurnTo(player);
 					scholar.SayTo(player, eChatLoc.CL_PopupWindow, reply);
 					FinishQuest();
@@ -162,16 +163,25 @@ namespace DOL.GS.Quests.Atlantis.Artifacts
 			if (player == null || scholar == null)
 				return false;
 
-			if (Step == 1 && text.ToLower() == ArtifactID.ToLower())
+			if (Step > -1 && text.ToLower() == ArtifactID.ToLower())
 			{
-                String reply = "Oh, the mysterious Harpy Feather Cloak. Do you have the scrolls on it? I've found a few that allude to its true nature, but haven't found anything with any detail.";
+				/* Commenting out to give a template for future development
+				String reply = String.Format("Vara was a very skilled healer and she put her skills {0} {1} {2}",
+					"into the Healer's Embrace cloak. It would help me to unlock them if I was to read",
+					"her Medical Log. Please give me Vara's Medical Log now so that I may awaken the",
+					"magic within the Cloak for you.");
 				scholar.TurnTo(player);
 				scholar.SayTo(player, eChatLoc.CL_PopupWindow, reply);
 				Step = 2;
-				return true;
+				return true;*/
 			}
 
 			return false;
+		}
+
+		public override void Notify(DOLEvent e, object sender, EventArgs args)
+		{
+			// Need to do anything here?
 		}
 	}
 }


### PR DESCRIPTION
There were a bunch of placeholder artifact encounters without matching artifact quests.  I added placeholder quests to make those artifacts available.

They were also using two hard coded strings for ArtifactID and Init().  I changed it to use a common property, and moved hard coded properties to the beginning of the file to make them more visible.