### PR TITLE
Reduced roam frequency, longer roam distances

### DIFF
--- a/GameServer/ai/brain/StandardMobBrain.cs
+++ b/GameServer/ai/brain/StandardMobBrain.cs
@@ -127,7 +127,7 @@ namespace DOL.AI.Brain
 			}
 
 			//If this NPC can randomly walk around, we allow it to walk around
-			if (!Body.AttackState && CanRandomWalk && Util.Chance(DOL.GS.ServerProperties.Properties.GAMENPC_RANDOMWALK_CHANCE))
+			if (!Body.AttackState && CanRandomWalk && !Body.IsRoaming && Util.Chance(DOL.GS.ServerProperties.Properties.GAMENPC_RANDOMWALK_CHANCE))
 			{
 				IPoint3D target = CalcRandomWalkTarget();
 				if (target != null)
@@ -1555,21 +1555,12 @@ namespace DOL.AI.Brain
 		public virtual IPoint3D CalcRandomWalkTarget()
 		{
 			int maxRoamingRadius = Body.CurrentRegion.IsDungeon ? 5 : 500;
-			int minRoamingRadius = Body.CurrentRegion.IsDungeon ? 1 : 100;
 
 			if (Body.RoamingRange > 0)
-			{
 				maxRoamingRadius = Body.RoamingRange;
 
-				if (minRoamingRadius >= maxRoamingRadius)
-					minRoamingRadius = maxRoamingRadius / 3;
-			}
-
-			int roamingRadius = Util.Random(minRoamingRadius, maxRoamingRadius);
-
-			double angle = Util.Random(0, 360) / (2 * Math.PI);
-			double targetX = Body.SpawnPoint.X + Util.Random( -roamingRadius, roamingRadius );
-			double targetY = Body.SpawnPoint.Y + Util.Random( -roamingRadius, roamingRadius );
+			double targetX = Body.SpawnPoint.X + Util.Random( -maxRoamingRadius, maxRoamingRadius);
+			double targetY = Body.SpawnPoint.Y + Util.Random( -maxRoamingRadius, maxRoamingRadius);
 
 			return new Point3D( (int)targetX, (int)targetY, Body.SpawnPoint.Z );
 		}

--- a/GameServer/gameobjects/GameNPC.cs
+++ b/GameServer/gameobjects/GameNPC.cs
@@ -1016,6 +1016,18 @@ namespace DOL.GS
 		/// handler is set before calling the WalkTo function
 		/// </summary>
 		protected ArriveAtTargetAction m_arriveAtTargetAction;
+
+		/// <summary>
+		/// Is the mob roaming towards a target?
+		/// </summary>
+		public bool IsRoaming
+		{
+			get
+			{
+				return m_arriveAtTargetAction != null && m_arriveAtTargetAction.IsAlive;
+			}
+		}
+
 		/// <summary>
 		/// Timer to be set if an OnCloseToTarget
 		/// handler is set before calling the WalkTo function


### PR DESCRIPTION
Previously, each think() cycle set a new random location to roam to, leading to mobs erratically wandering short distances from their spawn regardless of their roaming range.

Mobs now walk all the way to a chosen roaming destination before picking a new one, so mobs with high roaming ranges will wander significantly further from their spawn point.

Also simplified CalcRandomWalkTarget significantly, removing an unused angle calculation and redundant radius calculation.

Fringe benefit: Overhead from roaming mobs should be a lot lower.