### PR TITLE
Fix power end heal spells

### DIFF
--- a/GameServer/spells/EnduranceHealSpellHandler.cs
+++ b/GameServer/spells/EnduranceHealSpellHandler.cs
@@ -41,14 +41,16 @@ namespace DOL.GS.Spells
 			if (targets.Count <= 0) return false;
 
 			bool healed = false;
-			int minHeal;
-			int maxHeal;
-			CalculateHealVariance(out minHeal, out maxHeal);
+
+			int spellValue = (int)Math.Round(Spell.Value);
 
 			foreach (GameLiving healTarget in targets)
 			{
-				int heal = Util.Random(minHeal, maxHeal);
-				healed |= HealTarget(healTarget, heal);
+				if (Spell.Value < 0)
+					// Restore a percentage of the target's endurance
+					spellValue = (int)Math.Round(Spell.Value * -0.01) * target.MaxEndurance;
+
+				healed |= HealTarget(healTarget, spellValue);
 			}
 
 			// group heals seem to use full power even if no heals
@@ -130,25 +132,6 @@ namespace DOL.GS.Spells
 					MessageToCaster(target.GetName(0, true) + " endurance is full.", eChatType.CT_Spell);
 			}
 			return true;
-		}
-
-		/// <summary>
-		/// Calculates heal variance based on spec
-		/// </summary>
-		/// <param name="min">store min variance here</param>
-		/// <param name="max">store max variance here</param>
-		public virtual void CalculateHealVariance(out int min, out int max)
-		{
-			double spellValue = m_spell.Value;
-			GamePlayer casterPlayer = m_caster as GamePlayer;
-
-			// percents if less than zero
-			if (spellValue < 0)
-			{
-				spellValue = (spellValue * -0.01) * m_caster.MaxEndurance;
-			}
-			min = max = (int)(spellValue);
-			return;
 		}
 
 		public override bool CheckBeginCast(GameLiving selectedTarget)

--- a/GameServer/spells/PowerHealSpellHandler.cs
+++ b/GameServer/spells/PowerHealSpellHandler.cs
@@ -40,9 +40,11 @@ namespace DOL.GS.Spells
 			if (targets.Count <= 0) return false;
 
 			bool healed = false;
-			int minHeal;
-			int maxHeal;
-			CalculateHealVariance(out minHeal, out maxHeal);
+
+			if (Spell.Value < 0 && m_caster is GamePlayer player)
+				Spell.Value = (Spell.Value * -0.01) * player.MaxMana;
+
+			int spellValue = (int)Math.Round(Spell.Value);
 
 			foreach (GameLiving healTarget in targets)
 			{
@@ -53,8 +55,12 @@ namespace DOL.GS.Spells
 					|| ((GamePlayer)healTarget).CharacterClass is PlayerClass.ClassMaulerHib
 					|| ((GamePlayer)healTarget).CharacterClass is PlayerClass.ClassMaulerMid))
 					continue;
-				int heal = Util.Random(minHeal, maxHeal);
-				healed |= HealTarget(healTarget, heal);
+
+				if (Spell.Value < 0)
+					// Restore a percentage of the target's mana
+					spellValue = (int)Math.Round((Spell.Value * -0.01) * healTarget.MaxMana);
+
+				healed |= HealTarget(healTarget, spellValue);
 			}
 
 			// group heals seem to use full power even if no heals
@@ -131,25 +137,6 @@ namespace DOL.GS.Spells
 					MessageToCaster(target.GetName(0, true) + " mana is full.", eChatType.CT_Spell);
 			}
 			return true;
-		}
-
-		/// <summary>
-		/// Calculates heal variance based on spec
-		/// </summary>
-		/// <param name="min">store min variance here</param>
-		/// <param name="max">store max variance here</param>
-		public virtual void CalculateHealVariance(out int min, out int max)
-		{
-			double spellValue = m_spell.Value;
-			GamePlayer casterPlayer = m_caster as GamePlayer;
-
-			// percents if less than zero
-			if (spellValue < 0)
-			{
-				spellValue = (spellValue * -0.01) * m_caster.MaxMana;
-			}
-			min = max = (int)(spellValue);
-			return;
 		}
 	}
 }


### PR DESCRIPTION
There was some redundant code copy/pasted over from heal spells that I removed.

I moved the percent calculation so that AE spells now restore a percentage of the target's end/mana rather than being based on the caster's end/mana.

This was a happy coincidence of fiddling with pet scaling code, and I didn't end up needing to add pet scaling here anyway.  :-)