### PR TITLE
Improved NPC style sorting and selection

### DIFF
--- a/GameServer/gameobjects/GamePet.cs
+++ b/GameServer/gameobjects/GamePet.cs
@@ -364,22 +364,6 @@ namespace DOL.GS
 
 			return ticks;
 		}
-
-		/// <summary>
-		/// Pick a random style for now.
-		/// </summary>
-		/// <returns></returns>
-		protected override Style GetStyleToUse()
-		{
-			if (Styles != null && Styles.Count > 0 && Util.Chance(Properties.GAMENPC_CHANCES_TO_STYLE + Styles.Count))
-			{
-				Style style = (Style)Styles[Util.Random(Styles.Count - 1)];
-				if (StyleProcessor.CanUseStyle(this, style, AttackWeapon))
-					return style;
-			}
-
-			return base.GetStyleToUse();
-		}
 		#endregion
 
 		public override void Die(GameObject killer)


### PR DESCRIPTION
When I tested pets on live, they use positional styles every single time, so I've updated style sorting and selection to do so as well.

I moved defensive styles before the chance to style check, which should make those styles more visible since most NPCs have very low block/evade/parry chances.

A fringe benefit of more granular sorts is random style selection.  NPCs can be given multiple styles requiring the same position, and the NPC will randomly choose from them rather than only using the first one in the list e.g. an NPC could have Pincer and Decaying Rage side styles and use both of them.

I also noticed that the SortSpells() method was clearing the instant harmful spell list twice and not clearing the miscellaneous spell list, so I remedied that.  It doesn't matter right now, but it will in the near future.