### PR TITLE
Fixed GetModifiedSpecLevel() returning 0

### DIFF
--- a/GameServer/gameobjects/GamePet.cs
+++ b/GameServer/gameobjects/GamePet.cs
@@ -129,17 +129,12 @@ namespace DOL.GS
 		/// <returns>The specialisation level.</returns>
 		public override int GetModifiedSpecLevel(string keyName)
 		{
-			switch (keyName)
-			{
-				case Specs.Slash:
-				case Specs.Crush:
-				case Specs.Two_Handed:
-				case Specs.Shields:
-				case Specs.Critical_Strike:
-				case Specs.Large_Weapons:
-					return Level;
-                default: return (Brain as IControlledBrain).GetLivingOwner().GetModifiedSpecLevel(keyName);
-			}
+			int spec = (Brain as IControlledBrain).GetLivingOwner().GetModifiedSpecLevel(keyName);
+
+			if (spec <= 0)
+				return Level;
+
+			return spec;
 		}
 
 		#endregion


### PR DESCRIPTION
GamePet.GetModifiedSpecLevel() was originally copy/pasted out of BDPet code, so I suspect it written to only check for styles that BD pets use.  Styles tied to other weapon types would return 0, which removes all style damage from Style.GrowthRate.

I haven't found any situation in which the owners spec returns non zero, but I think it's safer to leave it in than risk breaking something I can't see.