### PR TITLE
Pets strip buffs from groups when they die

### DIFF
--- a/GameServer/gameobjects/GamePet.cs
+++ b/GameServer/gameobjects/GamePet.cs
@@ -321,14 +321,14 @@ namespace DOL.GS
 				foreach (GamePlayer player in group.GetPlayersInTheGroup())
 				{
 					if (player.EffectList != null)
-						foreach (GameSpellEffect effect in player.EffectList)
-							if (effect.SpellHandler != null && effect.SpellHandler.Caster != null && effect.SpellHandler.Caster == this)
+						foreach (IGameEffect effect in player.EffectList)
+							if (effect is GameSpellEffect spellEffect && spellEffect.SpellHandler != null && spellEffect.SpellHandler.Caster != null && spellEffect.SpellHandler.Caster == this)
 								effect.Cancel(false);
 				}
 			else if (owner.EffectList != null)
 				// Owner not in a group, only strip buffs from the owner
-				foreach (GameSpellEffect effect in owner.EffectList)
-					if (effect.SpellHandler != null && effect.SpellHandler.Caster != null && effect.SpellHandler.Caster == this)
+				foreach (IGameEffect effect in owner.EffectList)
+					if (effect is GameSpellEffect spellEffect && spellEffect.SpellHandler != null && spellEffect.SpellHandler.Caster != null && spellEffect.SpellHandler.Caster == this)
 						effect.Cancel(false);
 		}
 		

--- a/GameServer/gameobjects/GamePet.cs
+++ b/GameServer/gameobjects/GamePet.cs
@@ -313,19 +313,23 @@ namespace DOL.GS
 		/// </param>
 		public virtual void StripOwnerBuffs(GameLiving owner)
 		{
-			if (owner != null & owner.EffectList != null)
-			{
-			   	foreach (IGameEffect effect in owner.EffectList)
+			if (owner == null)
+				return;
+
+			if (owner.Group is Group group)
+				// Strip all buffs from this pet off the group, and off other pets
+				foreach (GamePlayer player in group.GetPlayersInTheGroup())
 				{
-					if (effect != null && effect is GameSpellEffect)
-					{
-						GameSpellEffect spelleffect = effect as GameSpellEffect;
-						if (spelleffect.SpellHandler != null && spelleffect.SpellHandler.Caster != null
-							&& spelleffect.SpellHandler.Caster == this)
-								spelleffect.Cancel(false);
-					}
+					if (player.EffectList != null)
+						foreach (GameSpellEffect effect in player.EffectList)
+							if (effect.SpellHandler != null && effect.SpellHandler.Caster != null && effect.SpellHandler.Caster == this)
+								effect.Cancel(false);
 				}
-			}
+			else if (owner.EffectList != null)
+				// Owner not in a group, only strip buffs from the owner
+				foreach (GameSpellEffect effect in owner.EffectList)
+					if (effect.SpellHandler != null && effect.SpellHandler.Caster != null && effect.SpellHandler.Caster == this)
+						effect.Cancel(false);
 		}
 		
 		/// <summary>


### PR DESCRIPTION
I noticed when testing BAF code that pets will cast buffs on groupmates, but will only strip their buffs from their owner when they die.  They now strip their buffs from all group members when they die, or just the owner if they aren't part of a group.