### PR TITLE
Con buffs on necro pets now increase max health

### DIFF
--- a/GameServer/gameobjects/Necromancer/NecromancerPet.cs
+++ b/GameServer/gameobjects/Necromancer/NecromancerPet.cs
@@ -207,7 +207,7 @@ namespace DOL.GS
 					}
 				case eProperty.MaxHealth:
 					{
-						int conBonus = (int)(3.1 * Constitution);
+						int conBonus = (int)(3.1 * GetModified(eProperty.Constitution));
 						int hitsBonus = (int)(32.5 * Level + m_summonHitsBonus);
 						int debuff = DebuffCategory[(int)property];
 


### PR DESCRIPTION
GetModified() was basing max health on base rather than modified con, leading to necro pets not being increased by con buffs like other pets.