### PR TITLE
Optional: Pets level with owner

### DIFF
--- a/DOLDatabase/Tables/Mob.cs
+++ b/DOLDatabase/Tables/Mob.cs
@@ -54,14 +54,14 @@ namespace DOL.Database
 		private int m_meleeDamageType;
 		private int m_respawnInterval;
 		private int m_faction;
-		private int m_Constitution;
-		private int m_Dexterity;
-		private int m_Strength;
-		private int m_Quickness;
-		private int m_Intelligence;
-		private int m_Piety;
-		private int m_Empathy;
-		private int m_Charisma;
+		private short m_Strength;
+		private short m_Constitution;
+		private short m_Dexterity;
+		private short m_Quickness;
+		private short m_Intelligence;
+		private short m_Piety;
+		private short m_Empathy;
+		private short m_Charisma;
 		private string m_equipmentTemplateID;
 		private string m_itemsListTemplateID;
 		private int m_npcTemplateID;
@@ -369,7 +369,7 @@ namespace DOL.Database
 		/// The Mob's Strength
 		/// </summary>
 		[DataElement(AllowDbNull = false)]
-		public int Strength
+		public short Strength
 		{
 			get
 			{
@@ -385,7 +385,7 @@ namespace DOL.Database
 		/// The Mob's Con
 		/// </summary>
 		[DataElement(AllowDbNull = false)]
-		public int Constitution
+		public short Constitution
 		{
 			get
 			{
@@ -402,7 +402,7 @@ namespace DOL.Database
 		/// The Mob's Dexterity
 		/// </summary>
 		[DataElement(AllowDbNull = false)]
-		public int Dexterity
+		public short Dexterity
 		{
 			get
 			{
@@ -419,7 +419,7 @@ namespace DOL.Database
 		/// The Mob's Quickness
 		/// </summary>
 		[DataElement(AllowDbNull = false)]
-		public int Quickness
+		public short Quickness
 		{
 			get
 			{
@@ -436,7 +436,7 @@ namespace DOL.Database
 		/// The Mob's Int
 		/// </summary>
 		[DataElement(AllowDbNull = false)]
-		public int Intelligence
+		public short Intelligence
 		{
 			get
 			{
@@ -453,7 +453,7 @@ namespace DOL.Database
 		/// The Mob's Piety
 		/// </summary>
 		[DataElement(AllowDbNull = false)]
-		public int Piety
+		public short Piety
 		{
 			get
 			{
@@ -471,7 +471,7 @@ namespace DOL.Database
 		/// The Mob's Empathy
 		/// </summary>
 		[DataElement(AllowDbNull = false)]
-		public int Empathy
+		public short Empathy
 		{
 			get
 			{
@@ -488,7 +488,7 @@ namespace DOL.Database
 		/// The Mob's Charisma
 		/// </summary>
 		[DataElement(AllowDbNull = false)]
-		public int Charisma
+		public short Charisma
 		{
 			get
 			{

--- a/DOLDatabase/Tables/NpcTemplate.cs
+++ b/DOLDatabase/Tables/NpcTemplate.cs
@@ -59,14 +59,14 @@ namespace DOL.Database
 		private byte m_leftHandSwingChance;
 		private string m_spells = string.Empty;
 		private string m_styles = string.Empty;
-		private int m_strength = 0;
-		private int m_constitution = 0;
-		private int m_dexterity = 0;
-		private int m_quickness = 0;
-		private int m_intelligence = 0;
-		private int m_piety = 0;
-		private int m_empathy = 0;
-		private int m_charisma = 0;
+		private short m_strength = 0;
+		private short m_constitution = 0;
+		private short m_dexterity = 0;
+		private short m_quickness = 0;
+		private short m_intelligence = 0;
+		private short m_piety = 0;
+		private short m_empathy = 0;
+		private short m_charisma = 0;
 		private string m_abilities = string.Empty;
 		private byte m_aggroLevel = 0;
 		private int m_aggroRange = 0;
@@ -422,7 +422,7 @@ namespace DOL.Database
 		}
 
 		[DataElement(AllowDbNull = false)]
-		public int Strength
+		public short Strength
 		{
 			get { return m_strength; }
 			set
@@ -433,7 +433,7 @@ namespace DOL.Database
 		}
 
 		[DataElement(AllowDbNull = false)]
-		public int Constitution
+		public short Constitution
 		{
 			get { return m_constitution; }
 			set
@@ -444,7 +444,7 @@ namespace DOL.Database
 		}
 
 		[DataElement(AllowDbNull = false)]
-		public int Dexterity
+		public short Dexterity
 		{
 			get { return m_dexterity; }
 			set
@@ -455,7 +455,7 @@ namespace DOL.Database
 		}
 
 		[DataElement(AllowDbNull = false)]
-		public int Quickness
+		public short Quickness
 		{
 			get { return m_quickness; }
 			set
@@ -466,7 +466,7 @@ namespace DOL.Database
 		}
 
 		[DataElement(AllowDbNull = false)]
-		public int Intelligence
+		public short Intelligence
 		{
 			get { return m_intelligence; }
 			set
@@ -477,7 +477,7 @@ namespace DOL.Database
 		}
 
 		[DataElement(AllowDbNull = false)]
-		public int Piety
+		public short Piety
 		{
 			get { return m_piety; }
 			set
@@ -488,7 +488,7 @@ namespace DOL.Database
 		}
 
 		[DataElement(AllowDbNull = false)]
-		public int Charisma
+		public short Charisma
 		{
 			get { return m_charisma; }
 			set
@@ -499,7 +499,7 @@ namespace DOL.Database
 		}
 
 		[DataElement(AllowDbNull = false)]
-		public int Empathy
+		public short Empathy
 		{
 			get { return m_empathy; }
 			set

--- a/GameServer/commands/gmcommands/mob.cs
+++ b/GameServer/commands/gmcommands/mob.cs
@@ -1496,8 +1496,7 @@ namespace DOL.GS.Commands
 			try
 			{
 				level = Convert.ToByte(args[2]);
-				targetMob.Level = level;
-				targetMob.AutoSetStats();
+				targetMob.Level = level; // Also calls AutoSetStats()
 				targetMob.SaveIntoDatabase();
 				client.Out.SendMessage("Mob level changed to: " + targetMob.Level + " and stats adjusted", eChatType.CT_System, eChatLoc.CL_SystemWindow);
 			}

--- a/GameServer/gameobjects/CharacterClasses/CharacterClassBase.cs
+++ b/GameServer/gameobjects/CharacterClasses/CharacterClassBase.cs
@@ -31,7 +31,7 @@ namespace DOL.GS
 	/// </summary>
 	public abstract class CharacterClassBase : ICharacterClass
 	{
-		protected static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+		private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
 		/// <summary>
 		/// id of class in Client

--- a/GameServer/gameobjects/CharacterClasses/Midgard/CharacterClassBoneDancer.cs
+++ b/GameServer/gameobjects/CharacterClasses/Midgard/CharacterClassBoneDancer.cs
@@ -19,6 +19,7 @@
 using System;
 
 using DOL.Events;
+using DOL.AI;
 using DOL.AI.Brain;
 using DOL.GS.PlayerClass;
 
@@ -43,5 +44,26 @@ namespace DOL.GS
 
 			base.CommandNpcRelease();
 		}
+
+		/// <summary>
+		/// Add all spell-lines and other things that are new when this skill is trained
+		/// </summary>
+		/// <param name="player">player to modify</param>
+		/// <param name="skill">The skill that is trained</param>
+		public override void OnSkillTrained(GamePlayer player, Specialization skill)
+		{
+			base.OnSkillTrained(player, skill);
+
+			// BD subpet spells can be scaled with the BD's spec as a cap, so when a BD
+			//	trains, we have to re-scale spells for subpets from that spec.
+			if (DOL.GS.ServerProperties.Properties.PET_SCALE_SPELL_MAX_LEVEL > 0
+				&& DOL.GS.ServerProperties.Properties.PET_CAP_BD_MINION_SPELL_SCALING_BY_SPEC
+				&& player.ControlledBrain != null && player.ControlledBrain.Body is GamePet pet)
+					foreach (ABrain subBrain in pet.ControlledNpcList)
+						if (subBrain != null && subBrain.Body is BDSubPet subPet && subPet.PetSpecLine == skill.KeyName)
+							subPet.SortSpells();
+		}
+
+
 	}
 }

--- a/GameServer/gameobjects/GameNPC.cs
+++ b/GameServer/gameobjects/GameNPC.cs
@@ -197,54 +197,139 @@ namespace DOL.GS
 			get { return base.Level; }
 			set
 			{
-				base.Level = value;
+				bool bMaxHealth = (m_health == MaxHealth);
 
-				if (value > 0)
-					AutoSetStats();  // Always recalculate stats when level changes
-
-				if (!InCombat)
-					m_health = MaxHealth;
-
-				if (ObjectState == eObjectState.Active)
+				if (Level != value)
 				{
-					foreach (GamePlayer player in GetPlayersInRadius(WorldMgr.VISIBILITY_DISTANCE))
+					if (Level < 1 && ObjectState == eObjectState.Active)
 					{
-						player.Out.SendNPCCreate(this);
-						if (m_inventory != null)
-							player.Out.SendLivingEquipmentUpdate(this);
+						// This is a newly created NPC, so notify nearby players of its creation
+						foreach (GamePlayer player in GetPlayersInRadius(WorldMgr.VISIBILITY_DISTANCE))
+						{
+							player.Out.SendNPCCreate(this);
+							if (m_inventory != null)
+								player.Out.SendLivingEquipmentUpdate(this);
+						}
 					}
+
+					base.Level = value;
+					AutoSetStats();  // Recalculate stats when level changes
 				}
+				else
+					base.Level = value;
+
+				if (bMaxHealth)
+					m_health = MaxHealth;
 			}
 		}
 
 		/// <summary>
-		/// Auto set any stats which haven't already been assigned a value;
+		/// Auto set stats based on DB entry, npcTemplate, and level.
 		/// </summary>
 		public virtual void AutoSetStats()
 		{
-			// We have to check both the current values and the template to account for mobs leveling up
-			if (Strength < 1 || (m_npcTemplate != null && m_npcTemplate.ReplaceMobValues && m_npcTemplate.Strength < 1))
-				Strength = (short)Math.Max(1, Properties.MOB_AUTOSET_STR_BASE + (Level - 1) * 10 * Properties.MOB_AUTOSET_STR_MULTIPLIER);
-			
-			if (Constitution < 1 || (m_npcTemplate != null && m_npcTemplate.ReplaceMobValues && m_npcTemplate.Constitution < 1))
-				Constitution = (short)Math.Max(1, Properties.MOB_AUTOSET_CON_BASE + (Level - 1) * Properties.MOB_AUTOSET_CON_MULTIPLIER);
-			
-			if (Quickness < 1 || (m_npcTemplate != null && m_npcTemplate.ReplaceMobValues && m_npcTemplate.Quickness < 1))
-				Quickness = (short)Math.Max(1, Properties.MOB_AUTOSET_QUI_BASE + (Level - 1) * Properties.MOB_AUTOSET_QUI_MULTIPLIER);
-			
-			if (Dexterity < 1 || (m_npcTemplate != null && m_npcTemplate.ReplaceMobValues && m_npcTemplate.Dexterity < 1))
-				Dexterity = (short)Math.Max(1, Properties.MOB_AUTOSET_DEX_BASE + (Level - 1) * Properties.MOB_AUTOSET_DEX_MULTIPLIER);
-			
-			if (Intelligence < 1 || (m_npcTemplate != null && m_npcTemplate.ReplaceMobValues && m_npcTemplate.Intelligence < 1))
-				Intelligence = (short)Math.Max(1, Properties.MOB_AUTOSET_INT_BASE + (Level - 1) * Properties.MOB_AUTOSET_INT_MULTIPLIER);
-			
-			if (Empathy < 1 || (m_npcTemplate != null && m_npcTemplate.ReplaceMobValues && m_npcTemplate.Empathy < 1))
+			AutoSetStats(null);
+		}
+
+		/// <summary>
+		/// Auto set stats based on DB entry, npcTemplate, and level.
+		/// </summary>
+		/// <param name="dbMob">Mob DB entry to load stats from, retrieved from DB if null</param>
+		public virtual void AutoSetStats(Mob dbMob = null)
+		{
+			// Don't set stats for mobs until their level is set
+			if (Level < 1)
+				return;
+
+			// We have to check both the DB and template values to account for mobs changing levels.
+			// Otherwise, high level mobs retain their stats when their level is lowered by a GM.
+			if (NPCTemplate != null && NPCTemplate.ReplaceMobValues)
+			{
+				Strength = NPCTemplate.Strength;
+				Constitution = NPCTemplate.Constitution;
+				Quickness = NPCTemplate.Quickness;
+				Dexterity = NPCTemplate.Dexterity;
+				Intelligence = NPCTemplate.Intelligence;
+				Empathy = NPCTemplate.Empathy;
+				Piety = NPCTemplate.Piety;
+				Charisma = NPCTemplate.Strength;
+			}
+			else
+			{
+				Mob mob = dbMob;
+
+				if (mob == null && !String.IsNullOrEmpty(InternalID))
+					// This should only happen when a GM command changes level on a mob with no npcTemplate,
+					mob = GameServer.Database.FindObjectByKey<Mob>(InternalID);
+
+				if (mob != null)
+				{
+					Strength = mob.Strength;
+					Constitution = mob.Constitution;
+					Quickness = mob.Quickness;
+					Dexterity = mob.Dexterity;
+					Intelligence = mob.Intelligence;
+					Empathy = mob.Empathy;
+					Piety = mob.Piety;
+					Charisma = mob.Charisma;
+				}
+				else
+				{
+					// This is usually a mob about to be loaded from its DB entry,
+					//	but it could also be a new mob created by a GM command, so we need to assign stats.
+					Strength = 0;
+					Constitution = 0;
+					Quickness = 0;
+					Dexterity = 0;
+					Intelligence = 0;
+					Empathy = 0;
+					Piety = 0;
+					Charisma = 0;
+				}
+			}
+
+			if (Strength < 1)
+			{
+				Strength = (Properties.MOB_AUTOSET_STR_BASE > 0) ? Properties.MOB_AUTOSET_STR_BASE : (short)1;
+				if (Level > 1)
+					Strength += (byte)(10.0 * (Level - 1) * Properties.MOB_AUTOSET_STR_MULTIPLIER);
+			}
+
+			if (Constitution < 1)
+			{
+				Constitution = (Properties.MOB_AUTOSET_CON_BASE > 0) ? Properties.MOB_AUTOSET_CON_BASE : (short)1;
+				if (Level > 1)
+					Constitution += (byte)((Level - 1) * Properties.MOB_AUTOSET_CON_MULTIPLIER);
+			}
+
+			if (Quickness < 1)
+			{
+				Quickness = (Properties.MOB_AUTOSET_QUI_BASE > 0) ? Properties.MOB_AUTOSET_QUI_BASE : (short)1;
+				if (Level > 1)
+					Quickness += (byte)((Level - 1) * Properties.MOB_AUTOSET_QUI_MULTIPLIER);
+			}
+
+			if (Dexterity < 1)
+			{
+				Dexterity = (Properties.MOB_AUTOSET_DEX_BASE > 0) ? Properties.MOB_AUTOSET_DEX_BASE : (short)1;
+				if (Level > 1)
+					Dexterity += (byte)((Level - 1) * Properties.MOB_AUTOSET_DEX_MULTIPLIER);
+			}
+
+			if (Intelligence < 1)
+			{
+				Intelligence = (Properties.MOB_AUTOSET_INT_BASE > 0) ? Properties.MOB_AUTOSET_INT_BASE : (short)1;
+				if (Level > 1)
+					Intelligence += (byte)((Level - 1) * Properties.MOB_AUTOSET_INT_MULTIPLIER);
+			}
+
+			if (Empathy < 1)
 				Empathy = (short)(29 + Level);
-			
-			if (Piety < 1 || (m_npcTemplate != null && m_npcTemplate.ReplaceMobValues && m_npcTemplate.Piety < 1))
+
+			if (Piety < 1)
 				Piety = (short)(29 + Level);
-			
-			if (Charisma < 1 || (m_npcTemplate != null && m_npcTemplate.ReplaceMobValues && m_npcTemplate.Charisma < 1))
+
+			if (Charisma < 1)
 				Charisma = (short)(29 + Level);
 		}
 
@@ -1927,7 +2012,7 @@ namespace DOL.GS
 			if (!(obj is Mob)) return;
 			m_loadedFromScript = false;
 			Mob dbMob = (Mob)obj;
-			INpcTemplate npcTemplate = NpcTemplateMgr.GetTemplate(dbMob.NPCTemplateID);
+			NPCTemplate = NpcTemplateMgr.GetTemplate(dbMob.NPCTemplateID);
 
 			TranslationId = dbMob.TranslationId;
 			Name = dbMob.Name;
@@ -1945,19 +2030,13 @@ namespace DOL.GS
 			Realm = (eRealm)dbMob.Realm;
 			Model = dbMob.Model;
 			Size = dbMob.Size;
-			Level = dbMob.Level;    // health changes when GameNPC.Level changes
 			Flags = (eFlags)dbMob.Flags;
 			m_packageID = dbMob.PackageID;
 
-			Strength = (short)dbMob.Strength;
-			Constitution = (short)dbMob.Constitution;
-			Dexterity = (short)dbMob.Dexterity;
-			Quickness = (short)dbMob.Quickness;
-			Empathy = (short)dbMob.Empathy;
-			Intelligence = (short)dbMob.Intelligence;
-			Charisma = (short)dbMob.Charisma;
-			Piety = (short)dbMob.Piety;
-			AutoSetStats();
+			// Skip Level.set calling AutoSetStats() so it doesn't load the DB entry we already have
+			m_level = dbMob.Level;
+			AutoSetStats(dbMob);
+			Level = dbMob.Level;
 
 			MeleeDamageType = (eDamageType)dbMob.MeleeDamageType;
 			if (MeleeDamageType == 0)
@@ -2051,8 +2130,7 @@ namespace DOL.GS
 			Gender = (eGender)dbMob.Gender;
 			OwnerID = dbMob.OwnerID;
 
-			if (npcTemplate != null)
-				LoadTemplate(npcTemplate);
+			LoadTemplate(NPCTemplate);
 			/*
 						if (Inventory != null)
 							SwitchWeapon(ActiveWeaponSlot);
@@ -2202,7 +2280,7 @@ namespace DOL.GS
 				return;
 
 			// Save the template for later
-			m_npcTemplate = template as NpcTemplate;
+			NPCTemplate = template as NpcTemplate;
 
 			// These stats aren't found in the mob table, so always get them from the template
 			this.TetherRange = template.TetherRange;
@@ -2210,6 +2288,18 @@ namespace DOL.GS
 			this.EvadeChance = template.EvadeChance;
 			this.BlockChance = template.BlockChance;
 			this.LeftHandSwingChance = template.LeftHandSwingChance;
+
+			// We need level set before assigning spells to scale pet spells
+			if (template.ReplaceMobValues)
+			{
+				byte choosenLevel = 1;
+				if (!Util.IsEmpty(template.Level))
+				{
+					var split = template.Level.SplitCSV(true);
+					byte.TryParse(split[Util.Random(0, split.Count - 1)], out choosenLevel);
+				}
+				this.Level = choosenLevel; // Also calls AutosetStats()
+			}
 
 			if (template.Spells != null) this.Spells = template.Spells;
 			if (template.Styles != null) this.Styles = template.Styles;
@@ -2261,26 +2351,6 @@ namespace DOL.GS
 				byte.TryParse(split[Util.Random(0, split.Count - 1)], out choosenSize);
 			}
 			this.Size = choosenSize;
-
-			byte choosenLevel = 1;
-			if (!Util.IsEmpty(template.Level))
-			{
-				var split = template.Level.SplitCSV(true);
-				byte.TryParse(split[Util.Random(0, split.Count - 1)], out choosenLevel);
-			}
-			this.Level = choosenLevel;
-			#endregion
-
-			#region Stats
-			Strength = (short)template.Strength;
-			Constitution = (short)template.Constitution;
-			Dexterity = (short)template.Dexterity;
-			Quickness = (short)template.Quickness;
-			Empathy = (short)template.Empathy;
-			Intelligence = (short)template.Intelligence;
-			Charisma = (short)template.Charisma;
-			Piety = (short)template.Piety;
-			AutoSetStats();
 			#endregion
 
 			#region Misc Stats
@@ -4807,8 +4877,11 @@ namespace DOL.GS
 		/// <summary>
 		/// Sort spells into specific lists
 		/// </summary>
-		public void SortSpells()
+		public virtual void SortSpells()
 		{
+			if (Spells.Count < 1)
+				return;
+
 			// Clear the lists
 			if (InstantHarmfulSpells != null)
 				InstantHarmfulSpells.Clear();
@@ -4830,6 +4903,7 @@ namespace DOL.GS
 			{
 				if (spell == null)
 					continue;
+
 
 				if (spell.IsHarmful)
 				{
@@ -5683,7 +5757,8 @@ namespace DOL.GS
 
 		public GameNPC(ABrain defaultBrain) : base()
 		{
-			Level = 1; // health changes when GameNPC.Level changes
+			Level = 1;
+			m_health = MaxHealth;
 			m_Realm = 0;
 			m_name = "new mob";
 			m_model = 408;

--- a/GameServer/gameobjects/GameObject.cs
+++ b/GameServer/gameobjects/GameObject.cs
@@ -437,7 +437,7 @@ namespace DOL.GS
 		/// <summary>
 		/// The level of the Object
 		/// </summary>
-		protected byte m_level;
+		protected byte m_level = 0; // Default to 0 to force AutoSetStats() to be called when level set
 
 		/// <summary>
 		/// The name of the Object

--- a/GameServer/gameobjects/GamePet.cs
+++ b/GameServer/gameobjects/GamePet.cs
@@ -318,7 +318,6 @@ namespace DOL.GS
 				case "damagespeeddecrease":
 				case "stylebleeding": // Style bleed effect
 					spell.Damage *= (double)casterLevel / ServerProperties.Properties.PET_SCALE_SPELL_MAX_LEVEL;
-					log.Error($"TEGS: ScalePetSpell() scaled spell {spell.Name} to Damage {spell.Damage}");
 					break;
 				// Scale Value
 				case "enduranceregenbuff":
@@ -356,7 +355,6 @@ namespace DOL.GS
 				case "speeddecrease":
 				case "stylecombatspeeddebuff": // Style attack speed debuff
 					spell.Value *= (double)casterLevel / ServerProperties.Properties.PET_SCALE_SPELL_MAX_LEVEL;
-					log.Error($"TEGS: ScalePetSpell() scaled spell {spell.Name} to Value {spell.Value}");
 					break;
 				// Scale Duration
 				case "disease":
@@ -366,7 +364,6 @@ namespace DOL.GS
 				case "stylestun": // Style stun effect
 				case "stylespeeddecrease": // Style hinder effect
 					spell.Duration = (int)Math.Ceiling(spell.Duration * (double)casterLevel / ServerProperties.Properties.PET_SCALE_SPELL_MAX_LEVEL);
-					log.Error($"TEGS: ScalePetSpell() scaled spell {spell.Name} to Duration {spell.Duration}");
 					break;
 				case "styletaunt": // Style taunt effects already scale with damage
 				case "curepoison":

--- a/GameServer/gameobjects/GamePet.cs
+++ b/GameServer/gameobjects/GamePet.cs
@@ -53,19 +53,81 @@ namespace DOL.GS
 
         }
 
+		/// <summary>
+		/// The owner of this pet
+		/// </summary>
 		public GameLiving Owner
 		{
 			get
 			{
 				if (Brain is IControlledBrain)
-				{
 					return (Brain as IControlledBrain).Owner;
-				}
 
 				return null;
 			}
 		}
 
+		/// <summary>
+		/// The root owner of this pet, the person at the top of the owner chain.
+		/// </summary>
+		public GameLiving RootOwner
+		{
+			get
+			{
+				if (Brain is IControlledBrain petBrain)
+					return petBrain.GetLivingOwner();
+
+				return null;
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the level of this NPC
+		/// </summary>
+		public override byte Level
+		{
+			get { return base.Level; }
+			set
+			{
+				// Don't set the pet level until the owner is set
+				// This skips unnecessary calls to code in base.Level
+				if (Owner != null)
+					base.Level = value;
+			}
+		}
+
+		// Store the info we need from the summoning spell to calculate pet level.
+		public double SummonSpellDamage { get; set; } = -88.0;
+		public double SummonSpellValue { get; set; } = 44.0;
+
+		/// <summary>
+		/// Set the pet's level based on owner's level.  Make sure Owner brain has been assigned before calling!
+		/// </summary>
+		/// <returns>Did the pet's level change?</returns>
+		public virtual bool SetPetLevel()
+		{
+			// Changing Level calls additional code, so only do it at the end
+			byte newLevel = 0;
+
+			if (SummonSpellDamage >= 0)
+				newLevel = (byte)SummonSpellDamage;
+			else if (!(Owner is GamePet))
+				newLevel = (byte)(Owner.Level * SummonSpellDamage * -0.01);
+			else if (RootOwner is GameLiving summoner)
+				newLevel = (byte)(summoner.Level * SummonSpellDamage * -0.01);
+
+			if (newLevel > SummonSpellValue)
+				newLevel = (byte)SummonSpellValue;
+
+			if (newLevel < 1)
+				newLevel = 1;
+
+			if (Level == newLevel)
+				return false;
+
+			Level = newLevel;
+			return true;
+		}
 
 		#region Inventory
 
@@ -127,6 +189,91 @@ namespace DOL.GS
 		#region Spells
 
 		/// <summary>
+		/// Sort spells into specific lists
+		/// </summary>
+		public override void SortSpells()
+		{
+			SortSpells(0);
+		}
+
+		/// <summary>
+		/// Sort spells into specific lists, scaling spells by scaleLevel
+		/// </summary>
+		/// <param name="casterLevel">The level to scale the pet spell to, 0 to use pet level</param>
+		public virtual void SortSpells(int scaleLevel)
+		{
+			if (Spells.Count < 1 || Level < 1)
+				return;
+
+			if (DOL.GS.ServerProperties.Properties.PET_SCALE_SPELL_MAX_LEVEL <= 0)
+				base.SortSpells();
+			else
+			{
+				if (scaleLevel <= 0)
+					scaleLevel = Level;
+
+				if (DOL.GS.ServerProperties.Properties.PET_LEVELS_WITH_OWNER || 
+					(this is BDSubPet && DOL.GS.ServerProperties.Properties.PET_CAP_BD_MINION_SPELL_SCALING_BY_SPEC))
+				{
+					// We'll need to be able to scale spells for this pet multiple times, so we
+					//	need to keep the original spells in Spells and only scale sorted copies.
+
+					base.SortSpells();
+
+					if (CanCastHarmfulSpells)
+						for (int i = 0; i < HarmfulSpells.Count; i++)
+						{
+							HarmfulSpells[i] = HarmfulSpells[i].Copy();
+							ScalePetSpell(HarmfulSpells[i], scaleLevel);
+						}
+
+					if (CanCastInstantHarmfulSpells)
+						for (int i = 0; i < InstantHarmfulSpells.Count; i++)
+						{
+							InstantHarmfulSpells[i] = InstantHarmfulSpells[i].Copy();
+							ScalePetSpell(InstantHarmfulSpells[i], scaleLevel);
+						}
+
+					if (CanCastHealSpells)
+						for (int i = 0; i < HealSpells.Count; i++)
+						{
+							HealSpells[i] = HealSpells[i].Copy();
+							ScalePetSpell(HealSpells[i], scaleLevel);
+						}
+
+					if (CanCastInstantHealSpells)
+						for (int i = 0; i < InstantHealSpells.Count; i++)
+						{
+							InstantHealSpells[i] = InstantHealSpells[i].Copy();
+							ScalePetSpell(InstantHealSpells[i], scaleLevel);
+						}
+
+					if (CanCastInstantMiscSpells)
+						for (int i = 0; i < InstantMiscSpells.Count; i++)
+						{
+							InstantMiscSpells[i] = InstantMiscSpells[i].Copy();
+							ScalePetSpell(InstantMiscSpells[i], scaleLevel);
+						}
+
+					if (CanCastMiscSpells)
+						for (int i = 0; i < MiscSpells.Count; i++)
+						{
+							MiscSpells[i] = MiscSpells[i].Copy();
+							ScalePetSpell(MiscSpells[i], scaleLevel);
+						}
+				}
+				else
+				{
+					// We don't need to keep the original spells, so don't waste memory keeping separate copies.
+					foreach (Spell spell in Spells)
+						ScalePetSpell(spell, scaleLevel);
+
+					base.SortSpells();
+				}
+			}
+		}
+
+		/// <summary>
 		/// Can this living cast the given spell while in combat?
 		/// </summary>
 		/// <param name="spell"></param>
@@ -150,16 +297,14 @@ namespace DOL.GS
 		/// Scale the passed spell according to PET_SCALE_SPELL_MAX_LEVEL
 		/// </summary>
 		/// <param name="spell">The spell to scale</param>
-		public void ScalePetSpell(Spell spell)
+		/// <param name="casterLevel">The level to scale the pet spell to, 0 to use pet level</param>
+		public virtual void ScalePetSpell(Spell spell, int casterLevel = 0)
 		{
-			if (ServerProperties.Properties.PET_SCALE_SPELL_MAX_LEVEL <= 0)
+			if (ServerProperties.Properties.PET_SCALE_SPELL_MAX_LEVEL <= 0 || spell == null || Level < 1)
 				return;
 
-			double CasterLevel = Level;
-
-			// Cap the level we scale BD minions' spell effects to the player's modified spec for the spec line the pet is from
-			if (this is BDSubPet subpet && subpet.Owner is CommanderPet commander && commander.Owner is GamePlayer player)
-				CasterLevel = Math.Min(subpet.Level, player.GetModifiedSpecLevel(subpet.PetSpecLine));
+			if (casterLevel < 1)
+				casterLevel = Level;
 
 			switch (spell.SpellType.ToString().ToLower())
 			{
@@ -171,8 +316,9 @@ namespace DOL.GS
 				case "directdamagewithdebuff":
 				case "lifedrain":
 				case "damagespeeddecrease":
-				case "stylebleeding": // Style Effect
-					spell.Damage *= CasterLevel / ServerProperties.Properties.PET_SCALE_SPELL_MAX_LEVEL;
+				case "stylebleeding": // Style bleed effect
+					spell.Damage *= (double)casterLevel / ServerProperties.Properties.PET_SCALE_SPELL_MAX_LEVEL;
+					log.Error($"TEGS: ScalePetSpell() scaled spell {spell.Name} to Damage {spell.Damage}");
 					break;
 				// Scale Value
 				case "enduranceregenbuff":
@@ -209,7 +355,8 @@ namespace DOL.GS
 				case "unbreakablespeeddecrease":
 				case "speeddecrease":
 				case "stylecombatspeeddebuff": // Style attack speed debuff
-					spell.Value *= CasterLevel / ServerProperties.Properties.PET_SCALE_SPELL_MAX_LEVEL;
+					spell.Value *= (double)casterLevel / ServerProperties.Properties.PET_SCALE_SPELL_MAX_LEVEL;
+					log.Error($"TEGS: ScalePetSpell() scaled spell {spell.Name} to Value {spell.Value}");
 					break;
 				// Scale Duration
 				case "disease":
@@ -218,12 +365,14 @@ namespace DOL.GS
 				case "mesmerize":
 				case "stylestun": // Style stun effect
 				case "stylespeeddecrease": // Style hinder effect
-					spell.Duration = (int)Math.Ceiling(spell.Duration * CasterLevel / ServerProperties.Properties.PET_SCALE_SPELL_MAX_LEVEL);
+					spell.Duration = (int)Math.Ceiling(spell.Duration * (double)casterLevel / ServerProperties.Properties.PET_SCALE_SPELL_MAX_LEVEL);
+					log.Error($"TEGS: ScalePetSpell() scaled spell {spell.Name} to Duration {spell.Duration}");
 					break;
-				case "styletaunt": // Taunt styles already scale with damage
+				case "styletaunt": // Style taunt effects already scale with damage
+				case "curepoison":
+				case "curedisease":
 						break;
 				default:
-					log.Warn("ScalePetSpell(): unrecognized spell type " + spell.SpellType);
 					break; // Don't mess with types we don't know
 			} // switch (m_spell.SpellType.ToString().ToLower())
 		}
@@ -232,29 +381,47 @@ namespace DOL.GS
 
 		#region Stats
 		/// <summary>
-		/// Set stats according to PET_AUTOSET values, then scale them according to the values in the DB
+		/// Set stats according to PET_AUTOSET values, then scale them according to the npcTemplate
 		/// </summary>
 		public override void AutoSetStats()
 		{
-			// Assign values from Autoset
-			Strength = (short)Math.Max(1, Properties.PET_AUTOSET_STR_BASE);
-			Constitution = (short)Math.Max(1, Properties.PET_AUTOSET_CON_BASE);
-			Quickness = (short)Math.Max(1, Properties.PET_AUTOSET_QUI_BASE);
-			Dexterity = (short)Math.Max(1, Properties.PET_AUTOSET_DEX_BASE);
-			Intelligence = (short)Math.Max(1,Properties.PET_AUTOSET_INT_BASE);
-			Empathy = (short)30;
-			Piety = (short)30;
-			Charisma = (short)30;
-			
-			// Now add stats for levelling
-			Strength += (short)Math.Round(10.0 * (Level - 1) * Properties.PET_AUTOSET_STR_MULTIPLIER);
-			Constitution += (short)Math.Round((Level - 1) * Properties.PET_AUTOSET_CON_MULTIPLIER);
-			Quickness += (short)Math.Round((Level - 1) * Properties.PET_AUTOSET_QUI_MULTIPLIER);
-			Dexterity += (short)Math.Round((Level - 1) * Properties.PET_AUTOSET_DEX_MULTIPLIER);
-			Intelligence += (short)Math.Round((Level - 1) * Properties.PET_AUTOSET_INT_MULTIPLIER);
-			Empathy += (short)(Level - 1);
-			Piety += (short)(Level - 1);
-			Charisma += (short)(Level - 1);
+			// Assign base values
+			Strength = Properties.PET_AUTOSET_STR_BASE;
+			if (Strength < 1)
+				Strength = 1;
+
+			Constitution = Properties.PET_AUTOSET_CON_BASE;
+			if (Constitution < 1)
+				Constitution = 1;
+
+			Quickness = Properties.PET_AUTOSET_QUI_BASE;
+			if (Quickness < 1)
+				Quickness = 1;
+
+			Dexterity = Properties.PET_AUTOSET_DEX_BASE;
+			if (Dexterity < 1)
+				Dexterity = 1;
+
+			Intelligence = Properties.PET_AUTOSET_INT_BASE;
+			if (Intelligence < 1)
+				Intelligence = 1;
+
+			Empathy = 30;
+			Piety = 30;
+			Charisma = 30;
+
+			if (Level > 1)
+			{
+				// Now add stats for levelling
+				Strength += (short)Math.Round(10.0 * (Level - 1) * Properties.PET_AUTOSET_STR_MULTIPLIER);
+				Constitution += (short)Math.Round((Level - 1) * Properties.PET_AUTOSET_CON_MULTIPLIER);
+				Quickness += (short)Math.Round((Level - 1) * Properties.PET_AUTOSET_QUI_MULTIPLIER);
+				Dexterity += (short)Math.Round((Level - 1) * Properties.PET_AUTOSET_DEX_MULTIPLIER);
+				Intelligence += (short)Math.Round((Level - 1) * Properties.PET_AUTOSET_INT_MULTIPLIER);
+				Empathy += (short)(Level - 1);
+				Piety += (short)(Level - 1);
+				Charisma += (short)(Level - 1);
+			}
 
 			// Now scale them according to NPCTemplate values
 			if (NPCTemplate != null)
@@ -269,6 +436,7 @@ namespace DOL.GS
 					Dexterity = (short)Math.Round(Dexterity * (NPCTemplate.Dexterity / 100.0));
 				if (NPCTemplate.Intelligence > 0)
 					Intelligence = (short)Math.Round(Intelligence * (NPCTemplate.Intelligence / 100.0));
+
 				// Except for CHA, EMP, AND PIE as those don't have autoset values.
 				if (NPCTemplate.Empathy > 0)
 					Empathy = (short)NPCTemplate.Empathy;

--- a/GameServer/gameobjects/GamePlayer.cs
+++ b/GameServer/gameobjects/GamePlayer.cs
@@ -24,6 +24,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 
+using DOL.AI;
 using DOL.AI.Brain;
 using DOL.Database;
 using DOL.Events;
@@ -3229,6 +3230,17 @@ namespace DOL.GS
 			}
 			else specLine.Level = 1;
 
+			// If BD subpet spells scaled and capped by BD spec, respecing a spell line
+			//	requires re-scaling the spells for all subpets from that line.
+			if (CharacterClass is CharacterClassBoneDancer
+				&& DOL.GS.ServerProperties.Properties.PET_SCALE_SPELL_MAX_LEVEL > 0
+				&& DOL.GS.ServerProperties.Properties.PET_CAP_BD_MINION_SPELL_SCALING_BY_SPEC
+				&& ControlledBrain is IControlledBrain brain && brain.Body is GamePet pet
+				&& pet.ControlledNpcList != null)
+					foreach (ABrain subBrain in pet.ControlledNpcList)
+						if (subBrain != null && subBrain.Body is BDSubPet subPet && subPet.PetSpecLine == specLine.KeyName)
+							subPet.SortSpells();
+
 			return specPoints;
 		}
 
@@ -5231,6 +5243,27 @@ namespace DOL.GS
 				Task.SaveIntoDatabase();
 			}
 			
+			// Level up pets and subpets
+			if (DOL.GS.ServerProperties.Properties.PET_LEVELS_WITH_OWNER &&
+				ControlledBrain is ControlledNpcBrain brain && brain.Body is GamePet pet)
+			{
+				if (pet.SetPetLevel())
+				{
+					if (DOL.GS.ServerProperties.Properties.PET_SCALE_SPELL_MAX_LEVEL > 0 && pet.Spells.Count > 0)
+						pet.SortSpells();
+
+					brain.UpdatePetWindow();
+				}
+
+				// subpets
+				if (pet.ControlledNpcList != null)
+					foreach (ABrain subBrain in pet.ControlledNpcList)
+						if (subBrain != null && subBrain.Body is GamePet subPet)
+							if (subPet.SetPetLevel()) // Levels up subpet
+								if (DOL.GS.ServerProperties.Properties.PET_SCALE_SPELL_MAX_LEVEL > 0)
+									subPet.SortSpells();
+			}
+
 			// save player to database
 			SaveIntoDatabase();
 		}
@@ -14398,13 +14431,16 @@ namespace DOL.GS
 		/// <returns>true if invulnerability was set (smaller than old invulnerability)</returns>
 		public virtual bool StartInvulnerabilityTimer(int duration, InvulnerabilityExpiredCallback callback)
 		{
+			if (GameServer.Instance.Configuration.ServerType == eGameServerType.GST_PvE)
+				return false;
+
 			if (duration < 1)
-            		{
-                		//throw new ArgumentOutOfRangeException("duration", duration, "Immunity duration cannot be less than 1ms"); This causes problems down the road, just log it instead.
-                		if (log.IsWarnEnabled)
-                    			log.Warn("GamePlayer.StartInvulnerabilityTimer(): Immunity duration cannot be less than 1ms");
-                		return false;
-            		}
+            {
+                //throw new ArgumentOutOfRangeException("duration", duration, "Immunity duration cannot be less than 1ms"); This causes problems down the road, just log it instead.
+                if (log.IsWarnEnabled)
+                    	log.Warn("GamePlayer.StartInvulnerabilityTimer(): Immunity duration cannot be less than 1ms");
+                return false;
+            }
 
 			long newTick = CurrentRegion.Time + duration;
 			if (newTick < m_invulnerabilityTick)

--- a/GameServer/gameobjects/Necromancer/NecromancerPet.cs
+++ b/GameServer/gameobjects/Necromancer/NecromancerPet.cs
@@ -114,7 +114,6 @@ namespace DOL.GS
 			}
 		}
 		#region Stats
-
 		/// <summary>
 		/// Get modified bonuses for the pet; some bonuses come from the shade,
 		/// some come from the pet.
@@ -267,32 +266,74 @@ namespace DOL.GS
 		/// </summary>
 		public override void AutoSetStats()
 		{
-			// Use normal pet stats for Cha, Emp, Int, and Pie.
-			base.AutoSetStats();
-
 			if (Name.ToUpper() == "GREATER NECROSERVANT")
 			{
-				Strength = (short)(ServerProperties.Properties.NECRO_GREATER_PET_STR_BASE
-					+ (short)(Math.Round(ServerProperties.Properties.NECRO_GREATER_PET_STR_MULTIPLIER * Level)));
-				Constitution = (short)(ServerProperties.Properties.NECRO_GREATER_PET_CON_BASE
-					+ (short)(Math.Round(ServerProperties.Properties.NECRO_GREATER_PET_CON_MULTIPLIER * Level))
-					+ m_summonConBonus);
-				Dexterity = (short)(ServerProperties.Properties.NECRO_GREATER_PET_DEX_BASE
-					+ (short)(Math.Round(ServerProperties.Properties.NECRO_GREATER_PET_DEX_MULTIPLIER * Level)));
-				Quickness = (short)(ServerProperties.Properties.NECRO_GREATER_PET_QUI_BASE
-					+ (short)(Math.Round(ServerProperties.Properties.NECRO_GREATER_PET_QUI_MULTIPLIER * Level)));
+				Strength = ServerProperties.Properties.NECRO_GREATER_PET_STR_BASE;
+				Constitution = (short)(ServerProperties.Properties.NECRO_GREATER_PET_CON_BASE + m_summonConBonus);
+				Dexterity = ServerProperties.Properties.NECRO_GREATER_PET_DEX_BASE;
+				Quickness = ServerProperties.Properties.NECRO_GREATER_PET_QUI_BASE;
+
+				if (Level > 1)
+				{
+					Strength += (short)(Math.Round(ServerProperties.Properties.NECRO_GREATER_PET_STR_MULTIPLIER * Level));
+					Constitution += (short)(Math.Round(ServerProperties.Properties.NECRO_GREATER_PET_CON_MULTIPLIER * Level));
+					Dexterity += (short)(Math.Round(ServerProperties.Properties.NECRO_GREATER_PET_DEX_MULTIPLIER * Level));
+					Quickness += (short)(Math.Round(ServerProperties.Properties.NECRO_GREATER_PET_QUI_MULTIPLIER * Level));
+				}
 			}
 			else
 			{
-				Strength = (short)(ServerProperties.Properties.NECRO_PET_STR_BASE
-					+ (short)(Math.Round(ServerProperties.Properties.NECRO_PET_STR_MULTIPLIER * Level)));
-				Constitution = (short)(ServerProperties.Properties.NECRO_PET_CON_BASE
-					+ (short)(Math.Round(ServerProperties.Properties.NECRO_PET_CON_MULTIPLIER * Level))
-					+ m_summonConBonus);
-				Dexterity = (short)(ServerProperties.Properties.NECRO_PET_DEX_BASE
-					+ (short)(Math.Round(ServerProperties.Properties.NECRO_PET_DEX_MULTIPLIER * Level)));
-				Quickness = (short)(ServerProperties.Properties.NECRO_PET_QUI_BASE
-					+ (short)(Math.Round(ServerProperties.Properties.NECRO_PET_QUI_MULTIPLIER * Level)));
+				Strength = ServerProperties.Properties.NECRO_PET_STR_BASE;
+				Constitution = (short)(ServerProperties.Properties.NECRO_PET_CON_BASE + m_summonConBonus);
+				Dexterity = ServerProperties.Properties.NECRO_PET_DEX_BASE;
+				Quickness = ServerProperties.Properties.NECRO_PET_QUI_BASE;
+
+				if (Level > 1)
+				{
+					Strength += (short)(Math.Round(ServerProperties.Properties.NECRO_PET_STR_MULTIPLIER * Level));
+					Constitution += (short)(Math.Round(ServerProperties.Properties.NECRO_PET_CON_MULTIPLIER * Level));
+					Dexterity += (short)(Math.Round(ServerProperties.Properties.NECRO_PET_DEX_MULTIPLIER * Level));
+					Quickness += (short)(Math.Round(ServerProperties.Properties.NECRO_PET_QUI_MULTIPLIER * Level));
+				}
+			}
+
+			Empathy = (byte)(29 + Level);
+			Piety = (byte)(29 + Level);
+			Charisma = (byte)(29 + Level);
+
+			// Now scale them according to NPCTemplate values
+			if (NPCTemplate != null)
+			{
+				if (NPCTemplate.Strength > 0)
+					Strength = (short)Math.Round(Strength * NPCTemplate.Strength / 100.0);
+
+				if (NPCTemplate.Constitution > 0)
+					Constitution = (short)Math.Round(Constitution * NPCTemplate.Constitution / 100.0);
+				
+				if (NPCTemplate.Quickness > 0)
+					Quickness = (short)Math.Round(Quickness * NPCTemplate.Quickness / 100.0);
+				
+				if (NPCTemplate.Dexterity > 0)
+					Dexterity = (short)Math.Round(Dexterity * NPCTemplate.Dexterity / 100.0);
+				
+				if (NPCTemplate.Intelligence > 0)
+					Intelligence = (short)Math.Round(Intelligence * NPCTemplate.Intelligence / 100.0);
+				
+				// Except for CHA, EMP, AND PIE as those don't have autoset values.
+				if (NPCTemplate.Empathy > 0)
+					Empathy = (short)(NPCTemplate.Empathy + Level);
+				
+				if (NPCTemplate.Piety > 0)
+					Piety = (short)(NPCTemplate.Piety + Level);
+
+				if (NPCTemplate.Charisma > 0)
+					Charisma = (short)(NPCTemplate.Charisma + Level);
+
+				// Older DBs have necro pet templates with stats at 30, so warn servers that they need to update their templates
+				if (NPCTemplate.Strength == 30 || NPCTemplate.Constitution == 30 || NPCTemplate.Quickness == 30 
+					|| NPCTemplate.Dexterity == 30 || NPCTemplate.Intelligence == 30)
+					log.Warn($"AutoSetStats(): NpcTemplate with TemplateId=[{NPCTemplate.TemplateId}] scales necro pet Str/Con/Qui/Dex/Int to 30%.  "
+						+ "If this is not intended, change stat values in template to desired percentage or set to 0 to use default.");
 			}
 		}
 
@@ -337,12 +378,17 @@ namespace DOL.GS
 		/// <param name="ad">information about the attack</param>
 		public override void OnAttackedByEnemy(AttackData ad)
 		{
-			if (Brain is NecromancerPetBrain necroBrain && necroBrain.SpellsQueued && !HasEffect(typeof(FacilitatePainworkingEffect)) 
-				&& ad != null && ad.Attacker != null && ChanceSpellInterrupt(ad.Attacker))
+			if (!HasEffect(typeof(FacilitatePainworkingEffect)) &&
+				ad != null && ad.Attacker != null && ChanceSpellInterrupt(ad.Attacker))
 			{
-				StopCurrentSpellcast();
-				necroBrain.ClearSpellQueue();
-				necroBrain.MessageToOwner("Your pet was attacked by " + ad.Attacker.Name + " and their spell was interrupted!", eChatType.CT_SpellResisted);
+				if (Brain is NecromancerPetBrain necroBrain)
+				{
+					StopCurrentSpellcast();
+					necroBrain.MessageToOwner("Your pet was attacked by " + ad.Attacker.Name + " and their spell was interrupted!", eChatType.CT_SpellResisted);
+
+					if(necroBrain.SpellsQueued)
+						necroBrain.ClearSpellQueue();
+				}
 			}
 
 			base.OnAttackedByEnemy(ad);
@@ -353,12 +399,17 @@ namespace DOL.GS
 		/// </summary>
 		protected override AttackData MakeAttack(GameObject target, InventoryItem weapon, Style style, double effectiveness, int interruptDuration, bool dualWield, bool ignoreLOS)
 		{
-			if (Brain is NecromancerPetBrain necroBrain && necroBrain.SpellsQueued && !HasEffect(typeof(FacilitatePainworkingEffect)))
+			if (!HasEffect(typeof(FacilitatePainworkingEffect)))
 			{
 				StopCurrentSpellcast();
-				necroBrain.ClearSpellQueue();
 
-				necroBrain.MessageToOwner("Your pet attacked and interrupted their spell!", eChatType.CT_SpellResisted);
+				if (Brain is NecromancerPetBrain necroBrain)
+				{
+					necroBrain.MessageToOwner("Your pet attacked and interrupted their spell!", eChatType.CT_SpellResisted);
+
+					if (necroBrain.SpellsQueued)
+						necroBrain.ClearSpellQueue();
+				}
 			}
 
 			return base.MakeAttack(target, weapon, style, effectiveness, interruptDuration, dualWield, ignoreLOS);

--- a/GameServer/gameutils/INpcTemplate.cs
+++ b/GameServer/gameutils/INpcTemplate.cs
@@ -89,14 +89,14 @@ namespace DOL.GS
 		/// <summary>
 		/// Gets the template npc stats
 		///</summary>
-		int Strength { get; }
-		int Constitution { get; }
-		int Dexterity { get; }
-		int Quickness { get; }
-		int Piety { get; }
-		int Intelligence { get; }
-		int Empathy { get; }
-		int Charisma { get; }
+		short Strength { get; }
+		short Constitution { get; }
+		short Dexterity { get; }
+		short Quickness { get; }
+		short Piety { get; }
+		short Intelligence { get; }
+		short Empathy { get; }
+		short Charisma { get; }
 
 		/// <summary>
 		/// Gets the template npc aggro values

--- a/GameServer/gameutils/NpcTemplate.cs
+++ b/GameServer/gameutils/NpcTemplate.cs
@@ -59,14 +59,14 @@ namespace DOL.GS
 		protected ushort m_flags;
 		protected string m_inventory;
 		protected eDamageType m_meleeDamageType;
-		protected int m_strength;
-		protected int m_constitution;
-		protected int m_dexterity;
-		protected int m_quickness;
-		protected int m_piety;
-		protected int m_intelligence;
-		protected int m_empathy;
-		protected int m_charisma;
+		protected short m_strength;
+		protected short m_constitution;
+		protected short m_dexterity;
+		protected short m_quickness;
+		protected short m_piety;
+		protected short m_intelligence;
+		protected short m_empathy;
+		protected short m_charisma;
 		protected IList m_styles;
 		protected IList m_spells;
 		protected IList m_spelllines;
@@ -548,49 +548,49 @@ namespace DOL.GS
 			set { m_abilities = value; }
 		}
 
-		public int Strength
+		public short Strength
 		{
 			get { return m_strength; }
 			set { m_strength = value; }
 		}
 
-		public int Constitution
+		public short Constitution
 		{
 			get { return m_constitution; }
 			set { m_constitution = value; }
 		}
 
-		public int Dexterity
+		public short Dexterity
 		{
 			get { return m_dexterity; }
 			set { m_dexterity = value; }
 		}
 
-		public int Quickness
+		public short Quickness
 		{
 			get { return m_quickness; }
 			set { m_quickness = value; }
 		}
 
-		public int Piety
+		public short Piety
 		{
 			get { return m_piety; }
 			set { m_piety = value; }
 		}
 
-		public int Intelligence
+		public short Intelligence
 		{
 			get { return m_intelligence; }
 			set { m_intelligence = value; }
 		}
 
-		public int Empathy
+		public short Empathy
 		{
 			get { return m_empathy; }
 			set { m_empathy = value; }
 		}
 
-		public int Charisma
+		public short Charisma
 		{
 			get { return m_charisma; }
 			set { m_charisma = value; }

--- a/GameServer/quests/Tasks/CraftTask.cs
+++ b/GameServer/quests/Tasks/CraftTask.cs
@@ -30,7 +30,7 @@ namespace DOL.GS.Quests
 	/// </summary>
 	public class CraftTask : AbstractTask
 	{
-		protected static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+		private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
 		public const string RECIEVER_ZONE = "recieverZone";
 

--- a/GameServer/serverproperty/ServerProperties.cs
+++ b/GameServer/serverproperty/ServerProperties.cs
@@ -1007,8 +1007,8 @@ namespace DOL.GS.ServerProperties
 		/// <summary>
 		/// Base Value to use when auto-setting STR stat.
 		/// </summary>
-		[ServerProperty("npc", "mob_autoset_str_base", "Base Value to use when auto-setting STR stat. ", 30.0)]
-		public static double MOB_AUTOSET_STR_BASE;
+		[ServerProperty("npc", "mob_autoset_str_base", "Base Value to use when auto-setting STR stat. ", (short)30)]
+		public static short MOB_AUTOSET_STR_BASE;
 
 		/// <summary>
 		/// Multiplier to use when auto-setting STR stat.
@@ -1019,8 +1019,8 @@ namespace DOL.GS.ServerProperties
 		/// <summary>
 		/// Base Value to use when auto-setting CON stat.
 		/// </summary>
-		[ServerProperty("npc", "mob_autoset_con_base", "Base Value to use when auto-setting CON stat. ", 30.0)]
-		public static double MOB_AUTOSET_CON_BASE;
+		[ServerProperty("npc", "mob_autoset_con_base", "Base Value to use when auto-setting CON stat. ", (short)30)]
+		public static short MOB_AUTOSET_CON_BASE;
 
 		/// <summary>
 		/// Multiplier to use when auto-setting CON stat.
@@ -1031,8 +1031,8 @@ namespace DOL.GS.ServerProperties
 		/// <summary>
 		/// Base Value to use when auto-setting QUI stat.
 		/// </summary>
-		[ServerProperty("npc", "mob_autoset_qui_base", "Base Value to use when auto-setting qui stat. ", 30.0)]
-		public static double MOB_AUTOSET_QUI_BASE;
+		[ServerProperty("npc", "mob_autoset_qui_base", "Base Value to use when auto-setting qui stat. ", (short)30)]
+		public static short MOB_AUTOSET_QUI_BASE;
 
 		/// <summary>
 		/// Multiplier to use when auto-setting QUI stat.
@@ -1043,8 +1043,8 @@ namespace DOL.GS.ServerProperties
 		/// <summary>
 		/// Base Value to use when auto-setting DEX stat.
 		/// </summary>
-		[ServerProperty("npc", "mob_autoset_dex_base", "Base Value to use when auto-setting DEX stat. ", 30.0)]
-		public static double MOB_AUTOSET_DEX_BASE;
+		[ServerProperty("npc", "mob_autoset_dex_base", "Base Value to use when auto-setting DEX stat. ", (short)30)]
+		public static short MOB_AUTOSET_DEX_BASE;
 
 		/// <summary>
 		/// Multiplier to use when auto-setting DEX stat.
@@ -1055,20 +1055,26 @@ namespace DOL.GS.ServerProperties
 		/// <summary>
 		/// Base Value to use when auto-setting INT stat.
 		/// </summary>
-		[ServerProperty("npc", "mob_autoset_int_base", "Base Value to use when auto-setting INT stat. ", 30)]
-		public static int MOB_AUTOSET_INT_BASE;
+		[ServerProperty("npc", "mob_autoset_int_base", "Base Value to use when auto-setting INT stat. ", (short)30)]
+		public static short MOB_AUTOSET_INT_BASE;
 
 		/// <summary>
 		/// Multiplier to use when auto-setting INT stat.
 		/// </summary>
 		[ServerProperty("npc", "mob_autoset_int_multiplier", "Multiplier to use when auto-setting INT stat. ", 1.0)]
-		public static double MOB_AUTOSET_INT_MULTIPLIER;		
-		
+		public static double MOB_AUTOSET_INT_MULTIPLIER;
+
+		/// <summary>
+		/// Do pets level up with their owner?
+		/// </summary>
+		[ServerProperty("npc", "pet_levels_with_owner", "Do pets level up with their owner? ", false)]
+		public static bool PET_LEVELS_WITH_OWNER;
+
 		/// <summary>
 		/// Base Value to use when auto-setting pet STR stat.
 		/// </summary>
-		[ServerProperty("npc", "pet_autoset_str_base", "Base Value to use when auto-setting Pet STR stat. ", 30.0)]
-		public static double PET_AUTOSET_STR_BASE;
+		[ServerProperty("npc", "pet_autoset_str_base", "Base Value to use when auto-setting Pet STR stat. ", (short)30)]
+		public static short PET_AUTOSET_STR_BASE;
 
 		/// <summary>
 		/// Multiplier to use when auto-setting pet STR stat.
@@ -1078,8 +1084,8 @@ namespace DOL.GS.ServerProperties
 		
 		/// Base Value to use when auto-setting pet CON stat.
 		/// </summary>
-		[ServerProperty("npc", "pet_autoset_con_base", "Base Value to use when auto-setting Pet CON stat. ", 30.0)]
-		public static double PET_AUTOSET_CON_BASE;
+		[ServerProperty("npc", "pet_autoset_con_base", "Base Value to use when auto-setting Pet CON stat. ", (short)30)]
+		public static short PET_AUTOSET_CON_BASE;
 
 		/// <summary>
 		/// Multiplier to use when auto-setting pet CON stat.
@@ -1089,8 +1095,8 @@ namespace DOL.GS.ServerProperties
 
 		/// Base Value to use when auto-setting Pet DEX stat.
 		/// </summary>
-		[ServerProperty("npc", "pet_autoset_dex_base", "Base Value to use when auto-setting Pet DEX stat. ", 30.0)]
-		public static double PET_AUTOSET_DEX_BASE;
+		[ServerProperty("npc", "pet_autoset_dex_base", "Base Value to use when auto-setting Pet DEX stat. ", (short)30)]
+		public static short PET_AUTOSET_DEX_BASE;
 
 		/// <summary>
 		/// Multiplier to use when auto-setting pet DEX stat.
@@ -1100,8 +1106,8 @@ namespace DOL.GS.ServerProperties
 
 		/// Base Value to use when auto-setting Pet QUI stat.
 		/// </summary>
-		[ServerProperty("npc", "pet_autoset_qui_base", "Base Value to use when auto-setting Pet QUI stat. ", 30.0)]
-		public static double PET_AUTOSET_QUI_BASE;
+		[ServerProperty("npc", "pet_autoset_qui_base", "Base Value to use when auto-setting Pet QUI stat. ", (short)30)]
+		public static short PET_AUTOSET_QUI_BASE;
 
 		/// <summary>
 		/// Multiplier to use when auto-setting pet QUI stat.
@@ -1113,8 +1119,8 @@ namespace DOL.GS.ServerProperties
 		/// Multiplier to use when auto-setting pet INT stat.
 		/// INT is the stat used for spell damage for mobs/pets
 		/// </summary>
-		[ServerProperty("npc", "pet_autoset_int_base", "Multiplier to use when auto-setting Pet INT stat. ", 30)]
-		public static double PET_AUTOSET_INT_BASE;
+		[ServerProperty("npc", "pet_autoset_int_base", "Multiplier to use when auto-setting Pet INT stat. ", (short)30)]
+		public static short PET_AUTOSET_INT_BASE;
 
 		/// <summary>
 		/// Multiplier to use when auto-setting pet INT stat.
@@ -1128,8 +1134,8 @@ namespace DOL.GS.ServerProperties
 		/// <summary>
 		/// Base value to use when setting strength for most necromancer pets.
 		/// </summary>
-		[ServerProperty("npc", "necro_pet_str_base", "Base value to use when setting strength for most necromancer pets.", 60)]
-		public static int NECRO_PET_STR_BASE;
+		[ServerProperty("npc", "necro_pet_str_base", "Base value to use when setting strength for most necromancer pets.", (short)60)]
+		public static short NECRO_PET_STR_BASE;
 
 		/// <summary>
 		/// Multiplier to use when setting strength for most necromancer pets.
@@ -1140,8 +1146,8 @@ namespace DOL.GS.ServerProperties
 		/// <summary>
 		/// Base value to use when setting constitution for most necromancer pets.
 		/// </summary>
-		[ServerProperty("npc", "necro_pet_con_base", "Base value to use when setting constitution for most necromancer pets.", 60)]
-		public static int NECRO_PET_CON_BASE;
+		[ServerProperty("npc", "necro_pet_con_base", "Base value to use when setting constitution for most necromancer pets.", (short)60)]
+		public static short NECRO_PET_CON_BASE;
 
 		/// <summary>
 		/// Multiplier to use when setting constitution for most necromancer pets.
@@ -1152,8 +1158,8 @@ namespace DOL.GS.ServerProperties
 		/// <summary>
 		/// Base value to use when setting dexterity for most necromancer pets.
 		/// </summary>
-		[ServerProperty("npc", "necro_pet_dex_base", "Base value to use when setting dexterity for most necromancer pets.", 60)]
-		public static int NECRO_PET_DEX_BASE;
+		[ServerProperty("npc", "necro_pet_dex_base", "Base value to use when setting dexterity for most necromancer pets.", (short)60)]
+		public static short NECRO_PET_DEX_BASE;
 
 		/// <summary>
 		/// Multiplier to use when setting dexterity for most necromancer pets.
@@ -1164,8 +1170,8 @@ namespace DOL.GS.ServerProperties
 		/// <summary>
 		/// Base value to use when setting quickness for most necromancer pets.
 		/// </summary>
-		[ServerProperty("npc", "necro_pet_qui_base", "Base value to use when setting quickness for most necromancer pets.", 60)]
-		public static int NECRO_PET_QUI_BASE;
+		[ServerProperty("npc", "necro_pet_qui_base", "Base value to use when setting quickness for most necromancer pets.", (short)60)]
+		public static short NECRO_PET_QUI_BASE;
 
 		/// <summary>
 		/// Multiplier to use when setting quickness for most necromancer pets.
@@ -1176,8 +1182,8 @@ namespace DOL.GS.ServerProperties
 		/// <summary>
 		/// Base value to use when setting strength for greater necroservant pets.
 		/// </summary>
-		[ServerProperty("npc", "necro_greater_pet_str_base", "Base value to use when setting strength for greater necroservant pets.", 60)]
-		public static int NECRO_GREATER_PET_STR_BASE;
+		[ServerProperty("npc", "necro_greater_pet_str_base", "Base value to use when setting strength for greater necroservant pets.", (short)60)]
+		public static short NECRO_GREATER_PET_STR_BASE;
 
 		/// <summary>
 		/// Multiplier to use when setting strength for greater necroservant pets.
@@ -1188,8 +1194,8 @@ namespace DOL.GS.ServerProperties
 		/// <summary>
 		/// Base value to use when setting constitution forgreater necroservant pets.
 		/// </summary>
-		[ServerProperty("npc", "necro_greater_pet_con_base", "Base value to use when setting constitution for greater necroservant pets.", 60)]
-		public static int NECRO_GREATER_PET_CON_BASE;
+		[ServerProperty("npc", "necro_greater_pet_con_base", "Base value to use when setting constitution for greater necroservant pets.", (short)60)]
+		public static short NECRO_GREATER_PET_CON_BASE;
 
 		/// <summary>
 		/// Multiplier to use when setting constitution for greater necroservant pets.
@@ -1200,8 +1206,8 @@ namespace DOL.GS.ServerProperties
 		/// <summary>
 		/// Base value to use when setting dexterity for greater necroservant pets.
 		/// </summary>
-		[ServerProperty("npc", "necro_greater_pet_dex_base", "Base value to use when setting dexterity for greater necroservant pets.", 60)]
-		public static int NECRO_GREATER_PET_DEX_BASE;
+		[ServerProperty("npc", "necro_greater_pet_dex_base", "Base value to use when setting dexterity for greater necroservant pets.", (short)60)]
+		public static short NECRO_GREATER_PET_DEX_BASE;
 
 		/// <summary>
 		/// Multiplier to use when setting dexterity for greater necroservant pets.
@@ -1212,8 +1218,8 @@ namespace DOL.GS.ServerProperties
 		/// <summary>
 		/// Base value to use when setting quickness for greater necroservant pets.
 		/// </summary>
-		[ServerProperty("npc", "necro_greater_pet_qui_base", "Base value to use when setting quickness for greater necroservant pets.", 60)]
-		public static int NECRO_GREATER_PET_QUI_BASE;
+		[ServerProperty("npc", "necro_greater_pet_qui_base", "Base value to use when setting quickness for greater necroservant pets.", (short)60)]
+		public static short NECRO_GREATER_PET_QUI_BASE;
 
 		/// <summary>
 		/// Multiplier to use when setting quickness for greater necroservant pets.
@@ -1232,8 +1238,14 @@ namespace DOL.GS.ServerProperties
 		/// Scale pet spell values according to their level?
 		/// </summary>
 		[ServerProperty("npc", "pet_scale_spell_max_level", "Disabled if 0 or less.  If greater than 0, this value is the level at which pets cast their spells at 100% effectivness, so choose spells for pets assuming they're at the level set here.  Live is max pet level, 44 or 50 depending on patch.", 0)]
-		public static int PET_SCALE_SPELL_MAX_LEVEL;		
-		
+		public static int PET_SCALE_SPELL_MAX_LEVEL;
+
+		/// <summary>
+		/// Scale pet spell values according to their level?
+		/// </summary>
+		[ServerProperty("npc", "pet_cap_bd_minion_spell_scaling_by_spec", "When scaling BD minion spells, do we cap the level they scale do by the BD's spec level?  This provides an incentive to spec darkness and suppression and use items that boost them.", false)]
+		public static bool PET_CAP_BD_MINION_SPELL_SCALING_BY_SPEC;
+
 		/// <summary>
 		/// What level to start increasing mob damage
 		/// </summary>
@@ -1655,8 +1667,8 @@ namespace DOL.GS.ServerProperties
 		/// <summary>
 		/// Base Value to use when auto-setting STR stat.
 		/// </summary>
-		[ServerProperty("keeps", "guard_autoset_str_base", "Base Value to use when auto-setting STR stat. ", 20)]
-		public static int GUARD_AUTOSET_STR_BASE;
+		[ServerProperty("keeps", "guard_autoset_str_base", "Base Value to use when auto-setting STR stat. ", (short)20)]
+		public static short GUARD_AUTOSET_STR_BASE;
 
 		/// <summary>
 		/// Multiplier to use when auto-setting STR stat.
@@ -1667,8 +1679,8 @@ namespace DOL.GS.ServerProperties
 		/// <summary>
 		/// Base Value to use when auto-setting CON stat.
 		/// </summary>
-		[ServerProperty("keeps", "guard_autoset_con_base", "Base Value to use when auto-setting CON stat. ", 30)]
-		public static int GUARD_AUTOSET_CON_BASE;
+		[ServerProperty("keeps", "guard_autoset_con_base", "Base Value to use when auto-setting CON stat. ", (short)30)]
+		public static short GUARD_AUTOSET_CON_BASE;
 
 		/// <summary>
 		/// Multiplier to use when auto-setting CON stat.
@@ -1679,8 +1691,8 @@ namespace DOL.GS.ServerProperties
 		/// <summary>
 		/// Base Value to use when auto-setting QUI stat.
 		/// </summary>
-		[ServerProperty("keeps", "guard_autoset_qui_base", "Base Value to use when auto-setting qui stat. ", 40)]
-		public static int GUARD_AUTOSET_QUI_BASE;
+		[ServerProperty("keeps", "guard_autoset_qui_base", "Base Value to use when auto-setting qui stat. ", (short)40)]
+		public static short GUARD_AUTOSET_QUI_BASE;
 
 		/// <summary>
 		/// Multiplier to use when auto-setting QUI stat.
@@ -1691,8 +1703,8 @@ namespace DOL.GS.ServerProperties
 		/// <summary>
 		/// Base Value to use when auto-setting DEX stat.
 		/// </summary>
-		[ServerProperty("keeps", "guard_autoset_dex_base", "Base Value to use when auto-setting DEX stat. ", 1)]
-		public static int GUARD_AUTOSET_DEX_BASE;
+		[ServerProperty("keeps", "guard_autoset_dex_base", "Base Value to use when auto-setting DEX stat. ", (short)1)]
+		public static short GUARD_AUTOSET_DEX_BASE;
 
 		/// <summary>
 		/// Multiplier to use when auto-setting DEX stat.
@@ -1703,8 +1715,8 @@ namespace DOL.GS.ServerProperties
 		/// <summary>
 		/// Base Value to use when auto-setting INT stat.
 		/// </summary>
-		[ServerProperty("keeps", "guard_autoset_int_base", "Base Value to use when auto-setting INT stat. ", 30)]
-		public static int GUARD_AUTOSET_INT_BASE;
+		[ServerProperty("keeps", "guard_autoset_int_base", "Base Value to use when auto-setting INT stat. ", (short)30)]
+		public static short GUARD_AUTOSET_INT_BASE;
 
 		/// <summary>
 		/// Multiplier to use when auto-setting INT stat.
@@ -1715,8 +1727,8 @@ namespace DOL.GS.ServerProperties
 		/// <summary>
 		/// Base Value to use when auto-setting STR stat.
 		/// </summary>
-		[ServerProperty("keeps", "lord_autoset_str_base", "Base Value to use when auto-setting STR stat. ", 20)]
-		public static int LORD_AUTOSET_STR_BASE;
+		[ServerProperty("keeps", "lord_autoset_str_base", "Base Value to use when auto-setting STR stat. ", (short)20)]
+		public static short LORD_AUTOSET_STR_BASE;
 
 		/// <summary>
 		/// Multiplier to use when auto-setting STR stat.
@@ -1727,8 +1739,8 @@ namespace DOL.GS.ServerProperties
 		/// <summary>
 		/// Base Value to use when auto-setting CON stat.
 		/// </summary>
-		[ServerProperty("keeps", "lord_autoset_con_base", "Base Value to use when auto-setting CON stat. ", 30)]
-		public static int LORD_AUTOSET_CON_BASE;
+		[ServerProperty("keeps", "lord_autoset_con_base", "Base Value to use when auto-setting CON stat. ", (short)30)]
+		public static short LORD_AUTOSET_CON_BASE;
 
 		/// <summary>
 		/// Multiplier to use when auto-setting CON stat.
@@ -1739,8 +1751,8 @@ namespace DOL.GS.ServerProperties
 		/// <summary>
 		/// Base Value to use when auto-setting QUI stat.
 		/// </summary>
-		[ServerProperty("keeps", "lord_autoset_qui_base", "Base Value to use when auto-setting qui stat. ", 60)]
-		public static int LORD_AUTOSET_QUI_BASE;
+		[ServerProperty("keeps", "lord_autoset_qui_base", "Base Value to use when auto-setting qui stat. ", (short)60)]
+		public static short LORD_AUTOSET_QUI_BASE;
 
 		/// <summary>
 		/// Multiplier to use when auto-setting QUI stat.
@@ -1751,8 +1763,8 @@ namespace DOL.GS.ServerProperties
 		/// <summary>
 		/// Base Value to use when auto-setting DEX stat.
 		/// </summary>
-		[ServerProperty("keeps", "lord_autoset_dex_base", "Base Value to use when auto-setting DEX stat. ", 2)]
-		public static int LORD_AUTOSET_DEX_BASE;
+		[ServerProperty("keeps", "lord_autoset_dex_base", "Base Value to use when auto-setting DEX stat. ", (short)2)]
+		public static short LORD_AUTOSET_DEX_BASE;
 
 		/// <summary>
 		/// Multiplier to use when auto-setting DEX stat.
@@ -1763,8 +1775,8 @@ namespace DOL.GS.ServerProperties
 		/// <summary>
 		/// Base Value to use when auto-setting INT stat.
 		/// </summary>
-		[ServerProperty("keeps", "lord_autoset_int_base", "Base Value to use when auto-setting INT stat. ", 30)]
-		public static int LORD_AUTOSET_INT_BASE;
+		[ServerProperty("keeps", "lord_autoset_int_base", "Base Value to use when auto-setting INT stat. ", (short)30)]
+		public static short LORD_AUTOSET_INT_BASE;
 
 		/// <summary>
 		/// Multiplier to use when auto-setting INT stat.

--- a/GameServer/spells/Animist/BomberSpellHandler.cs
+++ b/GameServer/spells/Animist/BomberSpellHandler.cs
@@ -55,6 +55,7 @@ namespace DOL.GS.Spells
         public override void ApplyEffectOnTarget(GameLiving target, double effectiveness)
         {
             base.ApplyEffectOnTarget(target, effectiveness);
+            m_pet.Level = Caster.Level; // No bomber class to override SetPetLevel() in, so set level here
             m_pet.TempProperties.setProperty(BOMBERTARGET, target);
             m_pet.Name = Spell.Name;
 			m_pet.Flags ^= GameNPC.eFlags.DONTSHOWNAME;
@@ -70,11 +71,6 @@ namespace DOL.GS.Spells
         protected override void RemoveHandlers()
         {
             GameEventMgr.RemoveHandler(m_pet, GameNPCEvent.ArriveAtTarget, BomberArriveAtTarget);
-        }
-
-        protected override byte GetPetLevel()
-        {
-            return Caster.Level;
         }
 
         protected override IControlledBrain GetPetBrain(GameLiving owner)

--- a/GameServer/spells/Animist/SummonAnimistFnF.cs
+++ b/GameServer/spells/Animist/SummonAnimistFnF.cs
@@ -117,14 +117,6 @@ namespace DOL.GS.Spells
 				effect.Cancel(false);
 		}
 
-		protected override byte GetPetLevel()
-		{
-			byte level = base.GetPetLevel();
-			if (level > 44)
-				level = 44;
-			return level;
-		}
-
 		/// <summary>
 		/// When an applied effect expires.
 		/// Duration spells only.

--- a/GameServer/spells/Bonedancer/SummonMinionHandler.cs
+++ b/GameServer/spells/Bonedancer/SummonMinionHandler.cs
@@ -208,19 +208,6 @@ namespace DOL.GS.Spells
 			Caster.ControlledBrain.Body.AddControlledNpc(brain);
 		}
 
-		protected override byte GetPetLevel()
-		{
-			byte level = base.GetPetLevel();
-
-			//edit for BD
-			//Patch 1.87: subpets have been increased by one level to make them blue
-			//to a level 50
-			if (level == 37 && (m_pet.Brain as IControlledBrain).Owner.Level >= 41)
-				level = 41;
-
-			return level;
-		}
-
 		/// <summary>
 		/// Delve Info
 		/// </summary>

--- a/GameServer/spells/Necromancer/SummonNecromancerPet.cs
+++ b/GameServer/spells/Necromancer/SummonNecromancerPet.cs
@@ -145,24 +145,5 @@ namespace DOL.GS.Spells
 		{
 			return new NecromancerPet(template, m_summonConBonus, m_summonHitsBonus);
 		}
-
-		protected override byte GetPetLevel()
-		{
-			// Pet level will be 88% of the level of the caster +1, except for
-			// the minor zombie servant, which will cap out at level 2 (patch 1.87).
-			byte level;
-
-			if (Spell.Damage < 0)
-			{
-				double petLevel = Caster.Level * Spell.Damage * -0.01 + 1;
-				level = (byte)((m_pet.Name == "minor zombie servant")	? Math.Min(2, petLevel) : petLevel);
-			}
-			else
-			{
-				level = (byte)Spell.Damage;
-			}
-
-			return Math.Max((byte)1, level);
-		}
 	}
 }

--- a/GameServer/spells/SpellHandler.cs
+++ b/GameServer/spells/SpellHandler.cs
@@ -41,7 +41,7 @@ namespace DOL.GS.Spells
 	/// </summary>
 	public class SpellHandler : ISpellHandler
 	{
-		protected static readonly ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+		private static readonly ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
 		/// <summary>
 		/// Maximum number of sub-spells to get delve info for.

--- a/GameServer/spells/SummonIllusionBlade.cs
+++ b/GameServer/spells/SummonIllusionBlade.cs
@@ -60,7 +60,7 @@ namespace DOL.GS.Spells
            // m_pet.CurrentSpeed = 0;
             m_pet.Realm = Caster.Realm;
             m_pet.Race = 0;
-            m_pet.Level = 44; // lowered in patch 1109b
+            m_pet.Level = 44; // lowered in patch 1109b, also calls AutoSetStats()
             m_pet.AddToWorld();
             //Check for buffs
             if (brain is ControlledNpcBrain)
@@ -68,7 +68,7 @@ namespace DOL.GS.Spells
 
             AddHandlers();
             SetBrainToOwner(brain);
-            m_pet.AutoSetStats();
+
             effect.Start(m_pet);
             //Set pet infos & Brain
         }

--- a/GameServer/world/ZonePointEffects.cs
+++ b/GameServer/world/ZonePointEffects.cs
@@ -27,7 +27,7 @@ namespace DOL.GS.GameEvents
 {
 	public class ZonePointEffect
 	{
-		protected static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+		private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
 		[ScriptLoadedEvent]
 		public static void OnScriptsCompiled(DOLEvent e, object sender, EventArgs args)


### PR DESCRIPTION
This is another relatively simple sounding thing that led to a lot of changes.

Pets now level up with their owners if the PET_LEVELS_WITH_OWNER server property is true, default is false.  Pet spell scaling was revisited to have spells re-scaled when the pets level changes.

BD subpet spell scaling being capped by spec is now enabled by the PET_CAP_BD_MINION_SPELL_SCALING_BY_SPEC server property, disabled by default.  BDSubPet overrides pet scaling and sorting functions to move BDSubpet specific code out of GamePet.

Code to calculate pet level was moved from SummonSpellHandler to GamePet.  GamePet now stores the damage and value from the spell that summons them to allow their level to be changed on the fly.

Fixed a bug with Necro pet spellcasting interruptions only happening when a second spell was queued.

Mob DB entries, npcTemplates, and server properties for stats are now shorts to reduce the number of casts from int required.

AutosetStats() was being called multiple times unnecessarily.  There should now be a lot fewer calls, and they should be more efficient.

ControlledNpcBrain's GetLivingOwner(), GetNPCOwner(), and GetPlayerOwner() used two different implementations which were run back to back when GetLivingOwner() was called.  I've changed it to use a single simpler implementation which only runs once.

BDSubpets and Necro pets had special code increasing their levels based on patch 1.87.  Those changes should be done in the DB rather than in code; I'll be submitting those changes to Eve shortly.  Necro pets now scale stats by npcTemplate like other pets, and log a warning if the npcTemplates have stats set to 30 as in older DBs.

I changed a bunch of log objects from protected to private, as inherited classes were creating log entries that misrepresent the class that entered them.