### PR TITLE
Improved pet spell scaling

### DIFF
--- a/GameServer/gameobjects/GameNPC.cs
+++ b/GameServer/gameobjects/GameNPC.cs
@@ -3406,7 +3406,7 @@ namespace DOL.GS
 		/// <summary>
 		/// Sorts styles by type for more efficient style selection later
 		/// </summary>
-		protected void SortStyles()
+		public void SortStyles()
 		{
 			if (m_stylesAnyPos != null)
 				m_stylesAnyPos.Clear();
@@ -4956,7 +4956,7 @@ namespace DOL.GS
 		/// <summary>
 		/// Sort spells into specific lists
 		/// </summary>
-		private void SortSpells()
+		public void SortSpells()
 		{
 			// Clear the lists
 			if (m_HarmfulInstantSpells != null)

--- a/GameServer/spells/HealSpellHandler.cs
+++ b/GameServer/spells/HealSpellHandler.cs
@@ -201,12 +201,7 @@ namespace DOL.GS.Spells
                 amount += (int) ((amount*flaskHeal.Spell.Value)*0.01);
             }
 
-
-            // Scale spells that are cast by pets
-            if (Caster is GamePet && !(Caster is NecromancerPet) && ServerProperties.Properties.PET_SCALE_SPELL_MAX_LEVEL > 0)
-                amount = ScalePetHeal(amount);
-
-		amount = Math.Round(amount);
+            amount = Math.Round(amount);
             int heal = target.ChangeHealth(Caster, GameLiving.eHealthChangeType.Spell, (int)amount);
 
             #region PVP DAMAGE
@@ -348,10 +343,6 @@ namespace DOL.GS.Spells
 			// no healing of keep components
 			if (target is Keeps.GameKeepComponent || target is Keeps.GameKeepDoor)
 				return false;
-
-            // Scale spells that are cast by pets
-            if (Caster is GamePet && !(Caster is NecromancerPet) && ServerProperties.Properties.PET_SCALE_SPELL_MAX_LEVEL > 0)
-                    amount = ScalePetHeal(amount);
 
 			int heal = target.ChangeHealth(Caster, GameLiving.eHealthChangeType.Spell, (int)Math.Round(amount));
 
@@ -504,11 +495,6 @@ namespace DOL.GS.Spells
             min = lowerLimit;
             max = upperLimit;
             return;
-        }
-
-        private double ScalePetHeal(double amount)
-        {
-            return amount * (double)(Caster.Level) / (double)(ServerProperties.Properties.PET_SCALE_SPELL_MAX_LEVEL);
         }
     }
 }

--- a/GameServer/spells/SummonSpellHandler.cs
+++ b/GameServer/spells/SummonSpellHandler.cs
@@ -18,6 +18,7 @@
  */
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
 using DOL.AI.Brain;
@@ -41,7 +42,7 @@ namespace DOL.GS.Spells
 	/// </summary>
 	public abstract class SummonSpellHandler : SpellHandler
 	{
-		private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+		new private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
 		protected GamePet m_pet = null;
 
@@ -181,6 +182,12 @@ namespace DOL.GS.Spells
 			m_pet.CurrentSpeed = 0;
 			m_pet.Realm = Caster.Realm;
 			m_pet.Level = GetPetLevel();
+
+			// Scale pet spells
+			for (int i = 0; i < m_pet.Spells.Count; i++)
+				if (m_pet.Spells[i] is Spell spell)
+						m_pet.Spells[i] = m_pet.ScalePetSpell(spell);
+			m_pet.SortSpells(); // Do a sort of the scaled spells
 
 			if (m_isSilent)
 				m_pet.IsSilent = true;

--- a/GameServer/styles/StyleProcessor.cs
+++ b/GameServer/styles/StyleProcessor.cs
@@ -632,7 +632,11 @@ namespace DOL.GS.Styles
 			{
 				if (spell.ID == spellID)
 				{
-					styleSpell = spell;
+					// We have to scale style procs when cast
+					if (caster is GamePet pet)
+						styleSpell = pet.ScalePetSpell(spell);
+					else
+						styleSpell = spell;
 					break;
 				}
 			}


### PR DESCRIPTION
Pet spell scaling code is now significantly better.  Rather than scaling spells as pet cast them, spells are scaled as they're added to the pet.  Subspells and style effects are scaled on the fly by SpellHandler and StyleProcessor as they aren't stored on the pet.

There is no longer any need for spell scaling in specific spell handlers.

A fringe benefit is that spells that necromancer pets cast automatically and their style effects will be scaled, but spells cast by the necromancer won't.