### PR TITLE
Added BAF_MOBS_ATTACK_RANDOM_PLAYERS server property, expanded to check battlegroups

### DIFF
--- a/GameServer/gameutils/BattleGroup.cs
+++ b/GameServer/gameutils/BattleGroup.cs
@@ -174,13 +174,12 @@ namespace DOL.GS
         
         public GamePlayer[] GetPlayersInTheBattleGroup()
         {
-            ArrayList players = new ArrayList(ServerProperties.Properties.BATTLEGROUP_MAX_MEMBER);
+            ArrayList players;
             lock (m_battlegroupMembers.SyncRoot) // Mannen 10:56 PM 10/30/2006 - Fixing every lock(this)
             {
-                for (int i = 0; i < m_battlegroupMembers.Count; i++)
-                {
-                    players.Add((GamePlayer)m_battlegroupMembers[i]);
-                }
+                players = new ArrayList(m_battlegroupMembers.Keys.Count);
+                foreach (GamePlayer player in m_battlegroupMembers.Keys)
+                    players.Add(player);
             }
             return (GamePlayer[])players.ToArray(typeof(GamePlayer));
         }

--- a/GameServer/serverproperty/ServerProperties.cs
+++ b/GameServer/serverproperty/ServerProperties.cs
@@ -1682,6 +1682,12 @@ namespace DOL.GS.ServerProperties
 		public static int BAF_INITIAL_CHANCE;
 
 		/// <summary>
+		/// Do BAF mobs attack random players near the puller?
+		/// </summary>
+		[ServerProperty("pve", "baf_mobs_attack_random_players", "Do mobs brought by friends attack random nearby players in the puller's group or battlegroup?  If false, additional mobs attack the puller as on live.", false)]
+		public static bool BAF_MOBS_ATTACK_RANDOM_PLAYERS;
+
+		/// <summary>
 		/// Added percent chance of a mob BAFing for each attacker past the first
 		/// </summary>
 		[ServerProperty("pve", "baf_additional_chance", "Percent chance for a mob to bring a friend for each additional attacker.  Each multiples of 100 guarantee an add, so a cumulative chance of 250% guarantees two adds with a 50% chance of a third.", 50)]


### PR DESCRIPTION
Live almost always sends BAF mobs after the player who pulled, so I added a server property to choose whether mobs go after random players or after the player who pulled them.

I also expanded the code to look for battlegroups so that it counts and sends mobs after all the players in a raid rather than just the players in the pulling group.  Since BGs can be up to 64 players by default, I tried to make the code as efficient as possible.

During testing, I found that BattleGroup.GetPlayersInTheBattleGroup() always returned an empty array, so I fixed it.