### PR TITLE
New baf

### DIFF
--- a/GameServer/ai/brain/ControlledNpcBrain.cs
+++ b/GameServer/ai/brain/ControlledNpcBrain.cs
@@ -1029,7 +1029,7 @@ namespace DOL.AI.Brain
 			AttackMostWanted();
 		}
 
-		protected override void BringFriends(AttackData ad)
+		protected override void BringFriends(GameLiving trigger)
 		{
 			// don't
 		}

--- a/GameServer/ai/brain/Guards/Lord.cs
+++ b/GameServer/ai/brain/Guards/Lord.cs
@@ -38,8 +38,8 @@ namespace DOL.AI.Brain
 		/// <summary>
 		/// Bring all alive keep guards to defend the lord
 		/// </summary>
-		/// <param name="attackData">The data associated with the puller's attack.</param>
-		protected override void BringFriends(AttackData ad)
+		/// <param name="trigger">The entity which triggered the BAF.</param>
+		protected override void BringFriends(GameLiving trigger)
 		{
 			if (GameServer.Instance.Configuration.ServerType == eGameServerType.GST_PvE)
 			{
@@ -70,7 +70,7 @@ namespace DOL.AI.Brain
 				}
 			}
 			else
-				base.BringFriends(ad);
+				base.BringFriends(trigger);
 		}
 	}// LordBrain
 }

--- a/GameServer/serverproperty/ServerProperties.cs
+++ b/GameServer/serverproperty/ServerProperties.cs
@@ -1676,6 +1676,18 @@ namespace DOL.GS.ServerProperties
 
 		#region PVE / TOA
 		/// <summary>
+		/// Initial percent chance of a mob BAFing for a single attacker
+		/// </summary>
+		[ServerProperty("pve", "baf_initial_chance", "Percent chance for a mob to bring a friend when attacked by a single attacker.  Each multiples of 100 guarantee an add, so a cumulative chance of 250% guarantees two adds with a 50% chance of a third.", 0)]
+		public static int BAF_INITIAL_CHANCE;
+
+		/// <summary>
+		/// Added percent chance of a mob BAFing for each attacker past the first
+		/// </summary>
+		[ServerProperty("pve", "baf_additional_chance", "Percent chance for a mob to bring a friend for each additional attacker.  Each multiples of 100 guarantee an add, so a cumulative chance of 250% guarantees two adds with a 50% chance of a third.", 50)]
+		public static int BAF_ADDITIONAL_CHANCE;			
+
+		/// <summary>
 		/// Adjustment to missrate per number of attackers
 		/// </summary>
 		[ServerProperty("pve", "missrate_reduction_per_attackers", "Adjustment to missrate per number of attackers", 0)]


### PR DESCRIPTION
The old bring a friend code used two separate mechanisms, one of which was only used in dungeons.  The new code is used everywhere, is more consistent with live, and adds two server properties to allow the odds of mobs bringing friends to be adjusted.

Mobs don't always trigger a AttackedByEnemy event before going hostile, which was leading to BAF code not always being called.  I've moved the BringFriends() call to AddToAggroList() instead to ensure it is always called.

The new implementation fixes the following situations in which mobs wouldn't always BAF properly:
Mob attacked on its own
Pulled by pet
Pulled by non damaging spell such as debuff
Mob BAFing multiple times in a fight
Mobs brought by a friend also trying to BAF