### PR TITLE
Exposed necro pet stats via server properties

### DIFF
--- a/GameServer/gameobjects/Necromancer/NecromancerPet.cs
+++ b/GameServer/gameobjects/Necromancer/NecromancerPet.cs
@@ -263,71 +263,36 @@ namespace DOL.GS
 		}
 
 		/// <summary>
-		/// Base strength.
+		/// Set stats according to necro pet server properties
 		/// </summary>
-		public override short Strength
+		public override void AutoSetStats()
 		{
-			get
-			{
-				switch (Name.ToLower())
-				{
-					case "greater necroservant":
-						return 60;
-					default:
-						return (short)(60 + Level);
-				}
-			}
-		}
+			// Use normal pet stats for Cha, Emp, Int, and Pie.
+			base.AutoSetStats();
 
-		/// <summary>
-		/// Base constitution.
-		/// </summary>
-		public override short Constitution
-		{
-			get
+			if (Name.ToUpper() == "GREATER NECROSERVANT")
 			{
-				switch (Name.ToLower())
-				{
-					case "greater necroservant":
-						return (short)(60 + Level / 3 + m_summonConBonus);
-					default:
-						return (short)(60 + Level / 2 + m_summonConBonus);
-				}
+				Strength = (short)(ServerProperties.Properties.NECRO_GREATER_PET_STR_BASE
+					+ (short)(Math.Round(ServerProperties.Properties.NECRO_GREATER_PET_STR_MULTIPLIER * Level)));
+				Constitution = (short)(ServerProperties.Properties.NECRO_GREATER_PET_CON_BASE
+					+ (short)(Math.Round(ServerProperties.Properties.NECRO_GREATER_PET_CON_MULTIPLIER * Level))
+					+ m_summonConBonus);
+				Dexterity = (short)(ServerProperties.Properties.NECRO_GREATER_PET_DEX_BASE
+					+ (short)(Math.Round(ServerProperties.Properties.NECRO_GREATER_PET_DEX_MULTIPLIER * Level)));
+				Quickness = (short)(ServerProperties.Properties.NECRO_GREATER_PET_QUI_BASE
+					+ (short)(Math.Round(ServerProperties.Properties.NECRO_GREATER_PET_QUI_MULTIPLIER * Level)));
 			}
-		}
-
-		/// <summary>
-		/// Base dexterity. Make greater necroservant slightly more dextrous than
-		/// all the other pets.
-		/// </summary>
-		public override short Dexterity
-		{
-			get
+			else
 			{
-				switch (Name.ToLower())
-				{
-					case "greater necroservant":
-						return (short)(60 + Level / 2);
-					default:
-						return 60;
-				}
-			}
-		}
-
-		/// <summary>
-		/// Base quickness.
-		/// </summary>
-		public override short Quickness
-		{
-			get
-			{
-				switch (Name.ToLower())
-				{
-					case "greater necroservant":
-						return (short)(60 + Level);
-					default:
-						return (short)(60 + Level / 3);
-				}
+				Strength = (short)(ServerProperties.Properties.NECRO_PET_STR_BASE
+					+ (short)(Math.Round(ServerProperties.Properties.NECRO_PET_STR_MULTIPLIER * Level)));
+				Constitution = (short)(ServerProperties.Properties.NECRO_PET_CON_BASE
+					+ (short)(Math.Round(ServerProperties.Properties.NECRO_PET_CON_MULTIPLIER * Level))
+					+ m_summonConBonus);
+				Dexterity = (short)(ServerProperties.Properties.NECRO_PET_DEX_BASE
+					+ (short)(Math.Round(ServerProperties.Properties.NECRO_PET_DEX_MULTIPLIER * Level)));
+				Quickness = (short)(ServerProperties.Properties.NECRO_PET_QUI_BASE
+					+ (short)(Math.Round(ServerProperties.Properties.NECRO_PET_QUI_MULTIPLIER * Level)));
 			}
 		}
 

--- a/GameServer/serverproperty/ServerProperties.cs
+++ b/GameServer/serverproperty/ServerProperties.cs
@@ -1110,7 +1110,106 @@ namespace DOL.GS.ServerProperties
 		/// </summary>
 		[ServerProperty("npc", "pet_autoset_int_multiplier", "Multiplier to use when auto-setting Pet INT stat. ", 1.0)]
 		public static double PET_AUTOSET_INT_MULTIPLIER;		
-		
+
+		// Necro pet stat properties
+
+		/// <summary>
+		/// Base value to use when setting strength for most necromancer pets.
+		/// </summary>
+		[ServerProperty("npc", "necro_pet_str_base", "Base value to use when setting strength for most necromancer pets.", 60)]
+		public static int NECRO_PET_STR_BASE;
+
+		/// <summary>
+		/// Multiplier to use when setting strength for most necromancer pets.
+		/// </summary>
+		[ServerProperty("npc", "necro_pet_str_multiplier", "Multiplier to use when setting strength for most necromancer pets.", 1.0)]
+		public static double NECRO_PET_STR_MULTIPLIER;
+
+		/// <summary>
+		/// Base value to use when setting constitution for most necromancer pets.
+		/// </summary>
+		[ServerProperty("npc", "necro_pet_con_base", "Base value to use when setting constitution for most necromancer pets.", 60)]
+		public static int NECRO_PET_CON_BASE;
+
+		/// <summary>
+		/// Multiplier to use when setting constitution for most necromancer pets.
+		/// </summary>
+		[ServerProperty("npc", "necro_pet_con_multiplier", "Multiplier to use when setting constitution for most necromancer pets.", 0.5)]
+		public static double NECRO_PET_CON_MULTIPLIER;
+
+		/// <summary>
+		/// Base value to use when setting dexterity for most necromancer pets.
+		/// </summary>
+		[ServerProperty("npc", "necro_pet_dex_base", "Base value to use when setting dexterity for most necromancer pets.", 60)]
+		public static int NECRO_PET_DEX_BASE;
+
+		/// <summary>
+		/// Multiplier to use when setting dexterity for most necromancer pets.
+		/// </summary>
+		[ServerProperty("npc", "necro_pet_dex_multiplier", "Multiplier to use when setting dexterity for most necromancer pets.", 0.0)]
+		public static double NECRO_PET_DEX_MULTIPLIER;
+
+		/// <summary>
+		/// Base value to use when setting quickness for most necromancer pets.
+		/// </summary>
+		[ServerProperty("npc", "necro_pet_qui_base", "Base value to use when setting quickness for most necromancer pets.", 60)]
+		public static int NECRO_PET_QUI_BASE;
+
+		/// <summary>
+		/// Multiplier to use when setting quickness for most necromancer pets.
+		/// </summary>
+		[ServerProperty("npc", "necro_pet_qui_multiplier", "Multiplier to use when setting quickness for most necromancer pets.", 0.3333)]
+		public static double NECRO_PET_QUI_MULTIPLIER;
+
+		/// <summary>
+		/// Base value to use when setting strength for greater necroservant pets.
+		/// </summary>
+		[ServerProperty("npc", "necro_greater_pet_str_base", "Base value to use when setting strength for greater necroservant pets.", 60)]
+		public static int NECRO_GREATER_PET_STR_BASE;
+
+		/// <summary>
+		/// Multiplier to use when setting strength for greater necroservant pets.
+		/// </summary>
+		[ServerProperty("npc", "necro_greater_pet_str_multiplier", "Multiplier to use when setting strength for greater necroservant pets.", 0.0)]
+		public static double NECRO_GREATER_PET_STR_MULTIPLIER;
+
+		/// <summary>
+		/// Base value to use when setting constitution forgreater necroservant pets.
+		/// </summary>
+		[ServerProperty("npc", "necro_greater_pet_con_base", "Base value to use when setting constitution for greater necroservant pets.", 60)]
+		public static int NECRO_GREATER_PET_CON_BASE;
+
+		/// <summary>
+		/// Multiplier to use when setting constitution for greater necroservant pets.
+		/// </summary>
+		[ServerProperty("npc", "necro_greater_pet_con_multiplier", "Multiplier to use when setting constitution for greater necroservant pets.", 0.3333)]
+		public static double NECRO_GREATER_PET_CON_MULTIPLIER;
+
+		/// <summary>
+		/// Base value to use when setting dexterity for greater necroservant pets.
+		/// </summary>
+		[ServerProperty("npc", "necro_greater_pet_dex_base", "Base value to use when setting dexterity for greater necroservant pets.", 60)]
+		public static int NECRO_GREATER_PET_DEX_BASE;
+
+		/// <summary>
+		/// Multiplier to use when setting dexterity for greater necroservant pets.
+		/// </summary>
+		[ServerProperty("npc", "necro_greater_pet_dex_multiplier", "Multiplier to use when setting dexterity for greater necroservant pets.", 0.5)]
+		public static double NECRO_GREATER_PET_DEX_MULTIPLIER;
+
+		/// <summary>
+		/// Base value to use when setting quickness for greater necroservant pets.
+		/// </summary>
+		[ServerProperty("npc", "necro_greater_pet_qui_base", "Base value to use when setting quickness for greater necroservant pets.", 60)]
+		public static int NECRO_GREATER_PET_QUI_BASE;
+
+		/// <summary>
+		/// Multiplier to use when setting quickness for greater necroservant pets.
+		/// </summary>
+		[ServerProperty("npc", "necro_greater_pet_qui_multiplier", "Multiplier to use when setting quickness for greater necroservant pets.", 1.0)]
+		public static double NECRO_GREATER_PET_QUI_MULTIPLIER;
+
+
 		/// <summary>
 		/// How often should pets think?  Default 1500 or 1.5 seconds
 		/// </summary>


### PR DESCRIPTION
This is the same thing I did with mob, pet, and keep guard stats.  Greater necroservants have different stat calculations, so I had to use a second set of server properties for them.