### PR TITLE
Fixed BringFriends() bugs/exploit, added more server properties

### DIFF
--- a/GameServer/serverproperty/ServerProperties.cs
+++ b/GameServer/serverproperty/ServerProperties.cs
@@ -1793,16 +1793,28 @@ namespace DOL.GS.ServerProperties
 		public static int BAF_INITIAL_CHANCE;
 
 		/// <summary>
-		/// Do BAF mobs attack random players near the puller?
-		/// </summary>
-		[ServerProperty("pve", "baf_mobs_attack_random_players", "Do mobs brought by friends attack random nearby players in the puller's group or battlegroup?  If false, additional mobs attack the puller as on live.", false)]
-		public static bool BAF_MOBS_ATTACK_RANDOM_PLAYERS;
-
-		/// <summary>
 		/// Added percent chance of a mob BAFing for each attacker past the first
 		/// </summary>
 		[ServerProperty("pve", "baf_additional_chance", "Percent chance for a mob to bring a friend for each additional attacker.  Each multiples of 100 guarantee an add, so a cumulative chance of 250% guarantees two adds with a 50% chance of a third.", 50)]
-		public static int BAF_ADDITIONAL_CHANCE;			
+		public static int BAF_ADDITIONAL_CHANCE;
+
+		/// <summary>
+		/// Do BAF mobs attack the player who pulled?
+		/// </summary>
+		[ServerProperty("pve", "baf_mobs_attack_puller", "Do mobs brought by friends only attack the character who pulled them?  If false, mobs attack random players near the puller.", false)]
+		public static bool BAF_MOBS_ATTACK_PULLER;
+
+		/// <summary>
+		/// Do BAF mobs attack characters in the same BG as the pulling character?
+		/// </summary>
+		[ServerProperty("pve", "baf_mobs_attack_bg_members", "Do mobs brought by friends attack random nearby players in the puller's battlegroup?  If false, mobs only attack characters in the pulling player's group.", false)]
+		public static bool BAF_MOBS_ATTACK_BG_MEMBERS;
+
+		/// <summary>
+		/// Is the number of mobs added by BAF based on the number of nearby players in the puller's BG?
+		/// </summary>
+		[ServerProperty("pve", "baf_mobs_count_bg_members", "Is the number of mobs brought by a friend based on the number of nearby players in the pulling player's battlegroup?  If false, the number of mobs brought is determined by the number of players in the pulling player's group.", false)]
+		public static bool BAF_MOBS_COUNT_BG_MEMBERS;			
 
 		/// <summary>
 		/// Adjustment to missrate per number of attackers


### PR DESCRIPTION
Added several new server properties to expose BAF functionality for BGs.  Changed constants to virtual accessors so they can be properly overridden, and added an accessor to specify range for the player IsWithinRadius() check.

By default, BGs are ignored, number of mobs added is based on number of nearby group members, and adds attack random nearby members of the puller's group.

I tested this exhaustively and found a few bugs and possible exploits.  Code now checks for duplicates, players who are in both the group and the BG so they aren't counted twice, but only when absolutely necessary and as efficiently as possible.