### PR TITLE
Tickets are now automatically given to merchant when bought

### DIFF
--- a/GameServer/gameobjects/CustomNPC/GameBoatStableMaster.cs
+++ b/GameServer/gameobjects/CustomNPC/GameBoatStableMaster.cs
@@ -34,6 +34,72 @@ namespace DOL.GS
 	public class GameBoatStableMaster : GameMerchant
 	{
 		/// <summary>
+		/// Called when a player buys an item
+		/// </summary>
+		/// <param name="player">The player making the purchase</param>
+		/// <param name="item_slot">slot of the item to be bought</param>
+		/// <param name="number">Number to be bought</param>
+		public override void OnPlayerBuy(GamePlayer player, int item_slot, int number)
+		{
+			//Get the template
+			int pagenumber = item_slot / MerchantTradeItems.MAX_ITEM_IN_TRADEWINDOWS;
+			int slotnumber = item_slot % MerchantTradeItems.MAX_ITEM_IN_TRADEWINDOWS;
+
+			ItemTemplate template = this.TradeItems.GetItem(pagenumber, (eMerchantWindowSlot)slotnumber);
+			if (template == null) return;
+
+			//Calculate the amout of items
+			int amountToBuy = number;
+			if (template.PackSize > 0)
+				amountToBuy *= template.PackSize;
+
+			if (amountToBuy <= 0) return;
+
+			//Calculate the value of items
+			long totalValue = number * template.Price;
+
+			GameInventoryItem item = GameInventoryItem.Create(template);
+
+			lock (player.Inventory)
+			{
+
+				if (player.GetCurrentMoney() < totalValue)
+				{
+					player.Out.SendMessage(LanguageMgr.GetTranslation(player.Client.Account.Language, "GameMerchant.OnPlayerBuy.YouNeed", Money.GetString(totalValue)), eChatType.CT_System, eChatLoc.CL_SystemWindow);
+					return;
+				}
+
+				if (!player.Inventory.AddTemplate(item, amountToBuy, eInventorySlot.FirstBackpack, eInventorySlot.LastBackpack))
+				{
+					player.Out.SendMessage(LanguageMgr.GetTranslation(player.Client.Account.Language, "GameMerchant.OnPlayerBuy.NotInventorySpace"), eChatType.CT_System, eChatLoc.CL_SystemWindow);
+					return;
+				}
+				InventoryLogging.LogInventoryAction(this, player, eInventoryActionType.Merchant, template, amountToBuy);
+				//Generate the buy message
+				string message;
+				if (amountToBuy > 1)
+					message = LanguageMgr.GetTranslation(player.Client.Account.Language, "GameMerchant.OnPlayerBuy.BoughtPieces", amountToBuy, template.GetName(1, false), Money.GetString(totalValue));
+				else
+					message = LanguageMgr.GetTranslation(player.Client.Account.Language, "GameMerchant.OnPlayerBuy.Bought", template.GetName(1, false), Money.GetString(totalValue));
+
+				// Check if player has enough money and subtract the money
+				if (!player.RemoveMoney(totalValue, message, eChatType.CT_Merchant, eChatLoc.CL_SystemWindow))
+				{
+					throw new Exception("Money amount changed while adding items.");
+				}
+				InventoryLogging.LogInventoryAction(player, this, eInventoryActionType.Merchant, totalValue);
+			}
+
+			if (item.Name.ToUpper().Contains("TICKET TO") || item.Description.ToUpper() == "TICKET")
+			{
+				// Give the ticket to the merchant
+				InventoryItem ticket = player.Inventory.GetFirstItemByName(item.Name, eInventorySlot.FirstBackpack, eInventorySlot.LastBackpack) as InventoryItem;
+				if (ticket != null)
+					ReceiveItem(player, ticket);
+			}
+		}
+
+		/// <summary>
 		/// Called when the living is about to get an item from someone
 		/// else
 		/// </summary>

--- a/GameServer/gameobjects/CustomNPC/GameStableMaster.cs
+++ b/GameServer/gameobjects/CustomNPC/GameStableMaster.cs
@@ -42,6 +42,72 @@ namespace DOL.GS
 		}
 
 		/// <summary>
+		/// Called when a player buys an item
+		/// </summary>
+		/// <param name="player">The player making the purchase</param>
+		/// <param name="item_slot">slot of the item to be bought</param>
+		/// <param name="number">Number to be bought</param>
+		public override void OnPlayerBuy(GamePlayer player, int item_slot, int number)
+		{
+			//Get the template
+			int pagenumber = item_slot / MerchantTradeItems.MAX_ITEM_IN_TRADEWINDOWS;
+			int slotnumber = item_slot % MerchantTradeItems.MAX_ITEM_IN_TRADEWINDOWS;
+
+			ItemTemplate template = this.TradeItems.GetItem(pagenumber, (eMerchantWindowSlot)slotnumber);
+			if (template == null) return;
+
+			//Calculate the amout of items
+			int amountToBuy = number;
+			if (template.PackSize > 0)
+				amountToBuy *= template.PackSize;
+
+			if (amountToBuy <= 0) return;
+
+			//Calculate the value of items
+			long totalValue = number * template.Price;
+
+			GameInventoryItem item = GameInventoryItem.Create(template);
+
+			lock (player.Inventory)
+			{
+
+				if (player.GetCurrentMoney() < totalValue)
+				{
+					player.Out.SendMessage(LanguageMgr.GetTranslation(player.Client.Account.Language, "GameMerchant.OnPlayerBuy.YouNeed", Money.GetString(totalValue)), eChatType.CT_System, eChatLoc.CL_SystemWindow);
+					return;
+				}
+
+				if (!player.Inventory.AddTemplate(item, amountToBuy, eInventorySlot.FirstBackpack, eInventorySlot.LastBackpack))
+				{
+					player.Out.SendMessage(LanguageMgr.GetTranslation(player.Client.Account.Language, "GameMerchant.OnPlayerBuy.NotInventorySpace"), eChatType.CT_System, eChatLoc.CL_SystemWindow);
+					return;
+				}
+				InventoryLogging.LogInventoryAction(this, player, eInventoryActionType.Merchant, template, amountToBuy);
+				//Generate the buy message
+				string message;
+				if (amountToBuy > 1)
+					message = LanguageMgr.GetTranslation(player.Client.Account.Language, "GameMerchant.OnPlayerBuy.BoughtPieces", amountToBuy, template.GetName(1, false), Money.GetString(totalValue));
+				else
+					message = LanguageMgr.GetTranslation(player.Client.Account.Language, "GameMerchant.OnPlayerBuy.Bought", template.GetName(1, false), Money.GetString(totalValue));
+
+				// Check if player has enough money and subtract the money
+				if (!player.RemoveMoney(totalValue, message, eChatType.CT_Merchant, eChatLoc.CL_SystemWindow))
+				{
+					throw new Exception("Money amount changed while adding items.");
+				}
+				InventoryLogging.LogInventoryAction(player, this, eInventoryActionType.Merchant, totalValue);
+			}
+
+			if (item.Name.ToUpper().Contains("TICKET TO") || item.Description.ToUpper() == "TICKET")
+			{
+				// Give the ticket to the merchant
+				InventoryItem ticket = player.Inventory.GetFirstItemByName(item.Name, eInventorySlot.FirstBackpack, eInventorySlot.LastBackpack) as InventoryItem;
+				if (ticket != null)
+					ReceiveItem(player, ticket);
+			}
+		}
+
+		/// <summary>
 		/// Called when the living is about to get an item from someone
 		/// else
 		/// </summary>


### PR DESCRIPTION
On live, when you buy a ticket, it's immediately given to the merchant to start the trip.  I overloaded OnPlayerBuy() to add that feature.

It checks for "ticket to" in the ticket name, but also checks for "ticket" as the description.  This should make it function for English servers immediately, while giving non-English servers a way to make it work.