### PR TITLE
Added 2H bonus for guards/mobs/pets

### DIFF
--- a/GameServer/gameobjects/GameNPC.cs
+++ b/GameServer/gameobjects/GameNPC.cs
@@ -3965,6 +3965,35 @@ namespace DOL.GS
 		}
 
 		/// <summary>
+		/// Returns the Damage this NPC does on an attack, adding 2H damage bonus if appropriate
+		/// </summary>
+		/// <param name="weapon">the weapon used for attack</param>
+		/// <returns></returns>
+		public override double AttackDamage(InventoryItem weapon)
+		{
+			double damage = base.AttackDamage(weapon);
+
+			if (ActiveWeaponSlot == eActiveWeaponSlot.TwoHanded && m_blockChance > 0)
+				switch (this)
+				{
+					case Keeps.GameKeepGuard guard:
+						if (ServerProperties.Properties.GUARD_2H_BONUS_DAMAGE)
+							damage = (100 + m_blockChance) / 100.00;
+						break;
+					case GamePet pet:
+						if (ServerProperties.Properties.PET_2H_BONUS_DAMAGE)
+							damage = (100 + m_blockChance) / 100.00;
+						break;
+					default:
+						if (ServerProperties.Properties.MOB_2H_BONUS_DAMAGE)
+							damage = (100 + m_blockChance) / 100.00;
+						break;
+				}
+
+			return damage;
+		}
+
+		/// <summary>
 		/// Gets/sets the object health
 		/// </summary>
 		public override int Health

--- a/GameServer/serverproperty/ServerProperties.cs
+++ b/GameServer/serverproperty/ServerProperties.cs
@@ -1079,7 +1079,7 @@ namespace DOL.GS.ServerProperties
 		/// <summary>
 		/// Enable 2H weapon damage bonus for mobs?
 		/// </summary>
-		[ServerProperty("npc", "mob_2h_bonus_damage", "If true, mobs that use a 2H weapon and have a block chance get bonus damage equal to their block chance to compensate for not being able to block. ", true)]
+		[ServerProperty("npc", "mob_2h_bonus_damage", "If true, mobs that use a 2H weapon and have a block chance get bonus damage equal to their block chance to compensate for not being able to block. ", false)]
 		public static bool MOB_2H_BONUS_DAMAGE;
 
 		/// <summary>

--- a/GameServer/serverproperty/ServerProperties.cs
+++ b/GameServer/serverproperty/ServerProperties.cs
@@ -1077,6 +1077,12 @@ namespace DOL.GS.ServerProperties
 		public static double MOB_AUTOSET_INT_MULTIPLIER;
 
 		/// <summary>
+		/// Enable 2H weapon damage bonus for mobs?
+		/// </summary>
+		[ServerProperty("npc", "mob_2h_bonus_damage", "If true, mobs that use a 2H weapon and have a block chance get bonus damage equal to their block chance to compensate for not being able to block. ", true)]
+		public static bool MOB_2H_BONUS_DAMAGE;
+
+		/// <summary>
 		/// Do pets level up with their owner?
 		/// </summary>
 		[ServerProperty("npc", "pet_levels_with_owner", "Do pets level up with their owner? ", false)]
@@ -1090,7 +1096,7 @@ namespace DOL.GS.ServerProperties
 
 		/// <summary>
 		/// Multiplier to use when auto-setting pet STR stat.
-		/// </summary>
+		/// </summary> 
 		[ServerProperty("npc", "pet_autoset_str_multiplier", "Multiplier to use when auto-setting Pet STR stat. Multiplied by 10 when applied. ", 1.0)]
 		public static double PET_AUTOSET_STR_MULTIPLIER;
 		
@@ -1139,7 +1145,13 @@ namespace DOL.GS.ServerProperties
 		/// INT is the stat used for spell damage for mobs/pets
 		/// </summary>
 		[ServerProperty("npc", "pet_autoset_int_multiplier", "Multiplier to use when auto-setting Pet INT stat. ", 1.0)]
-		public static double PET_AUTOSET_INT_MULTIPLIER;		
+		public static double PET_AUTOSET_INT_MULTIPLIER;
+
+		/// <summary>
+		/// Enable 2H weapon damage bonus for pets?
+		/// </summary>
+		[ServerProperty("npc", "pet_2h_bonus_damage", "If true, pets that use a 2H weapon and have a block chance get bonus damage equal to their block chance to compensate for not being able to block. ", true)]
+		public static bool PET_2H_BONUS_DAMAGE;
 
 		// Necro pet stat properties
 
@@ -1795,7 +1807,13 @@ namespace DOL.GS.ServerProperties
 		/// </summary>
 		[ServerProperty("keeps", "lord_autoset_int_multiplier", "Multiplier to use when auto-setting INT stat. ", 1.0)]
 		public static double LORD_AUTOSET_INT_MULTIPLIER;
-		
+
+		/// <summary>
+		/// Enable 2H weapon damage bonus for keep guards?
+		/// </summary>
+		[ServerProperty("keeps", "guard_2h_bonus_damage", "If true, keep guards that use a 2H weapon and have a block chance get bonus damage equal to their block chance to compensate for not being able to block. ", true)]
+		public static bool GUARD_2H_BONUS_DAMAGE;
+
 		/// <summary>
 		/// Respawn time for keep guards in minutes.
 		/// </summary>


### PR DESCRIPTION
Guards/mobs/pets lose their chance to block when using a 2H weapon, but do not get any bonus damage to make up for it.  This adds the lost block chance as a percentage of damage to compensate.  Server properties allow it to be turned on or off for guards, mobs, and pets separately.

Keep lords & mission masters get a 15% block chance, fighters get 10%, and healers get 5%, so this will definitely have an impact on guards but not a game breaking one, so 2H damage is enabled by default for keep guards.

There are 12 mob npcTemplates in Eve that give a block chance and a 2H weapon, and they paradoxically only have 2H weapons so they can't ever block anyway.  Since they don't lose anything it doesn't make sense to give them bonus damage, so mob 2H damage is disabled by default.

I tested BD pets on live, and it's about a 30% difference in DPS with a 2H weapon, which matches Eve's 30% top tier BD commander block chance, so 2H bonus damage is enabled by default for pets.