### PR TITLE
Updated pet buff stripping code

### DIFF
--- a/GameServer/gameobjects/Bonedancer/CommanderPet.cs
+++ b/GameServer/gameobjects/Bonedancer/CommanderPet.cs
@@ -325,12 +325,8 @@ namespace DOL.GS
 				//Found it, lets remove it
 				if (found)
 				{
-					if (controlledNpc.Body != null && controlledNpc.Body is GamePet)
-                    			{
-						GamePet minion = controlledNpc.Body as GamePet;
-						minion.StripOwnerBuffs(this); // Strip buffs off commander
-						minion.StripOwnerBuffs(Owner); // Strip buffs off player
-                    			}
+					if (controlledNpc.Body is GamePet minion)
+						minion.StripBuffs();
 				
 					//First lets store the brain to kill it
 					IControlledBrain tempBrain = m_controlledBrain[i];

--- a/GameServer/gameobjects/CharacterClasses/CharacterClassBase.cs
+++ b/GameServer/gameobjects/CharacterClasses/CharacterClassBase.cs
@@ -350,11 +350,9 @@ namespace DOL.GS
 			GameNPC npc = controlledBrain.Body;
 			if (npc == null)
 				return;
-			else if (npc is GamePet)
-            		{
-				GamePet pet = npc as GamePet;
-				pet.StripOwnerBuffs(pet.Owner);
-            		}
+			
+			if (npc is GamePet pet)
+				pet.StripBuffs();
 
 			Player.Notify(GameLivingEvent.PetReleased, npc);
 		}

--- a/GameServer/spells/Spell.cs
+++ b/GameServer/spells/Spell.cs
@@ -305,27 +305,65 @@ namespace DOL.GS
 		}
 
         /// <summary>
-        /// Whether or not this spell is harmful.
+        /// Is this spell harmful?
         /// </summary>
         public bool IsHarmful
         {
             get
             {
-                return (Target.ToLower() == "enemy" || Target.ToLower() == "area" ||
-                    Target.ToLower() == "cone");
+				switch (Target.ToUpper())
+				{
+					case "ENEMY":
+					case "AREA":
+					case "CONE":
+						return true;
+					default:
+						return false;
+				}
             }
         }
-        
+
 		/// <summary>
-		/// Whether or not this is a healing spell
+		/// Is this spell Helpful?
+		/// </summary>
+		public bool IsHelpful
+		{
+			get { return !IsHarmful; }
+		}
+
+		/// <summary>
+		/// Is this a buff spell?
+		/// </summary>
+		public bool IsBuff
+		{
+			get
+			{
+				return (IsHelpful && (Duration > 0 || Concentration > 0));
+			}
+		}
+
+		/// <summary>
+		/// Is this a healing spell?
 		/// </summary>
 		public bool IsHealing
 		{
 			get
 			{
-				return (Target.ToUpper() == "COMBATHEAL" || Target.ToUpper() == "HEAL" || Target.ToUpper() == "HEALOVERTIME" || Target.ToUpper() == "HEALTHREGENBUFF" 
-					|| Target.ToUpper() == "MERCHEAL" || Target.ToUpper() == "OMNIHEAL" || Target.ToUpper() == "PBAEHEAL" || Target.ToUpper() == "SPREADHEAL" 
-					|| Target.ToUpper() == "SUMMONHEALINGELEMENTAL");
+				switch (SpellType.ToUpper())
+				{
+					case "COMBATHEAL":
+					case "HEAL":
+					case "HEALOVERTIME":
+					case "HEALTHREGENBUFF":
+					case "MERCHEAL":
+					case "OMNIHEAL":
+					case "PBAEHEAL":
+					case "SPREADHEAL":
+					case "SUMMONHEALINGELEMENTAL":
+						return true;
+					default:
+						return false;
+				}
 			}
 		}
 

--- a/GameServer/spells/SpellHandler.cs
+++ b/GameServer/spells/SpellHandler.cs
@@ -2512,6 +2512,9 @@ namespace DOL.GS.Spells
 					if (dist >= 0)
 						ApplyEffectOnTarget(t, (effectiveness - CalculateAreaVariance(t, dist, Spell.Radius)));
 				}
+
+				if (Caster is GamePet pet && Spell.IsBuff)
+					pet.AddBuffedTarget(target);
 			}
 
 			if (Spell.Target.ToLower() == "ground")
@@ -3208,13 +3211,7 @@ namespace DOL.GS.Spells
 		/// </summary>
 		public virtual bool HasPositiveEffect
 		{
-			get
-			{
-				if (m_spell.Target.ToLower() != "enemy" && m_spell.Target.ToLower() != "cone" && m_spell.Target.ToLower() != "area")
-					return true;
-
-				return false;
-			}
+			get { return m_spell.IsHelpful; }
 		}
 
 		/// <summary>


### PR DESCRIPTION
StripOwnerBuffs() had a potential exploit; a player could join a group, be buffed by a groupmate's pet, leave the group, and not have buffs cast by the pet stripped.

Pets now track which targets they've buffed via AddBuffedTarget(GameLiving).  StripOwnerBuffs(owner) has been changed to StripBuffs(), since the owner is no longer needed.

I added a few other things along the way.  Spells now have IsHelpful and IsBuff properties, IsHealing and IsHarmful are now more efficient, and SpellHandler.HasPositiveEffect now calls Spell.IsHelpful rather than duplicating code.