### PR TITLE
/mob info now shows base and modified stats

### DIFF
--- a/GameServer/commands/gmcommands/mob.cs
+++ b/GameServer/commands/gmcommands/mob.cs
@@ -1297,10 +1297,10 @@ namespace DOL.GS.Commands
 			}
 
 			info.Add(" ");
-			info.Add(" + STR  /  CON  /  DEX  /  QUI");
-			info.Add(" + " + targetMob.Strength + "  /  " + targetMob.Constitution + "  /  " + targetMob.Dexterity + "  /  " + targetMob.Quickness);
-			info.Add(" + INT  /  EMP  /  PIE  /  CHR");
-			info.Add(" + " + targetMob.Intelligence + "  /  " + targetMob.Empathy + "  /  " + targetMob.Piety + "  /  " + targetMob.Charisma);
+			info.Add(" +     STR      /      CON      /      DEX      /      QUI");
+			info.Add(" + " + targetMob.Strength + " (" + targetMob.GetModified(eProperty.Strength) + ")  /  " + targetMob.Constitution + " (" + targetMob.GetModified(eProperty.Constitution) + ")  /  " + targetMob.Dexterity + " (" + targetMob.GetModified(eProperty.Dexterity) + ")  /  " + targetMob.Quickness + " (" + targetMob.GetModified(eProperty.Quickness) + ")");
+			info.Add(" +     INT      /     EMP     /     PIE     /     CHR");
+			info.Add(" + " + targetMob.Intelligence + " (" + targetMob.GetModified(eProperty.Intelligence) + ")  /  " + targetMob.Empathy + " (" + targetMob.GetModified(eProperty.Empathy) + ")  /  " + targetMob.Piety + " (" + targetMob.GetModified(eProperty.Piety) + ")  /  " + targetMob.Charisma + " (" + targetMob.GetModified(eProperty.Charisma) + ")");
 			info.Add(" + Block / Parry / Evade %:  " + targetMob.BlockChance + " / " + targetMob.ParryChance + " / " + targetMob.EvadeChance);
 			info.Add(" + Attack Speed (Melee Speed Increase %):  " + targetMob.AttackSpeed(targetMob.AttackWeapon) + " (" + (100 - targetMob.GetModified(eProperty.MeleeSpeed)) + ")");
 			info.Add(" + Casting Speed Increase %:  " + targetMob.GetModified(eProperty.CastingSpeed));


### PR DESCRIPTION
/mob info now lets you see both a mob's buffed and unbuffed stats.  Especially useful when looking at pets that have a self-buff spell.