### PR TITLE
Necro pet spellcasting can be interrupted

### DIFF
--- a/GameServer/ai/brain/Necromancer/NecromancerPetBrain.cs
+++ b/GameServer/ai/brain/Necromancer/NecromancerPetBrain.cs
@@ -180,8 +180,8 @@ namespace DOL.AI.Brain
             }
             else if (e == GameLivingEvent.CastFailed)
             {
-				// Tell owner why cast has failed.
-				switch ((args as CastFailedEventArgs).Reason)
+                // Tell owner why cast has failed.
+                switch ((args as CastFailedEventArgs).Reason)
                 {
                     case CastFailedEventArgs.Reasons.TargetTooFarAway:
 

--- a/GameServer/gameobjects/Necromancer/NecromancerPet.cs
+++ b/GameServer/gameobjects/Necromancer/NecromancerPet.cs
@@ -112,7 +112,6 @@ namespace DOL.GS
 					break;
 			}
 		}
-
 		#region Stats
 
 		/// <summary>
@@ -366,6 +365,24 @@ namespace DOL.GS
 		#endregion
 
 		#region Spells
+		/// <summary>
+		/// This method is called at the end of the attack sequence to
+		/// notify objects if they have been attacked/hit by an attack
+		/// </summary>
+		/// <param name="ad">information about the attack</param>
+		public override void OnAttackedByEnemy(AttackData ad)
+		{
+			// IsCasting doesn't work for necro pets
+			if (Brain is NecromancerPetBrain necroBrain && necroBrain.SpellsQueued && !HasEffect(typeof(FacilitatePainworkingEffect)) 
+				&& ad != null && ad.Attacker != null && ChanceSpellInterrupt(ad.Attacker))
+			{
+				StopCurrentSpellcast();
+				necroBrain.ClearSpellQueue();
+				necroBrain.MessageToOwner("Your pet was attacked by " + ad.Attacker.Name + " and their spell was interrupted!", eChatType.CT_SpellResisted);
+			}
+
+			base.OnAttackedByEnemy(ad);
+		}
 
 		/// <summary>
 		/// Pet-only insta spells.


### PR DESCRIPTION
Necro pets weren't being interrupted when spellcasting.  I added code to ensure the pet can actually cast spells before adding them to the queue, and used OnAttackedByEnemy() to check for interrupts and cancel spellcasting/clear the spell queue.

That meant that instant spells could be queued behind ones with cast times and be lost if the former spell was interrupted and the queue cleared, so I had instant spells bypass the queue and cast immediately.