### PR TITLE
Added allow_train_anywhere functionality

### DIFF
--- a/GameServer/commands/playercommands/train.cs
+++ b/GameServer/commands/playercommands/train.cs
@@ -67,7 +67,7 @@ namespace DOL.GS.Commands
 
 			GameTrainer trainer = client.Player.TargetObject as GameTrainer;
 			// Make sure the player is at a trainer.
-			if (client.Account.PrivLevel == (int)ePrivLevel.Player && (trainer == null || trainer.CanTrain(client.Player) == false))
+			if (!DOL.GS.ServerProperties.Properties.ALLOW_TRAIN_ANYWHERE && client.Account.PrivLevel == (int)ePrivLevel.Player && (trainer == null || trainer.CanTrain(client.Player) == false))
 			{
 				client.Out.SendMessage("You have to be at your trainer to use this command.", eChatType.CT_System, eChatLoc.CL_SystemWindow);
 				return;

--- a/GameServer/packets/Client/168/PlayerTrainRequestHandler.cs
+++ b/GameServer/packets/Client/168/PlayerTrainRequestHandler.cs
@@ -41,7 +41,7 @@ namespace DOL.GS.PacketHandler.Client.v168
 
 		public void HandlePacket(GameClient client, GSPacketIn packet)
 		{
-            if (client.Account.PrivLevel == (int)ePrivLevel.Player)
+            if (!DOL.GS.ServerProperties.Properties.ALLOW_TRAIN_ANYWHERE && client.Account.PrivLevel == (int)ePrivLevel.Player)
             {
                 GameTrainer trainer = client.Player.TargetObject as DOL.GS.GameTrainer;
                 if (trainer == null || (trainer.CanTrain(client.Player) == false && trainer.CanTrainChampionLevels(client.Player) == false))
@@ -197,7 +197,7 @@ namespace DOL.GS.PacketHandler.Client.v168
 	{
 		public void HandlePacket(GameClient client, GSPacketIn packet)
 		{
-            if (client.Account.PrivLevel == (int)ePrivLevel.Player)
+            if (!DOL.GS.ServerProperties.Properties.ALLOW_TRAIN_ANYWHERE && client.Account.PrivLevel == (int)ePrivLevel.Player)
             {
                 // A trainer of the appropriate class must be around (or global trainer, with TrainedClass = eCharacterClass.Unknow
                 GameTrainer trainer = client.Player.TargetObject as DOL.GS.GameTrainer;
@@ -347,7 +347,7 @@ namespace DOL.GS.PacketHandler.Client.v168
 		{
 			public void HandlePacket(GameClient client, GSPacketIn packet)
 			{
-                if (client.Account.PrivLevel == (int)ePrivLevel.Player)
+				if (!DOL.GS.ServerProperties.Properties.ALLOW_TRAIN_ANYWHERE && client.Account.PrivLevel == (int)ePrivLevel.Player)
                 {
                     GameTrainer trainer = client.Player.TargetObject as DOL.GS.GameTrainer;
                     if (trainer == null || (trainer.CanTrain(client.Player) == false && trainer.CanTrainChampionLevels(client.Player) == false))

--- a/GameServer/serverproperty/ServerProperties.cs
+++ b/GameServer/serverproperty/ServerProperties.cs
@@ -1926,7 +1926,7 @@ namespace DOL.GS.ServerProperties
 		/// <summary>
 		/// Allow players to /train without having a trainer present
 		/// </summary>
-		[ServerProperty("classes", "allow_train_anywhere", "Allow players to use the /train command to open a trainer window anywhere in the world?", false)]
+		[ServerProperty("classes", "allow_train_anywhere", "Allow players to use the /train command to open a trainer window anywhere in the world?", true)]
 		public static bool ALLOW_TRAIN_ANYWHERE;
 
 		/// <summary>

--- a/GameServer/serverproperty/ServerProperties.cs
+++ b/GameServer/serverproperty/ServerProperties.cs
@@ -1923,6 +1923,11 @@ namespace DOL.GS.ServerProperties
 		#endregion
 
 		#region CLASSES
+		/// <summary>
+		/// Disable some classes from being created
+		/// </summary>
+		[ServerProperty("classes", "allow_train_anywhere", "Allow players to use the /train command to open a trainer window anywhere in the world?", false)]
+		public static bool ALLOW_TRAIN_ANYWHERE;
 
 		/// <summary>
 		/// Disable some classes from being created

--- a/GameServer/serverproperty/ServerProperties.cs
+++ b/GameServer/serverproperty/ServerProperties.cs
@@ -1924,7 +1924,7 @@ namespace DOL.GS.ServerProperties
 
 		#region CLASSES
 		/// <summary>
-		/// Disable some classes from being created
+		/// Allow players to /train without having a trainer present
 		/// </summary>
 		[ServerProperty("classes", "allow_train_anywhere", "Allow players to use the /train command to open a trainer window anywhere in the world?", false)]
 		public static bool ALLOW_TRAIN_ANYWHERE;


### PR DESCRIPTION
I really like Phoenix letting people use the /train command to train anywhere in the world rather than having to run back to their trainer, so I added that functionality.  Since it's not livelike, it's disabled by default and has to be enabled by the allow_train_anywhere server property.