### PR TITLE
Epic quests now works for non-mauler classes

### DIFF
--- a/GameServerScripts/quests/Albion/epic/Defenders50.cs
+++ b/GameServerScripts/quests/Albion/epic/Defenders50.cs
@@ -1248,8 +1248,17 @@ namespace DOL.GS.Quests.Albion
 			if (player == null)
 				return;
 
-			if(Lidmann.CanGiveQuest(typeof (Defenders_50), player)  <= 0)
+			if (Lidmann.CanGiveQuest(typeof(Defenders_50), player) <= 0)
 				return;
+
+			// player is not allowed to start this quest until the quest rewards are available
+			if (player.CharacterClass.ID == (byte)eCharacterClass.MaulerAlb &&
+				(MaulerAlbEpicArms == null || MaulerAlbEpicBoots == null || MaulerAlbEpicGloves == null ||
+				MaulerAlbEpicHelm == null || MaulerAlbEpicLegs == null || MaulerAlbEpicVest == null))
+			{
+				Lidmann.SayTo(player, "This quest is not available to Maulers yet.");
+				return;
+			}
 
 			//We also check if the player is already doing the quest
 			Defenders_50 quest = player.IsDoingQuest(typeof (Defenders_50)) as Defenders_50;
@@ -1429,15 +1438,6 @@ namespace DOL.GS.Quests.Albion
 
             if (Step == 2 && e == GamePlayerEvent.GiveItem)
             {
-                // Graveen: if not existing maulerepic in DB
-                // player is not allowed to finish this quest until we fix this problem
-                if (MaulerAlbEpicArms == null || MaulerAlbEpicBoots == null || MaulerAlbEpicGloves == null ||
-                    MaulerAlbEpicHelm == null || MaulerAlbEpicLegs == null || MaulerAlbEpicVest == null)
-                    {
-                    Lidmann.SayTo(player, "Dark forces are still voiding this quest, your armor is not ready.");
-                    return;
-                }
-
                 GiveItemEventArgs gArgs = (GiveItemEventArgs)args;
 				if (gArgs.Target.Name == Lidmann.Name && gArgs.Item.Id_nb == sealed_pouch.Id_nb)
 				{

--- a/GameServerScripts/quests/Hibernia/epic/Focus50.cs
+++ b/GameServerScripts/quests/Hibernia/epic/Focus50.cs
@@ -1287,8 +1287,17 @@ namespace DOL.GS.Quests.Hibernia
 			if (player == null)
 				return;
 
-			if(Ainrebh.CanGiveQuest(typeof (Focus_50), player)  <= 0)
+			if (Ainrebh.CanGiveQuest(typeof (Focus_50), player)  <= 0)
 				return;
+
+			// player is not allowed to start this quest until the quest rewards are available
+			if (player.CharacterClass.ID == (byte)eCharacterClass.MaulerHib &&
+				(MaulerHibEpicBoots == null || MaulerHibEpicBoots == null || MaulerHibEpicGloves == null ||
+				MaulerHibEpicHelm == null || MaulerHibEpicLegs == null || MaulerHibEpicVest == null))
+			{
+				Ainrebh.SayTo(player, "This quest is not available to Maulers yet.");
+				return;
+			}
 
 			//We also check if the player is already doing the quest
 			Focus_50 quest = player.IsDoingQuest(typeof (Focus_50)) as Focus_50;
@@ -1462,17 +1471,6 @@ namespace DOL.GS.Quests.Hibernia
 
 			if (Step == 2 && e == GamePlayerEvent.GiveItem)
             {
-                // Graveen: if not existing maulerepic in DB
-                // player is not allowed to finish this quest until we fix this problem
-//                if (MaulerHibEpicArms == null || MaulerHibEpicBoots == null || MaulerHibEpicGloves == null ||
-//                    MaulerHibEpicHelm == null || MaulerHibEpicLegs == null || MaulerHibEpicVest == null)
-                if (MaulerHibEpicArms == null || MaulerHibEpicBoots == null || MaulerHibEpicGloves == null ||
-                    MaulerHibEpicHelm == null || MaulerHibEpicLegs == null || MaulerHibEpicVest == null)
-                    {
-                    Ainrebh.SayTo(player, "Dark forces are still voiding this quest, your armor is not ready.");
-                    return;
-                }
-
 				GiveItemEventArgs gArgs = (GiveItemEventArgs) args;
 				if (gArgs.Target.Name == Ainrebh.Name && gArgs.Item.Id_nb == GreenMaw_key.Id_nb)
 				{

--- a/GameServerScripts/quests/Midgard/epic/Viking50.cs
+++ b/GameServerScripts/quests/Midgard/epic/Viking50.cs
@@ -1906,6 +1906,15 @@ namespace DOL.GS.Quests.Midgard
 			if(Lynnleigh.CanGiveQuest(typeof (Viking_50), player)  <= 0)
 				return;
 
+			// player is not allowed to start this quest until the quest rewards are available
+			if (player.CharacterClass.ID == (byte)eCharacterClass.MaulerMid &&
+				(MaulerMidEpicArms == null || MaulerMidEpicBoots == null || MaulerMidEpicGloves == null ||
+				MaulerMidEpicHelm == null || MaulerMidEpicLegs == null || MaulerMidEpicVest == null))
+			{
+				Elizabeth.SayTo(player, "This quest is not available to Maulers yet.");
+				return;
+			}
+
 			//We also check if the player is already doing the quest
 			Viking_50 quest = player.IsDoingQuest(typeof (Viking_50)) as Viking_50;
 
@@ -1970,17 +1979,6 @@ namespace DOL.GS.Quests.Midgard
 					{
                         case 4:
                             {
-                                // Graveen: if not existing maulerepic in DB
-                                // player is not allowed to finish this quest until we fix this problem
-//                                if (MaulerMidEpicArms == null || MaulerMidEpicBoots == null || MaulerMidEpicGloves == null ||
-//                                    MaulerMidEpicHelm == null || MaulerMidEpicLegs == null || MaulerMidEpicVest == null)
-                                if (MaulerMidEpicArms == null || MaulerMidEpicBoots == null || MaulerMidEpicGloves == null ||
-                                    MaulerMidEpicHelm == null || MaulerMidEpicLegs == null || MaulerMidEpicVest == null)
-                                {
-                                    Elizabeth.SayTo(player, "Dark forces are still voiding this quest, your armor is not ready.");
-                                    return;
-                                }
-
                                 Elizabeth.SayTo(player, "There are six parts to your reward, so make sure you have room for them. Just let me know when you are ready, and then you can [take them] with our thanks!");
                                 break;
                             }


### PR DESCRIPTION
Rather than allowing all classes to take the quest but not complete it, classes other than maulers can get and complete the quest while maulers can't start the quest.