### PR TITLE
add 1.124+ basic support

### DIFF
--- a/DOLBase/Network/PacketIn.cs
+++ b/DOLBase/Network/PacketIn.cs
@@ -45,8 +45,6 @@ namespace DOL.Network
 		{
 		}
 
-		#region IPacket Members
-
 		/// <summary>
 		/// Generates a human-readable dump of the packet contents.
 		/// </summary>
@@ -56,13 +54,11 @@ namespace DOL.Network
 			return Marshal.ToHexDump(ToString(), ToArray());
 		}
 
-		#endregion
-
 		/// <summary>
 		/// Reads in 2 bytes and converts it from network to host byte order
 		/// </summary>
 		/// <returns>A 2 byte (short) value</returns>
-		public virtual ushort ReadShort()
+		public ushort ReadShort()
 		{
 			var v1 = (byte) ReadByte();
 			var v2 = (byte) ReadByte();
@@ -74,7 +70,7 @@ namespace DOL.Network
 		/// Reads in 2 bytes
 		/// </summary>
 		/// <returns>A 2 byte (short) value in network byte order</returns>
-		public virtual ushort ReadShortLowEndian()
+		public ushort ReadShortLowEndian()
 		{
 			var v1 = (byte) ReadByte();
 			var v2 = (byte) ReadByte();
@@ -86,7 +82,7 @@ namespace DOL.Network
 		/// Reads in 4 bytes and converts it from network to host byte order
 		/// </summary>
 		/// <returns>A 4 byte value</returns>
-		public virtual uint ReadInt()
+		public uint ReadInt()
 		{
 			var v1 = (byte) ReadByte();
 			var v2 = (byte) ReadByte();
@@ -110,7 +106,7 @@ namespace DOL.Network
 		/// </summary>
 		/// <param name="maxlen">Maximum number of bytes to read in</param>
 		/// <returns>A string of maxlen or less</returns>
-		public virtual string ReadString(int maxlen)
+		public string ReadString(int maxlen)
 		{
 			var buf = new byte[maxlen];
 			Read(buf, 0, maxlen);
@@ -122,7 +118,7 @@ namespace DOL.Network
 		/// Reads in a pascal style string
 		/// </summary>
 		/// <returns>A string from the stream</returns>
-		public virtual string ReadPascalString()
+		public string ReadPascalString()
 		{
 			return ReadString(ReadByte());
 		}
@@ -131,12 +127,17 @@ namespace DOL.Network
 		/// Reads in a pascal style string, with header count formatted as a Low Endian Short.
 		/// </summary>
 		/// <returns>A string from the stream</returns>
-		public virtual string ReadLowEndianShortPascalString()
+		public string ReadShortPascalStringLowEndian()
 		{
 			return ReadString(ReadShortLowEndian());
 		}
-		
-		public virtual uint ReadIntLowEndian()
+
+		public string ReadIntPascalStringLowEndian()
+		{
+			return ReadString((int)ReadIntLowEndian());
+		}
+
+		public uint ReadIntLowEndian()
 		{
 			var v1 = (byte) ReadByte();
 			var v2 = (byte) ReadByte();
@@ -150,7 +151,7 @@ namespace DOL.Network
 		/// Reads low endian floats used in 1.124 packets
 		/// </summary>
 		/// <returns>converts it to a usable value</returns>
-		public virtual float ReadFloatLowEndian()
+		public float ReadFloatLowEndian()
         {
             var v1 = (byte)ReadByte();
             var v2 = (byte)ReadByte();

--- a/DOLBase/Network/PacketOut.cs
+++ b/DOLBase/Network/PacketOut.cs
@@ -130,19 +130,15 @@ namespace DOL.Network
 			WriteByte((byte) ((val >> 48) & 0xff));
 			WriteByte((byte) (val >> 56));
 		}
-		
+
 		/// <summary>
-        /// writes a float value to low endian used in 1.124 packets
-        /// </summary>        
-        public virtual void WriteFloatLowEndian(float val)
-        {
-            uint l = BitConverter.ToUInt32(BitConverter.GetBytes(val), 0);
-            byte[] bytes = BitConverter.GetBytes(l);            
-            WriteByte(bytes[0]);
-            WriteByte(bytes[1]);
-            WriteByte(bytes[2]);
-            WriteByte(bytes[3]);
-        }
+		/// writes a float value to low endian used in 1.124 packets
+		/// </summary>
+		public virtual void WriteFloatLowEndian(float val)
+		{
+			var bytes = BitConverter.GetBytes(val);
+			Write(bytes, 0, bytes.Length);
+		}
 		
 		/// <summary>
 		/// Calculates the checksum for the internal buffer
@@ -204,6 +200,20 @@ namespace DOL.Network
 			byte[] bytes = Constants.DefaultEncoding.GetBytes(str);
 			WriteByte((byte) bytes.Length);
 			Write(bytes, 0, bytes.Length);
+		}
+
+		public void WritePascalStringIntLE(string str)
+		{
+			if (str == null || str.Length <= 0)
+			{
+				WriteIntLowEndian(0);
+				return;
+			}
+
+			byte[] bytes = Constants.DefaultEncoding.GetBytes(str);
+			WriteIntLowEndian((uint)bytes.Length + 1);
+			Write(bytes, 0, bytes.Length);
+			WriteByte(0);
 		}
 
 		/// <summary>

--- a/DOLBase/WeakMulticastDelegate.cs
+++ b/DOLBase/WeakMulticastDelegate.cs
@@ -302,13 +302,14 @@ namespace DOL
 
 				try
 				{
+					var target = current._weakRef?.Target;
 					if (current._weakRef == null)
 					{
 						current._method.Invoke(null, args);
 					}
-					else if (current._weakRef.IsAlive)
+					else if (target != null && current._weakRef.IsAlive)
 					{
-						current._method.Invoke(current._weakRef.Target, args);
+						current._method.Invoke(target, args);
 					}
 				}
 				catch (Exception ex)

--- a/DOLServer/ConsolePacketLib.cs
+++ b/DOLServer/ConsolePacketLib.cs
@@ -84,7 +84,7 @@ namespace DOLGameServerConsole
 		public void SendPingReply(ulong timestamp, ushort sequence) { }
 		public void SendRealm(eRealm realm) { }
 		public void SendCharacterOverview(eRealm realm) { }
-		public void SendDupNameCheckReply(string name, bool nameExists) { }
+		public void SendDupNameCheckReply(string name, byte nameExists) { }
 		public void SendBadNameCheckReply(string name, bool bad) { }
 		public void SendAttackMode(bool attackState) { }
 		public void SendCharCreateReply(string name) { }
@@ -168,6 +168,7 @@ namespace DOLGameServerConsole
 		public void SendWeather(uint x, uint width, ushort speed, ushort fogdiffusion, ushort intensity) { }
 		public void SendPlayerModelTypeChange(GamePlayer player, byte modelType) { }
 		public void SendObjectDelete(GameObject obj) { }
+		public void SendObjectDelete(ushort oid) { }
 		public void SendObjectUpdate(GameObject obj) { }
 		public void SendObjectRemove(GameObject obj) { }
 		public void SendObjectCreate(GameObject obj) { }

--- a/GameServer/GameServer.csproj
+++ b/GameServer/GameServer.csproj
@@ -1056,6 +1056,7 @@
     <Compile Include="packets\Server\PacketLib1123.cs" />
     <Compile Include="packets\Server\PacketLib1124.cs" />
     <Compile Include="packets\Server\PacketLib1125.cs" />
+    <Compile Include="packets\Server\PacketLib1126.cs" />
     <Compile Include="packets\Server\PacketLib197.cs" />
     <Compile Include="packets\Server\PacketLib196.cs" />
     <Compile Include="packets\Server\PacketLib188.cs" />

--- a/GameServer/GlobalConstants.cs
+++ b/GameServer/GlobalConstants.cs
@@ -1010,14 +1010,15 @@ namespace DOL.GS
 		Labyrinth = 6
 	}
 
-    public enum eQuestIndicator : byte
-    {
-        None = 0x00,
-        Available = 0x01,
-        Finish = 0x02,
-        Lesson = 0x04,
-        Lore = 0x08,
-    }
+	public enum eQuestIndicator : byte
+	{
+		None = 0x00,
+		Available = 0x01,
+		Finish = 0x02,
+		Lesson = 0x04,
+		Lore = 0x08,
+		Pending = 0x10, // patch 0031
+	}
 
 	/// <summary>
 	/// strong name constants of spell line used in the world (poison, proc ect ...)

--- a/GameServer/commands/gmcommands/Ban.cs
+++ b/GameServer/commands/gmcommands/Ban.cs
@@ -55,7 +55,7 @@ namespace DOL.GS.Commands
 			{
 				try
 				{
-					int sessionID = Convert.ToInt32(args[1].Substring(1));
+					var sessionID = Convert.ToUInt32(args[1].Substring(1));
 					gc = WorldMgr.GetClientFromID(sessionID);
 				}
 				catch

--- a/GameServer/commands/gmcommands/jump.cs
+++ b/GameServer/commands/gmcommands/jump.cs
@@ -104,7 +104,7 @@ namespace DOL.GS.Commands
 					{
 						try
 						{
-							int sessionID = Convert.ToInt32(args[2].Substring(1));
+							var sessionID = Convert.ToUInt32(args[2].Substring(1));
 							clientc = WorldMgr.GetClientFromID(sessionID);
 						}
 						catch

--- a/GameServer/commands/gmcommands/kick.cs
+++ b/GameServer/commands/gmcommands/kick.cs
@@ -31,7 +31,7 @@ namespace DOL.GS.Commands
 			{
 				try
 				{
-					int sessionID = Convert.ToInt32(args[1].Substring(1));
+					var sessionID = Convert.ToUInt32(args[1].Substring(1));
 					clientc = WorldMgr.GetClientFromID(sessionID);
 				}
 				catch

--- a/GameServer/commands/gmcommands/mute.cs
+++ b/GameServer/commands/gmcommands/mute.cs
@@ -46,7 +46,7 @@ namespace DOL.GS.Commands
 			{
 				try
 				{
-					int sessionID = Convert.ToInt32(args[1].Substring(1));
+					var sessionID = Convert.ToUInt32(args[1].Substring(1));
 					playerClient = WorldMgr.GetClientFromID(sessionID);
 				}
 				catch

--- a/GameServer/gameobjects/GamePlayer.cs
+++ b/GameServer/gameobjects/GamePlayer.cs
@@ -2684,57 +2684,44 @@ namespace DOL.GS
 		/// Calculates fall damage taking fall damage reduction bonuses into account
 		/// </summary>
 		/// <returns></returns>
-		public virtual void CalcFallDamage(int fallDamagePercent)
+		public virtual double CalcFallDamage(int fallDamagePercent)
 		{
-			if (fallDamagePercent > 0)
+			if (fallDamagePercent <= 0)
+				return 0;
+
+			int safeFallLevel = GetAbilityLevel(Abilities.SafeFall);
+			int mythSafeFall = GetModified(eProperty.MythicalSafeFall);
+
+			if (mythSafeFall > 0 & mythSafeFall < fallDamagePercent)
 			{
-				int safeFallLevel = GetAbilityLevel(Abilities.SafeFall);
-				int mythSafeFall = GetModified(eProperty.MythicalSafeFall);
-
-				if (mythSafeFall > 0 & mythSafeFall < fallDamagePercent)
-				{
-					Client.Out.SendMessage(LanguageMgr.GetTranslation(Client.Account.Language, "PlayerPositionUpdateHandler.MythSafeFall"),
-					                       eChatType.CT_Damaged, eChatLoc.CL_SystemWindow);
-					fallDamagePercent = mythSafeFall;
-					Out.SendMessage(LanguageMgr.GetTranslation(Client.Account.Language, "PlayerPositionUpdateHandler.FallPercent", fallDamagePercent),
-					                eChatType.CT_Damaged, eChatLoc.CL_SystemWindow);
-				}
-				if (safeFallLevel > 0 & mythSafeFall == 0)
-				{
-					Out.SendMessage(LanguageMgr.GetTranslation(Client.Account.Language, "PlayerPositionUpdateHandler.SafeFall"),
-					                eChatType.CT_Damaged, eChatLoc.CL_SystemWindow);
-				}
-				if (mythSafeFall == 0)
-				{
-					Out.SendMessage(LanguageMgr.GetTranslation(Client.Account.Language, "PlayerPositionUpdateHandler.FallPercent", fallDamagePercent),
-					                eChatType.CT_Damaged, eChatLoc.CL_SystemWindow);
-				}
-
-				Endurance -= MaxEndurance * fallDamagePercent / 100;
-				double damage = (0.01 * fallDamagePercent * (MaxHealth - 1));
-
-				// [Freya] Nidel: CloudSong falling damage reduction
-				GameSpellEffect cloudSongFall = SpellHandler.FindEffectOnTarget(this, "CloudsongFall");
-				if (cloudSongFall != null)
-				{
-					damage -= (damage * cloudSongFall.Spell.Value) * 0.01;
-				}
-
-				//Mattress: SafeFall property for Mythirians, the value of the MythicalSafeFall property represents the percent damage taken in a fall.
-				if (mythSafeFall != 0 && damage > mythSafeFall)
-				{
-					damage = ((MaxHealth - 1) * (mythSafeFall * 0.01));
-				}
-
-				TakeDamage(null, eDamageType.Falling, (int)damage, 0);
-
-				//Update the player's health to all other players around
-				foreach (GamePlayer player in GetPlayersInRadius(WorldMgr.VISIBILITY_DISTANCE))
-					Out.SendCombatAnimation(null, Client.Player, 0, 0, 0, 0, 0, HealthPercent);
-
-				return;
+				Client.Out.SendMessage(LanguageMgr.GetTranslation(Client.Account.Language, "PlayerPositionUpdateHandler.MythSafeFall"), eChatType.CT_Damaged, eChatLoc.CL_SystemWindow);
+				fallDamagePercent = mythSafeFall;
+				Out.SendMessage(LanguageMgr.GetTranslation(Client.Account.Language, "PlayerPositionUpdateHandler.FallPercent", fallDamagePercent), eChatType.CT_Damaged, eChatLoc.CL_SystemWindow);
 			}
-			return;
+			if (safeFallLevel > 0 & mythSafeFall == 0)
+				Out.SendMessage(LanguageMgr.GetTranslation(Client.Account.Language, "PlayerPositionUpdateHandler.SafeFall"), eChatType.CT_Damaged, eChatLoc.CL_SystemWindow);
+			if (mythSafeFall == 0)
+				Out.SendMessage(LanguageMgr.GetTranslation(Client.Account.Language, "PlayerPositionUpdateHandler.FallPercent", fallDamagePercent), eChatType.CT_Damaged, eChatLoc.CL_SystemWindow);
+
+			Endurance -= MaxEndurance * fallDamagePercent / 100;
+			double damage = (0.01 * fallDamagePercent * (MaxHealth - 1));
+
+			// [Freya] Nidel: CloudSong falling damage reduction
+			GameSpellEffect cloudSongFall = SpellHandler.FindEffectOnTarget(this, "CloudsongFall");
+			if (cloudSongFall != null)
+				damage -= (damage * cloudSongFall.Spell.Value) * 0.01;
+
+			//Mattress: SafeFall property for Mythirians, the value of the MythicalSafeFall property represents the percent damage taken in a fall.
+			if (mythSafeFall != 0 && damage > mythSafeFall)
+				damage = ((MaxHealth - 1) * (mythSafeFall * 0.01));
+
+			TakeDamage(null, eDamageType.Falling, (int)damage, 0);
+
+			//Update the player's health to all other players around
+			foreach (GamePlayer player in GetPlayersInRadius(WorldMgr.VISIBILITY_DISTANCE))
+				Out.SendCombatAnimation(null, Client.Player, 0, 0, 0, 0, 0, HealthPercent);
+
+			return damage;
 		}
 
 		#endregion

--- a/GameServer/gameutils/GSPacketIn.cs
+++ b/GameServer/gameutils/GSPacketIn.cs
@@ -121,7 +121,8 @@ namespace DOL.GS
 			m_sequence = (ushort)((buf[offset + 2] << 8) | buf[offset + 3]);
 			m_sessionID = (ushort)((buf[offset + 4] << 8) | buf[offset + 5]);
 			m_parameter = (ushort)((buf[offset + 6] << 8) | buf[offset + 7]);
-			m_id = (ushort)((buf[offset + 8] << 8) | buf[offset + 9]);
+			// m_id = (ushort)((buf[offset + 8] << 8) | buf[offset + 9]);
+			m_id = buf[offset + 9];
 
 			Position = 0;
 			Write(buf, offset + 10, count - HDR_SIZE);

--- a/GameServer/packets/Client/168/BadNameCheckRequestHandler.cs
+++ b/GameServer/packets/Client/168/BadNameCheckRequestHandler.cs
@@ -20,7 +20,7 @@ using System;
 
 namespace DOL.GS.PacketHandler.Client.v168
 {
-	[PacketHandler(PacketHandlerType.TCP,0x6A^168,"Checks for bad character names")]
+	[PacketHandler(PacketHandlerType.TCP, 0x6A ^ 168, "Checks for bad character names")]
 	public class BadNameCheckRequestHandler : IPacketHandler
 	{
 		private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
@@ -29,11 +29,10 @@ namespace DOL.GS.PacketHandler.Client.v168
 		{
 			string name = packet.ReadString(30);
 
-			//TODO do bad name checks here from some database with
-			//bad names, this is just a temp testthing here
+			//TODO do bad name checks here from some database with bad names, this is just a temp test thing here
 			var bad = GameServer.Instance.PlayerManager.InvalidNames[name];
 
-			client.Out.SendBadNameCheckReply(name,bad);
+			client.Out.SendBadNameCheckReply(name, bad);
 		}
 	}
 }

--- a/GameServer/packets/Client/168/BuyHookPointHandler.cs
+++ b/GameServer/packets/Client/168/BuyHookPointHandler.cs
@@ -21,7 +21,7 @@ using DOL.GS.Keeps;
 
 namespace DOL.GS.PacketHandler.Client.v168
 {
-	[PacketHandlerAttribute(PacketHandlerType.TCP,eClientPackets.BuyHookPoint, "buy hookpoint siege weapon/mob", eClientStatus.PlayerInGame)]
+	[PacketHandlerAttribute(PacketHandlerType.TCP, eClientPackets.BuyHookPoint, "buy hookpoint siege weapon/mob", eClientStatus.PlayerInGame)]
 	public class BuyHookPointHandler : IPacketHandler
 	{
 		public void HandlePacket(GameClient client, GSPacketIn packet)
@@ -29,32 +29,29 @@ namespace DOL.GS.PacketHandler.Client.v168
 			ushort keepId = packet.ReadShort();
 			ushort wallId = packet.ReadShort();
 			int hookpointID = packet.ReadShort();
-            ushort itemslot = packet.ReadShort();
+			ushort itemslot = packet.ReadShort();
 			int payType = packet.ReadByte();//gold RP BP contrat???
-			int unk2 = packet.ReadByte();
-			int unk3 = packet.ReadByte();
-			int unk4 = packet.ReadByte();
-//			client.Player.Out.SendMessage("x="+unk2+"y="+unk3+"z="+unk4,eChatType.CT_Say,eChatLoc.CL_SystemWindow);
-			AbstractGameKeep keep = GameServer.KeepManager.GetKeepByID(keepId);
-			if (keep == null) return;
-			GameKeepComponent component = keep.KeepComponents[wallId] as GameKeepComponent;
-			if (component == null) return;
-			/*GameKeepHookPoint hookpoint = component.HookPoints[hookpointID] as GameKeepHookPoint;
-			if (hookpoint == null) return 1;
-			*/
-			HookPointInventory inventory = null;
-			if(hookpointID > 0x80) inventory = HookPointInventory.YellowHPInventory; //oil
-			else if(hookpointID > 0x60) inventory = HookPointInventory.GreenHPInventory;//big siege
-			else if(hookpointID > 0x40) inventory = HookPointInventory.LightGreenHPInventory; //small siege
-			else if (hookpointID > 0x20) inventory = HookPointInventory.BlueHPInventory;//npc
-			else inventory = HookPointInventory.RedHPInventory;//guard
+			packet.ReadByte();
+			packet.ReadByte();
+			packet.ReadByte();
 
-			if (inventory != null)
-			{
-				HookPointItem item = inventory.GetItem(itemslot);
-				if (item != null)
-					item.Invoke(client.Player, payType, component.KeepHookPoints[hookpointID] as GameKeepHookPoint, component);
-			}
+
+			AbstractGameKeep keep = GameServer.KeepManager.GetKeepByID(keepId);
+			if (keep == null)
+				return;
+			GameKeepComponent component = keep.KeepComponents[wallId] as GameKeepComponent;
+			if (component == null)
+				return;
+
+			HookPointInventory inventory = null;
+			if (hookpointID > 0x80) inventory = HookPointInventory.YellowHPInventory; // oil
+			else if (hookpointID > 0x60) inventory = HookPointInventory.GreenHPInventory; // big siege
+			else if (hookpointID > 0x40) inventory = HookPointInventory.LightGreenHPInventory; // small siege
+			else if (hookpointID > 0x20) inventory = HookPointInventory.BlueHPInventory; // npc
+			else inventory = HookPointInventory.RedHPInventory; // guard
+
+			HookPointItem item = inventory?.GetItem(itemslot);
+			item?.Invoke(client.Player, payType, component.KeepHookPoints[hookpointID] as GameKeepHookPoint, component);
 		}
 	}
 }

--- a/GameServer/packets/Client/168/CharacterCreateRequestHandler.cs
+++ b/GameServer/packets/Client/168/CharacterCreateRequestHandler.cs
@@ -43,16 +43,16 @@ namespace DOL.GS.PacketHandler.Client.v168
 		/// Defines a logger for this class.
 		/// </summary>
 		private static readonly ILog log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
-		
+
 		/// <summary>
 		/// Max Points to allow on player creation
 		/// </summary>
-		public const int MAX_STARTING_BONUS_POINTS = 30;
+		public const int MaxStartingBonusPoints = 30;
 
 		/// <summary>
 		/// Client Operation Value.
 		/// </summary>
-		public enum eOperation: uint
+		public enum eOperation : uint
 		{
 			Delete = 0x12345678,
 			Create = 0x23456789,
@@ -60,38 +60,44 @@ namespace DOL.GS.PacketHandler.Client.v168
 			Unknown = 0x456789AB,
 		}
 
-		
+
 		public void HandlePacket(GameClient client, GSPacketIn packet)
 		{
-			string accountName = packet.ReadString(24);
+			if (client.Version >= GameClient.eClientVersion.Version1124) // 1124 support
+			{
+				_HandlePacket1124(client, packet);
+				return;
+			}
 
+			var accountName = packet.ReadString(24);
 			if (log.IsDebugEnabled)
 				log.DebugFormat("CharacterCreateRequestHandler for account {0} using version {1}", accountName, client.Version);
 
-			if (!accountName.StartsWith(client.Account.Name))// TODO more correctly check, client send accountName as account-S, -N, -H (if it not fit in 20, then only account)
+			// TODO more correctly check, client send accountName as account-S, -N, -H (if it not fit in 20, then only account)
+			if (!accountName.StartsWith(client.Account.Name))
 			{
-				if (ServerProperties.Properties.BAN_HACKERS)
+				if (Properties.BAN_HACKERS)
 					client.BanAccount(string.Format("Autoban wrong Account '{0}'", accountName));
 
 				client.Disconnect();
 				return;
 			}
-			
+
 			// Realm
 			eRealm currentRealm = eRealm.None;
 			if (accountName.EndsWith("-S")) currentRealm = eRealm.Albion;
 			else if (accountName.EndsWith("-N")) currentRealm = eRealm.Midgard;
 			else if (accountName.EndsWith("-H")) currentRealm = eRealm.Hibernia;
 
-			
+
 			// Client character count support
 			int charsCount = client.Version < GameClient.eClientVersion.Version173 ? 8 : 10;
 			bool needRefresh = false;
-			
+
 			for (int i = 0; i < charsCount; i++)
 			{
 				var pakdata = new CreationCharacterData(packet, client);
-				
+
 				// Graveen: changed the following to allow GMs to have special chars in their names (_,-, etc..)
 				var nameCheck = new Regex("^[A-Z][a-zA-Z]");
 				if (!string.IsNullOrEmpty(pakdata.CharName) && (pakdata.CharName.Length < 3 || !nameCheck.IsMatch(pakdata.CharName)))
@@ -105,7 +111,7 @@ namespace DOL.GS.PacketHandler.Client.v168
 						return;
 					}
 				}
-					
+
 				switch ((eOperation)pakdata.Operation)
 				{
 					case eOperation.Delete:
@@ -137,46 +143,46 @@ namespace DOL.GS.PacketHandler.Client.v168
 						break;
 				}
 			}
-			
-			if(needRefresh)
+
+			if (needRefresh)
 			{
 				client.Out.SendCharacterOverview(currentRealm);
 			}
 		}
-		
+
 		#region caracter creation data
-		class CreationCharacterData
+		struct CreationCharacterData
 		{
-			public string CharName { get; set; }
-			public int CustomMode { get; set; }
-			public int EyeSize { get; set; }
-			public int LipSize { get; set; }
-			public int EyeColor { get; set; }
-			public int HairColor { get; set; }
-			public int FaceType { get; set; }
-			public int HairStyle { get; set; }
-			public int MoodType { get; set; }
-			public uint Operation { get; set; }
-			public int Class { get; set; }
-			public int Realm { get; set; }
-			public int Race { get; set; }
-			public int Gender { get; set; }
-			public bool SIStartLocation { get; set; }
-			public ushort CreationModel { get; set; }
-			public int Region { get; set; }
-			
-			public int Strength { get; set; }
-			public int Dexterity { get; set; }
-			public int Constitution { get; set; }
-			public int Quickness { get; set; }
-			public int Intelligence { get; set; }
-			public int Piety { get; set; }
-			public int Empathy { get; set; }
-			public int Charisma { get; set; }
-			public int NewConstitution { get; set; }
-			
-			public int ConstitutionDiff { get { return NewConstitution - Constitution; }}
-			
+			public readonly string CharName;
+			public readonly int CustomMode;
+			public readonly int EyeSize;
+			public readonly int LipSize;
+			public readonly int EyeColor;
+			public readonly int HairColor;
+			public readonly int FaceType;
+			public readonly int HairStyle;
+			public readonly int MoodType;
+			public readonly uint Operation;
+			public readonly int Class;
+			public readonly int Realm;
+			public readonly int Race;
+			public readonly int Gender;
+			public readonly bool SIStartLocation;
+			public readonly ushort CreationModel;
+			public readonly int Region;
+
+			public readonly int Strength;
+			public readonly int Dexterity;
+			public readonly int Constitution;
+			public readonly int Quickness;
+			public readonly int Intelligence;
+			public readonly int Piety;
+			public readonly int Empathy;
+			public readonly int Charisma;
+			public readonly int NewConstitution;
+
+			public int ConstitutionDiff { get { return NewConstitution - Constitution; } }
+
 			/// <summary>
 			/// Reads up ONE character iteration on the packet stream
 			/// </summary>
@@ -199,18 +205,18 @@ namespace DOL.GS.PacketHandler.Client.v168
 				packet.Skip(3);
 				MoodType = packet.ReadByte();
 				packet.Skip(8);
-				
+
 				Operation = packet.ReadInt();
 				var unk = packet.ReadByte();
-				
+
 				packet.Skip(24); //Location String
 				packet.Skip(24); //Skip class name
 				packet.Skip(24); //Skip race name
-				
+
 				var level = packet.ReadByte(); //not safe!
 				Class = packet.ReadByte();
 				Realm = packet.ReadByte();
-				
+
 				//The following byte contains
 				//1bit=start location ... in ShroudedIsles you can choose ...
 				//1bit=first race bit
@@ -237,15 +243,15 @@ namespace DOL.GS.PacketHandler.Client.v168
 				Charisma = packet.ReadByte();
 
 				packet.Skip(40); //TODO equipment
-				
+
 				var activeRightSlot = packet.ReadByte(); // 0x9C
 				var activeLeftSlot = packet.ReadByte(); // 0x9D
 				var siZone = packet.ReadByte(); // 0x9E
-				
+
 				// skip 4 bytes added in 1.99
 				if (client.Version >= GameClient.eClientVersion.Version199 && client.Version < GameClient.eClientVersion.Version1104)
 					packet.Skip(4);
-				
+
 				// New constitution must be read before skipping 4 bytes
 				NewConstitution = packet.ReadByte(); // 0x9F
 
@@ -261,7 +267,7 @@ namespace DOL.GS.PacketHandler.Client.v168
 			var ch = new DOLCharacters();
 			ch.AccountName = account.Name;
 			ch.Name = pdata.CharName;
-			
+
 			if (pdata.CustomMode == 0x01)
 			{
 				ch.EyeSize = (byte)pdata.EyeSize;
@@ -272,23 +278,23 @@ namespace DOL.GS.PacketHandler.Client.v168
 				ch.HairStyle = (byte)pdata.HairStyle;
 				ch.MoodType = (byte)pdata.MoodType;
 				ch.CustomisationStep = 2; // disable config button
-				
+
 				if (log.IsDebugEnabled)
 					log.Debug("Disable Config Button");
 			}
-			
+
 			ch.Level = 1;
 			// Set Realm and Class
 			ch.Realm = pdata.Realm;
 			ch.Class = pdata.Class;
-			
+
 			// Set Account Slot, Gender
 			ch.AccountSlot = accountSlot + ch.Realm * 100;
 			ch.Gender = pdata.Gender;
 
 			// Set Race
 			ch.Race = pdata.Race;
-			
+
 			ch.CreationModel = pdata.CreationModel;
 			ch.CurrentModel = ch.CreationModel;
 			ch.Region = pdata.Region;
@@ -301,7 +307,7 @@ namespace DOL.GS.PacketHandler.Client.v168
 			ch.Piety = pdata.Piety;
 			ch.Empathy = pdata.Empathy;
 			ch.Charisma = pdata.Charisma;
-			
+
 			// defaults
 			ch.CreationDate = DateTime.Now;
 
@@ -309,31 +315,31 @@ namespace DOL.GS.PacketHandler.Client.v168
 			ch.MaxEndurance = 100;
 			ch.Concentration = 100;
 			ch.MaxSpeed = GamePlayer.PLAYER_BASE_SPEED;
-			
+
 			if (log.IsDebugEnabled)
 				log.DebugFormat("Creation {0} character, class:{1}, realm:{2}", client.Version, ch.Class, ch.Realm);
-			
+
 			// Is class disabled ?
 			int occurences = 0;
 			List<string> disabled_classes = Properties.DISABLED_CLASSES.SplitCSV(true);
 			occurences = (from j in disabled_classes
-			              where j == ch.Class.ToString()
-			              select j).Count();
+						  where j == ch.Class.ToString()
+						  select j).Count();
 
 			if (occurences > 0 && (ePrivLevel)client.Account.PrivLevel == ePrivLevel.Player)
 			{
 				if (log.IsDebugEnabled)
 					log.DebugFormat("Client {0} tried to create a disabled classe: {1}", client.Account.Name, (eCharacterClass)ch.Class);
-				
-			    return true;
+
+				return true;
 			}
-			
+
 			// check if race disabled
 			List<string> disabled_races = Properties.DISABLED_RACES.SplitCSV(true);
 			occurences = (from j in disabled_races
-			              where j == ch.Race.ToString()
-			              select j).Count();
-			
+						  where j == ch.Race.ToString()
+						  select j).Count();
+
 			if (occurences > 0 && (ePrivLevel)client.Account.PrivLevel == ePrivLevel.Player)
 			{
 				if (log.IsDebugEnabled)
@@ -342,20 +348,20 @@ namespace DOL.GS.PacketHandler.Client.v168
 				return true;
 			}
 
-			
+
 			// If sending invalid Class ID
 			if (!Enum.IsDefined(typeof(eCharacterClass), (eCharacterClass)ch.Class))
 			{
 				if (log.IsErrorEnabled)
 					log.ErrorFormat("{0} tried to create a character with wrong class ID: {1}, realm:{2}", client.Account.Name, ch.Class, ch.Realm);
-				
+
 				if (ServerProperties.Properties.BAN_HACKERS)
 				{
 					client.BanAccount(string.Format("Autoban character create class: id:{0} realm:{1} name:{2} account:{3}", ch.Class, ch.Realm, ch.Name, account.Name));
 					client.Disconnect();
 					return false;
 				}
-			    return true;
+				return true;
 			}
 
 			// check if client tried to create invalid char
@@ -364,19 +370,19 @@ namespace DOL.GS.PacketHandler.Client.v168
 				if (log.IsWarnEnabled)
 				{
 					log.WarnFormat("{0} tried to create invalid character:\nchar name={1}, gender={2}, race={3}, realm={4}, class={5}, region={6}" +
-					               "\nstr={7}, con={8}, dex={9}, qui={10}, int={11}, pie={12}, emp={13}, chr={14}", ch.AccountName, ch.Name, ch.Gender,
-					              ch.Race, ch.Realm, ch.Class, ch.Region, ch.Strength, ch.Constitution, ch.Dexterity, ch.Quickness, ch.Intelligence, ch.Piety, ch.Empathy, ch.Charisma);
+								   "\nstr={7}, con={8}, dex={9}, qui={10}, int={11}, pie={12}, emp={13}, chr={14}", ch.AccountName, ch.Name, ch.Gender,
+								  ch.Race, ch.Realm, ch.Class, ch.Region, ch.Strength, ch.Constitution, ch.Dexterity, ch.Quickness, ch.Intelligence, ch.Piety, ch.Empathy, ch.Charisma);
 				}
-			    return true;
+				return true;
 			}
 
 			//Save the character in the database
 			GameServer.Database.AddObject(ch);
-			
+
 			// Fire the character creation event
 			// This is Where Most Creation Script should take over to update any data they would like !
 			GameEventMgr.Notify(DatabaseEvent.CharacterCreated, null, new CharacterEventArgs(ch, client));
-			
+
 			//write changes
 			GameServer.Database.SaveObject(ch);
 
@@ -391,9 +397,9 @@ namespace DOL.GS.PacketHandler.Client.v168
 			// Reload Account Relations
 			GameServer.Database.FillObjectRelations(client.Account);
 
-		    return true;
+			return true;
 		}
-		
+
 		#endregion Create Character
 
 
@@ -412,7 +418,7 @@ namespace DOL.GS.PacketHandler.Client.v168
 			if (pdata.CustomMode == 1 || pdata.CustomMode == 2 || pdata.CustomMode == 3)
 			{
 				bool flagChangedStats = false;
-				
+
 				if (Properties.ALLOW_CUSTOMIZE_FACE_AFTER_CREATION)
 				{
 					character.EyeSize = (byte)pdata.EyeSize;
@@ -423,7 +429,7 @@ namespace DOL.GS.PacketHandler.Client.v168
 					character.HairStyle = (byte)pdata.HairStyle;
 					character.MoodType = (byte)pdata.MoodType;
 				}
-				
+
 				if (pdata.CustomMode != 3 && client.Version >= GameClient.eClientVersion.Version189)
 				{
 					var stats = new Dictionary<eStat, int>();
@@ -452,11 +458,11 @@ namespace DOL.GS.PacketHandler.Client.v168
 
 						if (charClass != null)
 						{
-							int points;							
+							int points;
 							bool valid = IsCustomPointsDistributionValid(character, stats, out points);
 
 							// Hacking attemp ?
-							if (points > MAX_STARTING_BONUS_POINTS)
+							if (points > MaxStartingBonusPoints)
 							{
 								if ((ePrivLevel)client.Account.PrivLevel == ePrivLevel.Player)
 								{
@@ -467,13 +473,13 @@ namespace DOL.GS.PacketHandler.Client.v168
 									return false;
 								}
 							}
-							
+
 							// Error in setting points
 							if (!valid)
 							{
-							    return true;
+								return true;
 							}
-							
+
 							if (Properties.ALLOW_CUSTOMIZE_STATS_AFTER_CREATION)
 							{
 								// Set Stats, valid is ok.
@@ -485,15 +491,15 @@ namespace DOL.GS.PacketHandler.Client.v168
 								character.Piety = stats[eStat.PIE];
 								character.Empathy = stats[eStat.EMP];
 								character.Charisma = stats[eStat.CHR];
-	
+
 								if (log.IsInfoEnabled)
 									log.InfoFormat("Character {0} Stats updated in cache!", character.Name);
-	
+
 								if (client.Player != null)
 								{
-									foreach(var stat in stats.Keys)
+									foreach (var stat in stats.Keys)
 										client.Player.ChangeBaseStat(stat, (short)(stats[stat] - client.Player.GetBaseStat(stat)));
-									
+
 									if (log.IsInfoEnabled)
 										log.InfoFormat("Character {0} Player Stats updated in cache!", character.Name);
 								}
@@ -517,14 +523,14 @@ namespace DOL.GS.PacketHandler.Client.v168
 						}
 						return true;
 					}
-					
+
 					character.CustomisationStep = 2; // disable config button
 
 					if (Properties.ALLOW_CUSTOMIZE_FACE_AFTER_CREATION)
 					{
 						if (pdata.CreationModel != character.CreationModel)
 							character.CurrentModel = newModel;
-	
+
 						if (log.IsInfoEnabled)
 							log.InfoFormat("Character {0} face properties configured by account {1}!", character.Name, client.Account.Name);
 					}
@@ -533,11 +539,11 @@ namespace DOL.GS.PacketHandler.Client.v168
 				{
 					character.CustomisationStep = 3; // enable config button to player
 				}
-				
+
 				//Save the character in the database
 				GameServer.Database.SaveObject(character);
 			}
-			
+
 			return false;
 		}
 		#endregion Character Updates
@@ -563,11 +569,11 @@ namespace DOL.GS.PacketHandler.Client.v168
 							log.WarnFormat("DB Character Delete:  Account {0}, Character: {1}, slot position: {2}, client slot {3}", accountName, character.Name, character.AccountSlot, slot);
 
 						var characterRealm = (eRealm)character.Realm;
-						
+
 						if (allChars.Length < client.ActiveCharIndex && client.ActiveCharIndex > -1 && allChars[client.ActiveCharIndex] == character)
 							client.ActiveCharIndex = -1;
 
-						
+
 						GameEventMgr.Notify(DatabaseEvent.CharacterDeleted, null, new CharacterEventArgs(character, client));
 
 						if (Properties.BACKUP_DELETED_CHARACTERS)
@@ -575,7 +581,7 @@ namespace DOL.GS.PacketHandler.Client.v168
 							var backupCharacter = new DOLCharactersBackup(character);
 							backupCharacter.CustomParams.ForEach(param => GameServer.Database.AddObject(param));
 							GameServer.Database.AddObject(backupCharacter);
-							
+
 							if (log.IsWarnEnabled)
 								log.WarnFormat("DB Character {0} backed up to DOLCharactersBackup and no associated content deleted.", character.ObjectId);
 						}
@@ -639,7 +645,7 @@ namespace DOL.GS.PacketHandler.Client.v168
 
 						// Log deletion
 						AuditMgr.AddAuditEntry(client, AuditType.Character, AuditSubtype.CharacterDelete, "", deletedChar);
-						
+
 						return true;
 					}
 				}
@@ -662,15 +668,15 @@ namespace DOL.GS.PacketHandler.Client.v168
 
 			if (charClass != null)
 			{
-				points = 0;							
-				
+				points = 0;
+
 				// check if each stat is valid.
-				foreach(var stat in stats.Keys)
+				foreach (var stat in stats.Keys)
 				{
 					int raceAmount = GlobalConstants.STARTING_STATS_DICT[(eRace)character.Race][stat];
-					
+
 					int classAmount = 0;
-					
+
 					for (int level = character.Level; level > 5; level--)
 					{
 						if (charClass.PrimaryStat != eStat.UNDEFINED && charClass.PrimaryStat == stat)
@@ -680,21 +686,21 @@ namespace DOL.GS.PacketHandler.Client.v168
 						if (charClass.TertiaryStat != eStat.UNDEFINED && charClass.TertiaryStat == stat && (level - 6) % 3 == 0)
 							classAmount++;
 					}
-					
+
 					int above = stats[stat] - raceAmount - classAmount;
-					
+
 					// Miss Some points...
 					if (above < 0)
 						return false;
-					
+
 					points += above;
 					points += Math.Max(0, above - 10); //two points used
 					points += Math.Max(0, above - 15); //three points used
 				}
-				
-				return points == MAX_STARTING_BONUS_POINTS;
+
+				return points == MaxStartingBonusPoints;
 			}
-			
+
 			points = -1;
 			return false;
 		}
@@ -736,25 +742,25 @@ namespace DOL.GS.PacketHandler.Client.v168
 				int pointsUsed;
 				var stats = new Dictionary<eStat, int>{{eStat.STR, ch.Strength},{eStat.CON, ch.Constitution},{eStat.DEX, ch.Dexterity},{eStat.QUI, ch.Quickness},
 					{eStat.INT, ch.Intelligence},{eStat.PIE, ch.Piety},{eStat.EMP, ch.Empathy},{eStat.CHR, ch.Charisma},};
-				
+
 				valid &= IsCustomPointsDistributionValid(ch, stats, out pointsUsed);
-				
-				if (pointsUsed != MAX_STARTING_BONUS_POINTS)
+
+				if (pointsUsed != MaxStartingBonusPoints)
 				{
 					if (log.IsWarnEnabled)
 						log.WarnFormat("Points used: {0} on character creation from Account: {1}", pointsUsed, ch.AccountName);
 					valid = false;
 				}
-				
+
 				eGender gender = ch.Gender == 0 ? eGender.Male : eGender.Female;
-				
+
 				if (GlobalConstants.RACE_GENDER_CONSTRAINTS_DICT.ContainsKey((eRace)ch.Race) && GlobalConstants.RACE_GENDER_CONSTRAINTS_DICT[(eRace)ch.Race] != gender)
 				{
 					if (log.IsWarnEnabled)
 						log.WarnFormat("Wrong Race gender: {0}, race: {1} on character creation from Account: {2}", ch.Gender, ch.Race, ch.AccountName);
 					valid = false;
 				}
-				
+
 				if (GlobalConstants.CLASS_GENDER_CONSTRAINTS_DICT.ContainsKey((eCharacterClass)ch.Class) && GlobalConstants.CLASS_GENDER_CONSTRAINTS_DICT[(eCharacterClass)ch.Class] != gender)
 				{
 					if (log.IsWarnEnabled)
@@ -773,5 +779,410 @@ namespace DOL.GS.PacketHandler.Client.v168
 			return valid;
 		}
 		#endregion Validate Character
+
+		public struct CreationCharacterData1124
+		{
+			public readonly string CharName;
+			public readonly int CustomMode;
+			public readonly int EyeSize;
+			public readonly int LipSize;
+			public readonly int EyeColor;
+			public readonly int HairColor;
+			public readonly int FaceType;
+			public readonly int HairStyle;
+			public readonly int MoodType;
+			public readonly uint Operation;
+			public readonly int Class;
+			public readonly int Realm;
+			public readonly int Race;
+			public readonly int Gender;
+			public readonly ushort CreationModel;
+			public readonly int Region;
+
+			public readonly int Strength;
+			public readonly int Dexterity;
+			public readonly int Constitution;
+			public readonly int Quickness;
+			public readonly int Intelligence;
+			public readonly int Piety;
+			public readonly int Empathy;
+			public readonly int Charisma;
+			public readonly int NewConstitution;
+			public int CharacterSlot; // 1125 support
+			public int CustomizeType; // 1125 support
+
+			public CreationCharacterData1124(GameClient client, GSPacketIn packet)
+			{
+				CharacterSlot = packet.ReadByte();
+				CharName = packet.ReadIntPascalStringLowEndian();
+				packet.Skip(4); // 0x18 0x00 0x00 0x00
+				CustomMode = packet.ReadByte();
+				EyeSize = packet.ReadByte();
+				LipSize = packet.ReadByte();
+				EyeColor = packet.ReadByte();
+				HairColor = packet.ReadByte();
+				FaceType = packet.ReadByte();
+				HairStyle = packet.ReadByte();
+				packet.Skip(3);
+				MoodType = packet.ReadByte();
+				packet.Skip(9); // one extra byte skipped?
+				Operation = (uint)packet.ReadByte(); // probably low end int, but im just gonna read the first byte
+				CustomizeType = packet.ReadByte(); // 1 = face 2 = attributes 3 = both
+				packet.Skip(2); // last two bytes in the supposed int
+								// the following are now low endian int pascal strings
+				packet.Skip(5); //Location string
+				packet.Skip(5); //Skip class name
+				packet.Skip(5); //Skip race name
+				packet.Skip(1); // not sure what this is? previous pak says level, but its unused anyway
+				Class = packet.ReadByte();
+				Realm = packet.ReadByte();
+				if (Realm > 0) // put inside this, as when a char is deleted, there is no realm sent TODO redo how account slot is stored in DB perhaps
+				{
+					CharacterSlot -= (Realm - 1) * 10; // calc to get character slot into same format used in database.
+				}
+				//The following byte contains
+				//1bit=start location ... in ShroudedIsles you can choose ...
+				//1bit=first race bit
+				//1bit=unknown
+				//1bit=gender (0=male, 1=female)
+				//4bit=race
+				byte startRaceGender1 = (byte)packet.ReadByte();
+				Race = startRaceGender1 & 0x1F;
+				Gender = ((startRaceGender1 >> 7) & 0x01);
+				//SIStartLocation = ((startRaceGender1 >> 7) != 0);
+				CreationModel = packet.ReadShortLowEndian();
+				Region = packet.ReadByte();
+				packet.Skip(1); //TODO second byte of region unused currently
+				packet.Skip(4); //TODO Unknown Int / last used?
+				Strength = packet.ReadByte();
+				Dexterity = packet.ReadByte();
+				Constitution = packet.ReadByte();
+				Quickness = packet.ReadByte();
+				Intelligence = packet.ReadByte();
+				Piety = packet.ReadByte();
+				Empathy = packet.ReadByte();
+				Charisma = packet.ReadByte();
+				packet.Skip(40); //TODO equipment                    
+				packet.Skip(3); // explained above
+								// New constitution must be read before skipping 4 bytes
+				NewConstitution = packet.ReadByte(); // 0x9F
+													 // trailing 0x00
+			}
+		}
+
+		private void _HandlePacket1124(GameClient client, GSPacketIn packet)
+		{
+			var pakdata = new CreationCharacterData1124(client, packet);
+
+			// Graveen: changed the following to allow GMs to have special chars in their names (_,-, etc..)
+			var nameCheck = new Regex("^[A-Z][a-zA-Z]");
+			if (!string.IsNullOrEmpty(pakdata.CharName) && (pakdata.CharName.Length < 3 || !nameCheck.IsMatch(pakdata.CharName)))
+			{
+				if ((ePrivLevel)client.Account.PrivLevel == ePrivLevel.Player)
+				{
+					if (Properties.BAN_HACKERS)
+					{
+						client.BanAccount(string.Format("Autoban bad CharName '{0}'", pakdata.CharName));
+					}
+
+					client.Disconnect();
+					return;
+				}
+			}
+
+			var needRefresh = false;
+			switch (pakdata.Operation)
+			{
+				case 3: // delete request
+					if (string.IsNullOrEmpty(pakdata.CharName))
+					{
+						// Deletion in 1.104+ check for removed character.
+						needRefresh |= CheckForDeletedCharacter(client.Account.Name, client, pakdata.CharacterSlot);
+					}
+					break;
+				case 2: // Customize face or stats
+					if (!string.IsNullOrEmpty(pakdata.CharName))
+					{
+						// Candidate for Customizing ?
+						var character = client.Account.Characters?.FirstOrDefault(ch => ch.Name.Equals(pakdata.CharName, StringComparison.OrdinalIgnoreCase));
+						if (character != null)
+							needRefresh |= CheckCharacterForUpdates1124(pakdata, client, character, pakdata.CustomizeType);
+					}
+					break;
+				case 1: // create request
+					if (!string.IsNullOrEmpty(pakdata.CharName))
+					{
+						// Candidate for Creation ?
+						var character = client.Account.Characters?.FirstOrDefault(ch => ch.Name.Equals(pakdata.CharName, StringComparison.OrdinalIgnoreCase));
+						if (character == null)
+							needRefresh |= _CreateCharacter1124(pakdata, client, pakdata.CharacterSlot);
+					}
+					break;
+				default:
+					break;
+			}
+
+			// live actually just sends server login request response... i think this sets the realm select button again too
+			if (needRefresh)
+				client.Out.SendLoginGranted();
+		}
+
+		private bool _CreateCharacter1124(CreationCharacterData1124 pdata, GameClient client, int accountSlot)
+		{
+			Account account = client.Account;
+			var ch = new DOLCharacters
+			{
+				AccountName = account.Name,
+				Name = pdata.CharName
+			};
+
+			if (pdata.CustomMode == 0x01)
+			{
+				ch.EyeSize = (byte)pdata.EyeSize;
+				ch.LipSize = (byte)pdata.LipSize;
+				ch.EyeColor = (byte)pdata.EyeColor;
+				ch.HairColor = (byte)pdata.HairColor;
+				ch.FaceType = (byte)pdata.FaceType;
+				ch.HairStyle = (byte)pdata.HairStyle;
+				ch.MoodType = (byte)pdata.MoodType;
+				ch.CustomisationStep = 2; // disable config button
+				log.Debug("Disable Config Button");
+			}
+
+			ch.Level = 1;
+
+			// Set Realm and Class
+			ch.Realm = pdata.Realm;
+			ch.Class = pdata.Class;
+
+			// Set Account Slot, Gender
+			ch.AccountSlot = accountSlot + ch.Realm * 100;
+			ch.Gender = pdata.Gender;
+
+			// Set Race
+			ch.Race = pdata.Race;
+
+			ch.CreationModel = pdata.CreationModel;
+			ch.CurrentModel = ch.CreationModel;
+			ch.Region = pdata.Region;
+
+			ch.Strength = pdata.Strength;
+			ch.Dexterity = pdata.Dexterity;
+			ch.Constitution = pdata.Constitution;
+			ch.Quickness = pdata.Quickness;
+			ch.Intelligence = pdata.Intelligence;
+			ch.Piety = pdata.Piety;
+			ch.Empathy = pdata.Empathy;
+			ch.Charisma = pdata.Charisma;
+
+			// defaults
+			ch.CreationDate = DateTime.Now;
+
+			ch.Endurance = 100;
+			ch.MaxEndurance = 100;
+			ch.Concentration = 100;
+			ch.MaxSpeed = GamePlayer.PLAYER_BASE_SPEED;
+
+			log.Debug($"Creation {client.Version} character, class:{ch.Class}, realm:{ch.Realm}");
+
+			// Is class disabled ?
+			List<string> disabledClasses = Properties.DISABLED_CLASSES.SplitCSV(true);
+			var occurences = disabledClasses.Count(j => j == ch.Class.ToString());
+			if (occurences > 0 && (ePrivLevel)client.Account.PrivLevel == ePrivLevel.Player)
+			{
+				log.Debug($"Client {client.Account.Name} tried to create a disabled classe: {(eCharacterClass)ch.Class}");
+				return true;
+			}
+
+			// check if race disabled
+			List<string> disabledRaces = Properties.DISABLED_RACES.SplitCSV(true);
+			occurences = disabledRaces.Count(j => j == ch.Race.ToString());
+			if (occurences > 0 && (ePrivLevel)client.Account.PrivLevel == ePrivLevel.Player)
+			{
+				log.Debug($"Client {client.Account.Name} tried to create a disabled race: {(eRace)ch.Race}");
+				return true;
+			}
+
+			// If sending invalid Class ID
+			if (!Enum.IsDefined(typeof(eCharacterClass), (eCharacterClass)ch.Class))
+			{
+				log.Error($"{client.Account.Name} tried to create a character with wrong class ID: {ch.Class}, realm:{ch.Realm}");
+
+				if (Properties.BAN_HACKERS)
+				{
+					client.BanAccount($"Autoban character create class: id:{ch.Class} realm:{ch.Realm} name:{ch.Name} account:{account.Name}");
+					client.Disconnect();
+					return false;
+				}
+
+				return true;
+			}
+
+			// check if client tried to create invalid char
+			if (!IsCharacterValid(ch))
+			{
+				log.Warn($"{ch.AccountName} tried to create invalid character:\nchar name={ch.Name}, gender={ch.Gender}, race={ch.Race}, realm={ch.Realm}, class={ch.Class}, region={ch.Region}\nstr={ch.Strength}, con={ch.Constitution}, dex={ch.Dexterity}, qui={ch.Quickness}, int={ch.Intelligence}, pie={ch.Piety}, emp={ch.Empathy}, chr={ch.Charisma}");
+				return true;
+			}
+
+			// Save the character in the database
+			GameServer.Database.AddObject(ch);
+
+			// Fire the character creation event
+			// This is Where Most Creation Script should take over to update any data they would like !
+			GameEventMgr.Notify(DatabaseEvent.CharacterCreated, null, new CharacterEventArgs(ch, client));
+
+			// write changes
+			GameServer.Database.SaveObject(ch);
+
+			// Log creation
+			AuditMgr.AddAuditEntry(client, AuditType.Account, AuditSubtype.CharacterCreate, string.Empty, pdata.CharName);
+
+			client.Account.Characters = null;
+
+			log.Info($"Character {pdata.CharName} created on Account {account}!");
+
+			// Reload Account Relations
+			GameServer.Database.FillObjectRelations(client.Account);
+			return true;
+		}
+
+		// 1125 support
+		private bool CheckCharacterForUpdates1124(CreationCharacterData1124 pdata, GameClient client, DOLCharacters character, int type)
+		{
+			int newModel = character.CurrentModel;
+
+			if (pdata.CustomMode == 1 || pdata.CustomMode == 2 || pdata.CustomMode == 3)
+			{
+				bool flagChangedStats = false;
+
+				if (type == 1 || type == 3) // face changes
+				{
+					if (Properties.ALLOW_CUSTOMIZE_FACE_AFTER_CREATION)
+					{
+						character.EyeSize = (byte)pdata.EyeSize;
+						character.LipSize = (byte)pdata.LipSize;
+						character.EyeColor = (byte)pdata.EyeColor;
+						character.HairColor = (byte)pdata.HairColor;
+						character.FaceType = (byte)pdata.FaceType;
+						character.HairStyle = (byte)pdata.HairStyle;
+						character.MoodType = (byte)pdata.MoodType;
+					}
+				}
+				if (type == 2 || type == 3) // attributes changes
+				{
+					if (pdata.CustomMode != 3)//patch 0042 // TODO check out these different custommodes
+					{
+						var stats = new Dictionary<eStat, int>
+						{
+							[eStat.STR] = pdata.Strength, // Strength
+							[eStat.DEX] = pdata.Dexterity, // Dexterity
+							[eStat.CON] = pdata.NewConstitution, // New Constitution
+							[eStat.QUI] = pdata.Quickness, // Quickness
+							[eStat.INT] = pdata.Intelligence, // Intelligence
+							[eStat.PIE] = pdata.Piety, // Piety
+							[eStat.EMP] = pdata.Empathy, // Empathy
+							[eStat.CHR] = pdata.Charisma // Charisma
+						};
+
+						// check for changed stats.
+						flagChangedStats |= stats[eStat.STR] != character.Strength;
+						flagChangedStats |= stats[eStat.CON] != character.Constitution;
+						flagChangedStats |= stats[eStat.DEX] != character.Dexterity;
+						flagChangedStats |= stats[eStat.QUI] != character.Quickness;
+						flagChangedStats |= stats[eStat.INT] != character.Intelligence;
+						flagChangedStats |= stats[eStat.PIE] != character.Piety;
+						flagChangedStats |= stats[eStat.EMP] != character.Empathy;
+						flagChangedStats |= stats[eStat.CHR] != character.Charisma;
+
+						if (flagChangedStats)
+						{
+							ICharacterClass charClass = ScriptMgr.FindCharacterClass(character.Class);
+
+							if (charClass != null)
+							{
+								bool valid = IsCustomPointsDistributionValid(character, stats, out int points);
+
+								// Hacking attemp ?
+								if (points > MaxStartingBonusPoints)
+								{
+									if ((ePrivLevel)client.Account.PrivLevel == ePrivLevel.Player)
+									{
+										if (Properties.BAN_HACKERS)
+											client.BanAccount(string.Format("Autoban Hack char update : Wrong allowed points:{0}", points));
+
+										client.Disconnect();
+										return false;
+									}
+								}
+
+								// Error in setting points
+								if (!valid)
+									return true;
+
+								if (Properties.ALLOW_CUSTOMIZE_STATS_AFTER_CREATION)
+								{
+									// Set Stats, valid is ok.
+									character.Strength = stats[eStat.STR];
+									character.Constitution = stats[eStat.CON];
+									character.Dexterity = stats[eStat.DEX];
+									character.Quickness = stats[eStat.QUI];
+									character.Intelligence = stats[eStat.INT];
+									character.Piety = stats[eStat.PIE];
+									character.Empathy = stats[eStat.EMP];
+									character.Charisma = stats[eStat.CHR];
+
+									log.InfoFormat("Character {0} Stats updated in cache!", character.Name);
+									if (client.Player != null)
+									{
+										foreach (var stat in stats.Keys)
+											client.Player.ChangeBaseStat(stat, (short)(stats[stat] - client.Player.GetBaseStat(stat)));
+
+										log.InfoFormat("Character {0} Player Stats updated in cache!", character.Name);
+									}
+								}
+							}
+							else if (log.IsErrorEnabled)
+							{
+								log.ErrorFormat("No CharacterClass with ID {0} found", character.Class);
+							}
+						}
+					}
+				}
+
+				if (pdata.CustomMode == 2) // change player customization // is this changing starting race? im not sure TODO check
+				{
+					if (client.Account.PrivLevel == 1 && ((pdata.CreationModel >> 11) & 3) == 0)
+					{
+						if (Properties.BAN_HACKERS) // Player size must be > 0 (from 1 to 3)
+						{
+							client.BanAccount(string.Format("Autoban Hack char update : zero character size in model:{0}", newModel));
+							client.Disconnect();
+							return false;
+						}
+						return true;
+					}
+
+					character.CustomisationStep = 2; // disable config button
+
+					if (Properties.ALLOW_CUSTOMIZE_FACE_AFTER_CREATION)
+					{
+						if (pdata.CreationModel != character.CreationModel)
+							character.CurrentModel = newModel;
+
+						log.InfoFormat("Character {0} face properties configured by account {1}!", character.Name, client.Account.Name);
+					}
+				}
+				else if (pdata.CustomMode == 3) //auto config -- seems someone thinks this is not possible?
+				{
+					character.CustomisationStep = 3; // enable config button to player
+				}
+
+				//Save the character in the database
+				GameServer.Database.SaveObject(character);
+			}
+
+			return false;
+		}
 	}
 }

--- a/GameServer/packets/Client/168/CharacterDeleteRequestHandler.cs
+++ b/GameServer/packets/Client/168/CharacterDeleteRequestHandler.cs
@@ -40,15 +40,10 @@ namespace DOL.GS.PacketHandler.Client.v168
 			string charName = packet.ReadString(30);
 			DOLCharacters[] chars = client.Account.Characters;
 
-			if (chars == null)
-				return;
-			
-			var foundChar = chars.FirstOrDefault(ch => ch.Name.Equals(charName, StringComparison.OrdinalIgnoreCase));
-			
+			var foundChar = chars?.FirstOrDefault(ch => ch.Name.Equals(charName, StringComparison.OrdinalIgnoreCase));
 			if (foundChar != null)
 			{
 				var slot = foundChar.AccountSlot;
-				
 				CharacterCreateRequestHandler.CheckForDeletedCharacter(foundChar.AccountName, client, slot);
 			}
 		}

--- a/GameServer/packets/Client/168/CharacterOverviewRequestHandler.cs
+++ b/GameServer/packets/Client/168/CharacterOverviewRequestHandler.cs
@@ -31,6 +31,12 @@ namespace DOL.GS.PacketHandler.Client.v168
 
 		public void HandlePacket(GameClient client, GSPacketIn packet)
 		{
+			if (client.Version >= GameClient.eClientVersion.Version1124) // 1124 support
+			{
+				_HandlePacket1124(client, packet);
+				return;
+			}
+
 			client.ClientState = GameClient.eClientState.CharScreen;
 			if (client.Player != null)
 			{
@@ -120,6 +126,90 @@ namespace DOL.GS.PacketHandler.Client.v168
 					// use saved realm ignoring what user has chosen if server rules do not allow to choose the realm
 					chosenRealm = (eRealm)client.Account.Realm;
 				}
+
+				client.Out.SendCharacterOverview(chosenRealm);
+			}
+		}
+
+		private void _HandlePacket1124(GameClient client, GSPacketIn packet)
+		{
+			client.ClientState = GameClient.eClientState.CharScreen;
+
+			if (client.Player != null)
+			{
+				try
+				{
+					// find the cached character and force it to update with the latest saved character
+					DOLCharacters cachedCharacter = null;
+					foreach (DOLCharacters accountChar in client.Account.Characters)
+					{
+						if (accountChar.ObjectId == client.Player.InternalID)
+						{
+							cachedCharacter = accountChar;
+							break;
+						}
+					}
+
+					if (cachedCharacter != null)
+						cachedCharacter = client.Player.DBCharacter;
+				}
+				catch (System.Exception ex)
+				{
+					log.ErrorFormat("Error attempting to update cached player. {0}", ex.Message);
+				}
+			}
+
+			client.Player = null;
+
+			//reset realm if no characters
+			if ((client.Account.Characters == null || client.Account.Characters.Length <= 0) && client.Account.Realm != (int)eRealm.None)
+				client.Account.Realm = (int)eRealm.None;
+
+			//string accountName = packet.Readstring(24);
+			byte realm = (byte)packet.ReadByte();
+			if (realm == 0)
+			{
+				if (GameServer.ServerRules.IsAllowedCharsInAllRealms(client))
+					client.Out.SendRealm(eRealm.None);
+				else
+				{
+					//Requests to know what realm an account is
+					//assigned to... if Realm::NONE is sent, the
+					//Realm selection screen is shown
+					switch (client.Account.Realm)
+					{
+						case 1: client.Out.SendRealm(eRealm.Albion); break;
+						case 2: client.Out.SendRealm(eRealm.Midgard); break;
+						case 3: client.Out.SendRealm(eRealm.Hibernia); break;
+						default: client.Out.SendRealm(eRealm.None); break;
+					}
+				}
+			}
+			else
+			{
+				eRealm chosenRealm;
+
+				if (client.Account.Realm == (int)eRealm.None || GameServer.ServerRules.IsAllowedCharsInAllRealms(client))
+				{
+					// allow player to choose the realm if not set already or if allowed by server rules
+					if (realm == 1)
+						chosenRealm = eRealm.Albion;
+					else if (realm == 2)
+						chosenRealm = eRealm.Midgard;
+					else if (realm == 3)
+						chosenRealm = eRealm.Hibernia;
+					else
+					{
+						log.Error($"User has chosen unknown realm: {realm}; account={client.Account.Name}");
+						client.Out.SendRealm(eRealm.None);
+						return;
+					}
+
+					client.Account.Realm = (int)chosenRealm;
+				}
+				else
+					// use saved realm ignoring what user has chosen if server rules do not allow to choose the realm
+					chosenRealm = (eRealm)client.Account.Realm;
 
 				client.Out.SendCharacterOverview(chosenRealm);
 			}

--- a/GameServer/packets/Client/168/CharacterSelectRequestHandler.cs
+++ b/GameServer/packets/Client/168/CharacterSelectRequestHandler.cs
@@ -25,10 +25,20 @@ namespace DOL.GS.PacketHandler.Client.v168
 	[PacketHandlerAttribute(PacketHandlerType.TCP, eClientPackets.CharacterSelectRequest, "Handles setting SessionID and the active character", eClientStatus.LoggedIn)]
 	public class CharacterSelectRequestHandler : IPacketHandler
 	{
-		#region IPacketHandler Members
-
 		public void HandlePacket(GameClient client, GSPacketIn packet)
 		{
+			if (client.Version >= GameClient.eClientVersion.Version1126)
+			{
+				client.Out.SendSessionID();
+				return;
+			}
+			// 1125d support TODO this needs to be changed when a version greater than 1125d comes out
+			if (client.Version >= GameClient.eClientVersion.Version1125)
+			{
+				_HandlePacket1125d(client, packet);
+				return;
+			}
+
 			int packetVersion;
 			switch (client.Version)
 			{
@@ -98,6 +108,55 @@ namespace DOL.GS.PacketHandler.Client.v168
 			}
 		}
 
-		#endregion
+		private void _HandlePacket1125d(GameClient client, GSPacketIn packet)
+		{
+
+			byte type = (byte)packet.ReadByte(); // changed from ushort low end
+
+			packet.Skip(1); // unknown
+
+			string charName = packet.ReadString(24); // down from 28, both need checking
+
+			//TODO Character handling 
+			if (charName.Equals("noname"))
+			{
+				client.Out.SendLoginGranted();
+				client.Out.SendSessionID();
+			}
+			else
+			{
+				// SH: Also load the player if client player is NOT null but their charnames differ!!!
+				// only load player when on charscreen and player is not loaded yet
+				// packet is sent on every region change (and twice after "play" was pressed)
+				if (((client.Player == null && client.Account.Characters != null) || (client.Player != null && client.Player.Name.ToLower() != charName.ToLower()))
+					&& client.ClientState == GameClient.eClientState.CharScreen)
+				{
+					bool charFound = false;
+					for (int i = 0; i < client.Account.Characters.Length; i++)
+					{
+						if (client.Account.Characters[i] != null && client.Account.Characters[i].Name == charName)
+						{
+							charFound = true;
+							client.LoadPlayer(i);
+							break;
+						}
+					}
+					if (!charFound)
+					{
+						client.Player = null;
+						client.ActiveCharIndex = -1;
+					}
+					else
+					{
+						// Log character play
+						AuditMgr.AddAuditEntry(client, AuditType.Character, AuditSubtype.CharacterLogin, "", charName);
+					}
+				}
+
+				// live actually sends the login granted packet, which sets the button activity states
+				client.Out.SendLoginGranted();
+				client.Out.SendSessionID();
+			}
+		}
 	}
 }

--- a/GameServer/packets/Client/168/ClientCrashPacketHandler.cs
+++ b/GameServer/packets/Client/168/ClientCrashPacketHandler.cs
@@ -33,35 +33,27 @@ namespace DOL.GS.PacketHandler.Client.v168
 
 		public void HandlePacket(GameClient client, GSPacketIn packet)
 		{
-			lock (this)
-			{
-				string dllName = packet.ReadString(16);
-				packet.Position = 0x50;
-				uint upTime = packet.ReadInt();
-				string text = string.Format("Client crash ({0}) dll:{1} clientUptime:{2}sec", client.ToString(), dllName, upTime);
-				if (log.IsInfoEnabled)
-					log.Info(text);
+			string dllName = packet.ReadString(16);
+			packet.Position = 0x50;
+			uint upTime = packet.ReadInt();
+			string text = $"Client crash ({client.ToString()}) dll:{dllName} clientUptime:{upTime}sec";
+			log.Info(text);
 
-				if (log.IsDebugEnabled)
-				{
-					log.Debug("Last client sent/received packets (from older to newer):");
-					
-					foreach (IPacket prevPak in client.PacketProcessor.GetLastPackets())
-					{
-						log.Info(prevPak.ToHumanReadable());
-					}
-				}
-					
-				//Eden
-				if(client.Player!=null)
-				{
-					GamePlayer player = client.Player;
-					client.Out.SendPlayerQuit(true);
-					client.Player.SaveIntoDatabase();
-					client.Player.Quit(true);
-					client.Disconnect();
-				}
+			if (log.IsDebugEnabled)
+			{
+				log.Debug("Last client sent/received packets (from older to newer):");
+				foreach (IPacket prevPak in client.PacketProcessor.GetLastPackets())
+					log.Info(prevPak.ToHumanReadable());
 			}
+
+			//Eden
+			client.Out.SendPlayerQuit(true);
+			if (client.Player != null)
+			{
+				client.Player.SaveIntoDatabase();
+				client.Player.Quit(true);
+			}
+			client.Disconnect();
 		}
 	}
 }

--- a/GameServer/packets/Client/168/CryptKeyRequestHandler.cs
+++ b/GameServer/packets/Client/168/CryptKeyRequestHandler.cs
@@ -32,15 +32,15 @@ namespace DOL.GS.PacketHandler.Client.v168
 				byte clientType = (byte)packet.ReadByte();
 				client.ClientType = (GameClient.eClientType)(clientType & 0x0F);
 				client.ClientAddons = (GameClient.eClientAddons)(clientType & 0xF0);
-				byte major = (byte)packet.ReadByte();
-				byte minor = (byte)packet.ReadByte();
-				byte build = (byte)packet.ReadByte();
-				if(rc4==1)
+				client.MajorBuild = (byte)packet.ReadByte();
+				client.MinorBuild = (byte)packet.ReadByte();
+				client.MinorRev = packet.ReadString(1);
+				if (rc4 == 1)
 				{
 					//DOLConsole.Log("SBox=\n");
 					//DOLConsole.LogDump(client.PacketProcessor.Encoding.SBox);
 					packet.Read(((PacketEncoding168)client.PacketProcessor.Encoding).SBox,0,256);
-					((PacketEncoding168)client.PacketProcessor.Encoding).EncryptionState=PacketEncoding168.eEncryptionState.PseudoRC4Encrypted;
+					((PacketEncoding168)client.PacketProcessor.Encoding).EncryptionState = eEncryptionState.PseudoRC4Encrypted;
 					//DOLConsole.WriteLine(client.Socket.RemoteEndPoint.ToString()+": SBox set!");
 					//DOLConsole.Log("SBox=\n");
 					//DOLConsole.LogDump(((PacketEncoding168)client.PacketProcessor.Encoding).SBox);
@@ -51,26 +51,50 @@ namespace DOL.GS.PacketHandler.Client.v168
 					client.Out.SendVersionAndCryptKey();
 				}
 			}
-			else
+			else if (client.Version < GameClient.eClientVersion.Version1124) // Dre: don't know if this part works, I tested only with 1.109 & 1.125c
 			{
 				// we don't handle Encryption for 1.115c
 				// the rc4 secret can't be unencrypted from RSA.
-				
+
+				// if the DataSize is above 7 then the RC4 key is bundled
+				if (packet.DataSize > 7)
+				{
+					var length = packet.ReadIntLowEndian();
+					packet.Read(client.PacketProcessor.Encoding.SBox, 0, (int)length);
+					return;
+				}
 				// register client type
 				byte clientType = (byte)packet.ReadByte();
 				client.ClientType = (GameClient.eClientType)(clientType & 0x0F);
 				client.ClientAddons = (GameClient.eClientAddons)(clientType & 0xF0);
-				
+				// the next 4 bytes are the game.dll version but not in string form
+				// ie: 01 01 19 61 = 1.125a
+				// this version is handled elsewhere before being sent here.
+				packet.Skip(3); // skip the numbers in the version
+				client.MinorRev = packet.ReadString(1); // get the minor revision letter // 1125d support
+				packet.Skip(2); // build
+				//Send the crypt key to the client
+				client.Out.SendVersionAndCryptKey();
+			}
+			else // 1.124+ (maybe 1.125+)
+			{
+				// register client type
+				byte clientType = (byte)packet.ReadByte();
+				client.ClientType = (GameClient.eClientType)(clientType & 0x0F);
+				client.ClientAddons = (GameClient.eClientAddons)(clientType & 0xF0);
+				packet.Skip(3); // skip the numbers in the version
+				client.MinorRev = packet.ReadString(1); // get the minor revision letter // 1125d support
+				client.MajorBuild = (byte)packet.ReadByte();
+				client.MinorBuild = (byte)packet.ReadByte();
+
 				// if the DataSize is above 7 then the RC4 key is bundled
-				// this is stored in case we find a way to handle encryption someday !
 				if (packet.DataSize > 7)
 				{
-					packet.Skip(6);
 					ushort length = packet.ReadShortLowEndian();
 					packet.Read(client.PacketProcessor.Encoding.SBox, 0, length);
-					// ((PacketEncoding168)client.PacketProcessor.Encoding).EncryptionState=PacketEncoding168.eEncryptionState.PseudoRC4Encrypted;
+					return;
 				}
-				
+
 				//Send the crypt key to the client
 				client.Out.SendVersionAndCryptKey();
 			}

--- a/GameServer/packets/Client/168/DestroyItemRequestHandler.cs
+++ b/GameServer/packets/Client/168/DestroyItemRequestHandler.cs
@@ -34,8 +34,7 @@ namespace DOL.GS.PacketHandler.Client.v168
 			{
 				if (item.IsIndestructible)
 				{
-					client.Out.SendMessage(String.Format("You can't destroy {0}!",
-						item.GetName(0, false)), eChatType.CT_System, eChatLoc.CL_SystemWindow);
+					client.Out.SendMessage($"You can't destroy {item.GetName(0, false)}!", eChatType.CT_System, eChatLoc.CL_SystemWindow);
 					return;
 				}
 
@@ -53,7 +52,7 @@ namespace DOL.GS.PacketHandler.Client.v168
 
 				if (client.Player.Inventory.RemoveItem(item))
 				{
-					client.Out.SendMessage("You destroy the " + item.Name + ".", eChatType.CT_System, eChatLoc.CL_SystemWindow);
+					client.Out.SendMessage($"You destroy the {item.Name}.", eChatType.CT_System, eChatLoc.CL_SystemWindow);
 					InventoryLogging.LogInventoryAction(client.Player, "(destroy)", eInventoryActionType.Other, item.Template, item.Count);
 				}
 			}

--- a/GameServer/packets/Client/168/DialogResponseHandler.cs
+++ b/GameServer/packets/Client/168/DialogResponseHandler.cs
@@ -47,7 +47,7 @@ namespace DOL.GS.PacketHandler.Client.v168
 			/// <summary>
 			/// The general data field
 			/// </summary>
-			protected readonly int m_data1;
+			protected readonly uint m_data1;
 
 			/// <summary>
 			/// The general data field
@@ -78,7 +78,7 @@ namespace DOL.GS.PacketHandler.Client.v168
 			/// <param name="data3">The general data field</param>
 			/// <param name="messageType">The dialog type</param>
 			/// <param name="response">The players response</param>
-			public DialogBoxResponseAction(GamePlayer actionSource, int data1, int data2, int data3, int messageType, byte response)
+			public DialogBoxResponseAction(GamePlayer actionSource, uint data1, int data2, int data3, int messageType, byte response)
 				: base(actionSource)
 			{
 				m_data1 = data1;
@@ -176,30 +176,20 @@ namespace DOL.GS.PacketHandler.Client.v168
 						}
 					case eDialogCode.QuestSubscribe:
 						{
-							var questNPC = (GameLiving) WorldMgr.GetObjectByIDFromRegion(player.CurrentRegionID, (ushort) m_data2);
+							var questNPC = (GameLiving)WorldMgr.GetObjectByIDFromRegion(player.CurrentRegionID, (ushort) m_data2);
 							if (questNPC == null)
 								return;
 
 							var args = new QuestEventArgs(questNPC, player, (ushort) m_data1);
-							if (m_response == 0x01) //accept
+							if (m_response == 0x01) // accept
 							{
-								//TODO add quest to player
-								//Note: This is done withing quest code since we have to check requirements, etc for each quest individually
+								// TODO add quest to player
+								// Note: This is done withing quest code since we have to check requirements, etc for each quest individually
 								// i'm reusing the questsubscribe command for quest abort since its 99% the same, only different event dets fired
-								if (m_data3 == 0x01)
-									player.Notify(GamePlayerEvent.AbortQuest, player, args);
-								else
-									player.Notify(GamePlayerEvent.AcceptQuest, player, args);
+								player.Notify(m_data3 == 0x01 ? GamePlayerEvent.AbortQuest : GamePlayerEvent.AcceptQuest, player, args);
 								return;
 							}
-							if (m_data3 == 0x01)
-							{
-								player.Notify(GamePlayerEvent.ContinueQuest, player, args);
-							}
-							else
-							{
-								player.Notify(GamePlayerEvent.DeclineQuest, player, args);
-							}
+							player.Notify(m_data3 == 0x01 ? GamePlayerEvent.ContinueQuest : GamePlayerEvent.DeclineQuest, player, args);
 							return;
 						}
 					case eDialogCode.GroupInvite:

--- a/GameServer/packets/Client/168/DisbandFromGroupHandler.cs
+++ b/GameServer/packets/Client/168/DisbandFromGroupHandler.cs
@@ -24,16 +24,10 @@ namespace DOL.GS.PacketHandler.Client.v168
 	[PacketHandlerAttribute(PacketHandlerType.TCP, eClientPackets.DisbandFromGroup, "Disband From Group Request Handler", eClientStatus.PlayerInGame)]
 	public class DisbandFromGroupHandler : IPacketHandler
 	{
-		#region IPacketHandler Members
-
 		public void HandlePacket(GameClient client, GSPacketIn packet)
 		{
 			new PlayerDisbandAction(client.Player).Start(1);
 		}
-
-		#endregion
-
-		#region Nested type: PlayerDisbandAction
 
 		/// <summary>
 		/// Handles players disband actions
@@ -72,7 +66,5 @@ namespace DOL.GS.PacketHandler.Client.v168
 				player.Group.RemoveMember(disbandMember);
 			}
 		}
-
-		#endregion
 	}
 }

--- a/GameServer/packets/Client/168/DoorRequestHandler.cs
+++ b/GameServer/packets/Client/168/DoorRequestHandler.cs
@@ -31,8 +31,6 @@ namespace DOL.GS.PacketHandler.Client.v168
 	{
 		public static int m_handlerDoorID;
 
-		#region IPacketHandler Members
-
 		/// <summary>
 		/// door index which is unique
 		/// </summary>
@@ -41,17 +39,17 @@ namespace DOL.GS.PacketHandler.Client.v168
 			var doorID = (int) packet.ReadInt();
 			m_handlerDoorID = doorID;
 			var doorState = (byte) packet.ReadByte();
-			int doorType = doorID/100000000;
+			int doorType = doorID / 100000000;
 
-			int radius = ServerProperties.Properties.WORLD_PICKUP_DISTANCE * 2;
-			int zoneDoor = (int)(doorID / 1000000);
+			int radius = Properties.WORLD_PICKUP_DISTANCE * 2;
+			int zoneDoor = doorID / 1000000;
 
 			string debugText = "";
 
 			// For ToA the client always sends the same ID so we need to construct an id using the current zone
 			if (client.Player.CurrentRegion.Expansion == (int)eClientExpansion.TrialsOfAtlantis)
 			{
-				debugText = "ToA DoorID: " + doorID + " ";
+				debugText = $"ToA DoorID:{doorID} ";
 
 				doorID -= zoneDoor * 1000000;
 				zoneDoor = client.Player.CurrentZone.ID;
@@ -68,14 +66,12 @@ namespace DOL.GS.PacketHandler.Client.v168
 			{
 				if (doorType == 7)
 				{
-					int ownerKeepId = (doorID/100000)%1000;
-					int towerNum = (doorID/10000)%10;
-					int keepID = ownerKeepId + towerNum*256;
-					int componentID = (doorID/100)%100;
-					int doorIndex = doorID%10;
-					client.Out.SendDebugMessage(
-						"Keep Door ID: {0} state:{1} (Owner Keep: {6} KeepID:{2} ComponentID:{3} DoorIndex:{4} TowerNumber:{5})", doorID,
-						doorState, keepID, componentID, doorIndex, towerNum, ownerKeepId);
+					int ownerKeepId = (doorID / 100000) % 1000;
+					int towerNum = (doorID / 10000) % 10;
+					int keepID = ownerKeepId + towerNum * 256;
+					int componentID = (doorID / 100) % 100;
+					int doorIndex = doorID % 10;
+					client.Out.SendDebugMessage($"Keep Door ID:{doorID} state:{doorState} (Owner Keep:{ownerKeepId} KeepID:{keepID} ComponentID:{componentID} DoorIndex:{doorIndex} TowerNumber:{towerNum})");
 
 					if (keepID > 255 && ownerKeepId < 10)
 					{
@@ -84,32 +80,27 @@ namespace DOL.GS.PacketHandler.Client.v168
 				}
 				else if (doorType == 9)
 				{
-					int doorIndex = doorID - doorType*10000000;
-					client.Out.SendDebugMessage("House DoorID:{0} state:{1} (doorType:{2} doorIndex:{3})", doorID, doorState, doorType,
-					                            doorIndex);
+					int doorIndex = doorID - doorType * 10000000;
+					client.Out.SendDebugMessage($"House DoorID:{doorID} state:{doorState} (doorType:{doorType} doorIndex:{doorIndex})");
 				}
 				else
 				{
-					int fixture = (doorID - zoneDoor*1000000);
+					int fixture = (doorID - zoneDoor * 1000000);
 					int fixturePiece = fixture;
 					fixture /= 100;
-					fixturePiece = fixturePiece - fixture*100;
+					fixturePiece = fixturePiece - fixture * 100;
 
-					client.Out.SendDebugMessage("{6}DoorID:{0} state:{1} zone:{2} fixture:{3} fixturePiece:{4} Type:{5}",
-												doorID, doorState, zoneDoor, fixture, fixturePiece, doorType, debugText);
+					client.Out.SendDebugMessage($"{debugText}DoorID:{doorID} state:{doorState} zone:{zoneDoor} fixture:{fixture} fixturePiece:{fixturePiece} Type:{doorType}");
 				}
 			}
 
-			var target = client.Player.TargetObject as GameDoor;
-
-			if (target != null && !client.Player.IsWithinRadius(target, radius))
+			if (client.Player.TargetObject is GameDoor target && !client.Player.IsWithinRadius(target, radius))
 			{
 				client.Player.Out.SendMessage("You are too far to open this door", eChatType.CT_Important, eChatLoc.CL_SystemWindow);
 				return;
 			}
 
 			var door = GameServer.Database.SelectObjects<DBDoor>("`InternalID` = @InternalID", new QueryParameter("@InternalID", doorID)).FirstOrDefault();
-
 			if (door != null)
 			{
 				if (doorType == 7 || doorType == 9)
@@ -176,7 +167,6 @@ namespace DOL.GS.PacketHandler.Client.v168
 			}
 		}
 
-		#endregion
 
 		public void AddingDoor(GamePlayer player, byte response)
 		{
@@ -211,8 +201,6 @@ namespace DOL.GS.PacketHandler.Client.v168
 				DoorMgr.Init();
 			}
 		}
-
-		#region Nested type: ChangeDoorAction
 
 		/// <summary>
 		/// Handles the door state change actions
@@ -318,7 +306,5 @@ namespace DOL.GS.PacketHandler.Client.v168
 				}
 			}
 		}
-
-		#endregion
 	}
 }

--- a/GameServer/packets/Client/168/DuplicateNameCheckRequestHandler.cs
+++ b/GameServer/packets/Client/168/DuplicateNameCheckRequestHandler.cs
@@ -33,14 +33,14 @@ namespace DOL.GS.PacketHandler.Client.v168
 			string name = packet.ReadString(30);
 
 			var character = GameServer.Database.SelectObjects<DOLCharacters>("`Name` = @Name", new QueryParameter("@Name", name)).FirstOrDefault();
-			
-			var nameExists = (character != null);
-			
+			byte result = 0;
 			// Bad Name check.
-			if (!nameExists)
-				nameExists = GameServer.Instance.PlayerManager.InvalidNames[name];
-			
-			client.Out.SendDupNameCheckReply(name, nameExists);
+			if (character != null)
+				result = 0x02;
+			else if (GameServer.Instance.PlayerManager.InvalidNames[name])
+				result = 0x01;
+
+			client.Out.SendDupNameCheckReply(name, result);
 		}
 	}
 }

--- a/GameServer/packets/Client/168/GameOpenRequestHandler.cs
+++ b/GameServer/packets/Client/168/GameOpenRequestHandler.cs
@@ -31,8 +31,7 @@ namespace DOL.GS.PacketHandler.Client.v168
 			client.Out.SendGameOpenReply();
 			client.Out.SendStatusUpdate(); // based on 1.74 logs
 			client.Out.SendUpdatePoints(); // based on 1.74 logs
-			if (client.Player != null)
-				client.Player.UpdateDisabledSkills(); // based on 1.74 logs
+			client.Player?.UpdateDisabledSkills(); // based on 1.74 logs
 		}
 	}
 }

--- a/GameServer/packets/Client/168/HouseEditHandler.cs
+++ b/GameServer/packets/Client/168/HouseEditHandler.cs
@@ -25,11 +25,9 @@ namespace DOL.GS.PacketHandler.Client.v168
 	{
 		private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
-		#region IPacketHandler Members
-
 		public void HandlePacket(GameClient client, GSPacketIn packet)
 		{
-			ushort playerID = packet.ReadShort(); // no use for that.
+			packet.ReadShort(); // playerId no use for that.
 
 			// house is null, return
 			var house = client.Player.CurrentHouse;
@@ -44,18 +42,12 @@ namespace DOL.GS.PacketHandler.Client.v168
 				int change = packet.ReadByte();
 
 				if (swtch != 255)
-				{
 					changes.Add(change);
-				}
 			}
 
 			// apply changes
 			if (changes.Count > 0)
-			{
 				house.Edit(client.Player, changes);
-			}
 		}
-
-		#endregion
 	}
 }

--- a/GameServer/packets/Client/168/HouseEnterLeaveRequestHandler.cs
+++ b/GameServer/packets/Client/168/HouseEnterLeaveRequestHandler.cs
@@ -23,8 +23,6 @@ namespace DOL.GS.PacketHandler.Client.v168
 	[PacketHandlerAttribute(PacketHandlerType.TCP, eClientPackets.HouseEnterLeave, "Housing Enter Leave Request.", eClientStatus.PlayerInGame)]
 	public class HouseEnterLeaveHandler : IPacketHandler
 	{
-		#region IPacketHandler Members
-
 		public void HandlePacket(GameClient client, GSPacketIn packet)
 		{
 			int pid = packet.ReadShort();
@@ -38,10 +36,6 @@ namespace DOL.GS.PacketHandler.Client.v168
 
 			new EnterLeaveHouseAction(client.Player, house, enter).Start(1);
 		}
-
-		#endregion
-
-		#region Nested type: EnterLeaveHouseAction
 
 		/// <summary>
 		/// Handles house enter/leave events
@@ -107,7 +101,5 @@ namespace DOL.GS.PacketHandler.Client.v168
 				}
 			}
 		}
-
-		#endregion
 	}
 }

--- a/GameServer/packets/Client/168/HousePermissionsRequestHandler.cs
+++ b/GameServer/packets/Client/168/HousePermissionsRequestHandler.cs
@@ -23,8 +23,6 @@ namespace DOL.GS.PacketHandler.Client.v168
 	[PacketHandlerAttribute(PacketHandlerType.TCP, eClientPackets.HousePermissionRequest, "Handles housing permissions requests from menu", eClientStatus.PlayerInGame)]
 	public class HousePermissionsRequestHandler : IPacketHandler
 	{
-		#region IPacketHandler Members
-
 		public void HandlePacket(GameClient client, GSPacketIn packet)
 		{
 			int pid = packet.ReadShort();
@@ -76,7 +74,5 @@ namespace DOL.GS.PacketHandler.Client.v168
 				client.Out.SendTCP(pak);
 			}
 		}
-
-		#endregion
 	}
 }

--- a/GameServer/packets/Client/168/HousePermissionsSetHandler.cs
+++ b/GameServer/packets/Client/168/HousePermissionsSetHandler.cs
@@ -24,8 +24,6 @@ namespace DOL.GS.PacketHandler.Client.v168
 	[PacketHandlerAttribute(PacketHandlerType.TCP, eClientPackets.HousePermissionSet, "Handles housing permissions changes", eClientStatus.PlayerInGame)]
 	public class HousePermissionsSetHandler : IPacketHandler
 	{
-		#region IPacketHandler Members
-
 		public void HandlePacket(GameClient client, GSPacketIn packet)
 		{
 			int level = packet.ReadByte();
@@ -71,7 +69,5 @@ namespace DOL.GS.PacketHandler.Client.v168
 			// save the updated permission
 			GameServer.Database.SaveObject(permission);
 		}
-
-		#endregion
 	}
 }

--- a/GameServer/packets/Client/168/HouseUsersPermissionsRequestHandler.cs
+++ b/GameServer/packets/Client/168/HouseUsersPermissionsRequestHandler.cs
@@ -24,8 +24,6 @@ namespace DOL.GS.PacketHandler.Client.v168
 	[PacketHandlerAttribute(PacketHandlerType.TCP, eClientPackets.HouseUserPermissionRequest, "Handles housing Users permissions requests from menu", eClientStatus.PlayerInGame)]
 	public class HouseUsersPermissionsRequestHandler : IPacketHandler
 	{
-		#region IPacketHandler Members
-
 		public void HandlePacket(GameClient client, GSPacketIn packet)
 		{
 			int unk1 = packet.ReadByte();
@@ -48,7 +46,5 @@ namespace DOL.GS.PacketHandler.Client.v168
 			// build the packet
 			client.Out.SendHouseUsersPermissions(house);
 		}
-
-		#endregion
 	}
 }

--- a/GameServer/packets/Client/168/HouseUsersPermissionsSetHandler.cs
+++ b/GameServer/packets/Client/168/HouseUsersPermissionsSetHandler.cs
@@ -25,8 +25,6 @@ namespace DOL.GS.PacketHandler.Client.v168
 	[PacketHandlerAttribute(PacketHandlerType.TCP, eClientPackets.HouseUserPermissionSet, "Handles housing Users permissions requests", eClientStatus.PlayerInGame)]
 	public class HouseUsersPermissionsSetHandler : IPacketHandler
 	{
-		#region IPacketHandler Members
-
 		public void HandlePacket(GameClient client, GSPacketIn packet)
 		{
 			int permissionSlot = packet.ReadByte();
@@ -56,7 +54,5 @@ namespace DOL.GS.PacketHandler.Client.v168
 				house.AdjustPermissionSlot(permissionSlot, newPermissionLevel);
 			}
 		}
-
-		#endregion
 	}
 }

--- a/GameServer/packets/Client/168/HousingDecorationRotate.cs
+++ b/GameServer/packets/Client/168/HousingDecorationRotate.cs
@@ -23,8 +23,6 @@ namespace DOL.GS.PacketHandler.Client.v168
 	[PacketHandlerAttribute(PacketHandlerType.TCP, eClientPackets.HouseDecorationRotate, "Handles housing decoration rotation", eClientStatus.PlayerInGame)]
 	public class HousingDecorationRotateHandler : IPacketHandler
 	{
-		#region IPacketHandler Members
-
 		public void HandlePacket(GameClient client, GSPacketIn packet)
 		{
 			int unk1 = packet.ReadByte();
@@ -84,7 +82,5 @@ namespace DOL.GS.PacketHandler.Client.v168
 				plr.Client.Out.SendFurniture(house, position);
 			}
 		}
-
-		#endregion
 	}
 }

--- a/GameServer/packets/Client/168/HousingDecorationRotateRequestHandler.cs
+++ b/GameServer/packets/Client/168/HousingDecorationRotateRequestHandler.cs
@@ -23,8 +23,6 @@ namespace DOL.GS.PacketHandler.Client.v168
 	[PacketHandlerAttribute(PacketHandlerType.TCP, eClientPackets.HouseDecorationRequest, "Handles housing decoration request", eClientStatus.PlayerInGame)]
 	public class HousingDecorationRotateRequestHandler : IPacketHandler
 	{
-		#region IPacketHandler Members
-
 		public void HandlePacket(GameClient client, GSPacketIn packet)
 		{
 			ushort housenumber = packet.ReadShort();
@@ -54,7 +52,5 @@ namespace DOL.GS.PacketHandler.Client.v168
 			pak.WriteByte(0x01);
 			client.Out.SendTCP(pak);
 		}
-
-		#endregion
 	}
 }

--- a/GameServer/packets/Client/168/HousingMenuRequestHandler.cs
+++ b/GameServer/packets/Client/168/HousingMenuRequestHandler.cs
@@ -25,8 +25,6 @@ namespace DOL.GS.PacketHandler.Client.v168
 	{
 		private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
-		#region IPacketHandler Members
-
 		public void HandlePacket(GameClient client, GSPacketIn packet)
 		{
 			int housenumber = packet.ReadShort();
@@ -117,7 +115,5 @@ namespace DOL.GS.PacketHandler.Client.v168
 			}
 
 		}
-
-		#endregion
 	}
 }

--- a/GameServer/packets/Client/168/HousingPickupItemHandler.cs
+++ b/GameServer/packets/Client/168/HousingPickupItemHandler.cs
@@ -29,8 +29,6 @@ namespace DOL.GS.PacketHandler.Client.v168
 	{
 		private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
-		#region IPacketHandler Members
-
 		/// <summary>
 		/// Handle the packet
 		/// </summary>
@@ -193,12 +191,8 @@ namespace DOL.GS.PacketHandler.Client.v168
 			}
 		}
 
-		#endregion
-
 		private static bool GetItemBack(InventoryItem item)
 		{
-			#region item types
-
 			switch (item.Object_Type)
 			{
 				case (int) eObjectType.Axe:
@@ -230,8 +224,6 @@ namespace DOL.GS.PacketHandler.Client.v168
 				default:
 					return true;
 			}
-
-			#endregion
 		}
 	}
 }

--- a/GameServer/packets/Client/168/HousingPlaceItemHandler.cs
+++ b/GameServer/packets/Client/168/HousingPlaceItemHandler.cs
@@ -36,8 +36,6 @@ namespace DOL.GS.PacketHandler.Client.v168
 		private static readonly ILog log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
 		private int _position;
 
-		#region IPacketHandler Members
-
 		public void HandlePacket(GameClient client, GSPacketIn packet)
 		{
 			try
@@ -771,8 +769,6 @@ namespace DOL.GS.PacketHandler.Client.v168
 				client.Out.SendInventorySlotsUpdate(null);
 			}
 		}
-
-		#endregion
 
 		private static bool IsSuitableForWall(InventoryItem item)
 		{

--- a/GameServer/packets/Client/168/InviteToGroupHandler.cs
+++ b/GameServer/packets/Client/168/InviteToGroupHandler.cs
@@ -21,16 +21,10 @@ namespace DOL.GS.PacketHandler.Client.v168
 	[PacketHandlerAttribute(PacketHandlerType.TCP, eClientPackets.InviteToGroup, "Handle Invite to Group Request.", eClientStatus.PlayerInGame)]
 	public class InviteToGroupHandler : IPacketHandler
 	{
-		#region IPacketHandler Members
-
 		public void HandlePacket(GameClient client, GSPacketIn packet)
 		{
 			new HandleGroupInviteAction(client.Player).Start(1);
 		}
-
-		#endregion
-
-		#region Nested type: HandleGroupInviteAction
 
 		/// <summary>
 		/// Handles group invlite actions
@@ -95,7 +89,5 @@ namespace DOL.GS.PacketHandler.Client.v168
 				                           player.Name + " has invited you to join " + player.GetPronoun(1, false) + " group.");
 			}
 		}
-
-		#endregion
 	}
 }

--- a/GameServer/packets/Client/168/NPCCreationRequestHandler.cs
+++ b/GameServer/packets/Client/168/NPCCreationRequestHandler.cs
@@ -25,12 +25,19 @@ namespace DOL.GS.PacketHandler.Client.v168
 	{
 		public void HandlePacket(GameClient client, GSPacketIn packet)
 		{
-			ushort id = packet.ReadShort();
-//			GameNPC npc = (GameNPC)WorldMgr.GetObjectTypeByIDFromRegion(client.Player.CurrentRegionID, id, typeof(GameNPC));
-			if(client.Player==null) return;
+			if (client.Player == null)
+				return;
 			Region region = client.Player.CurrentRegion;
-			if (region == null) return;
+			if (region == null)
+				return;
+
+			ushort id = packet.ReadShort();
 			GameNPC npc = region.GetObject(id) as GameNPC;
+			if (npc == null)
+			{
+				client.Out.SendObjectDelete(id);
+				return;
+			}
 
 			if(npc != null)
 			{

--- a/GameServer/packets/Client/168/ObjectInteractRequestHandler.cs
+++ b/GameServer/packets/Client/168/ObjectInteractRequestHandler.cs
@@ -21,8 +21,6 @@ namespace DOL.GS.PacketHandler.Client.v168
 	[PacketHandlerAttribute(PacketHandlerType.TCP, eClientPackets.ObjectInteractRequest, "Handles Client Interact Request", eClientStatus.PlayerInGame)]
 	public class ObjectInteractRequestHandler : IPacketHandler
 	{
-		#region IPacketHandler Members
-
 		public void HandlePacket(GameClient client, GSPacketIn packet)
 		{
 			// packet.Skip(10);
@@ -35,10 +33,6 @@ namespace DOL.GS.PacketHandler.Client.v168
 			new InteractActionHandler(client.Player, targetOid).Start(1);
 		}
 
-		#endregion
-
-		#region Nested type: InteractActionHandler
-
 		/// <summary>
 		/// Handles player interact actions
 		/// </summary>
@@ -47,14 +41,14 @@ namespace DOL.GS.PacketHandler.Client.v168
 			/// <summary>
 			/// The interact target OID
 			/// </summary>
-			protected readonly int m_targetOid;
+			protected readonly ushort m_targetOid;
 
 			/// <summary>
 			/// Constructs a new InterractActionHandler
 			/// </summary>
 			/// <param name="actionSource">The action source</param>
 			/// <param name="targetOid">The interact target OID</param>
-			public InteractActionHandler(GamePlayer actionSource, int targetOid) : base(actionSource)
+			public InteractActionHandler(GamePlayer actionSource, ushort targetOid) : base(actionSource)
 			{
 				m_targetOid = targetOid;
 			}
@@ -69,14 +63,12 @@ namespace DOL.GS.PacketHandler.Client.v168
 				if (region == null)
 					return;
 
-				GameObject obj = region.GetObject((ushort) m_targetOid);
+				GameObject obj = region.GetObject(m_targetOid);
 				if (obj == null)
-					return;
-
-				obj.Interact(player);
+					player.Out.SendObjectDelete(m_targetOid);
+				else
+					obj.Interact(player);
 			}
 		}
-
-		#endregion
 	}
 }

--- a/GameServer/packets/Client/168/ObjectUpdateRequestHandler.cs
+++ b/GameServer/packets/Client/168/ObjectUpdateRequestHandler.cs
@@ -34,21 +34,14 @@ namespace DOL.GS.PacketHandler.Client.v168
 		public void HandlePacket(GameClient client, GSPacketIn packet)
 		{
 			foreach (GameStaticItem item in client.Player.GetItemsInRadius(WorldMgr.OBJ_UPDATE_DISTANCE))
-			{
 				client.Out.SendObjectCreate(item);
-			}
 
 			foreach (IDoor door in client.Player.GetDoorsInRadius(WorldMgr.OBJ_UPDATE_DISTANCE))
-			{
 				client.Player.SendDoorUpdate(door);
-			}
-			
 
 			//housing
 			if (client.Player.CurrentRegion.HousingEnabled)
-			{
 				WorldUpdateThread.UpdatePlayerHousing(client.Player, GameTimer.GetTickCount()+60000);
-			}
 		}
 	}
 }

--- a/GameServer/packets/Client/168/PetWindowHandler.cs
+++ b/GameServer/packets/Client/168/PetWindowHandler.cs
@@ -30,8 +30,6 @@ namespace DOL.GS.PacketHandler.Client.v168
 		/// </summary>
 		private static readonly ILog Log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
 
-		#region IPacketHandler Members
-
 		public void HandlePacket(GameClient client, GSPacketIn packet)
 		{
 			var aggroState = (byte) packet.ReadByte(); // 1-Aggressive, 2-Deffensive, 3-Passive
@@ -59,10 +57,6 @@ namespace DOL.GS.PacketHandler.Client.v168
 			}
 		}
 
-		#endregion
-
-		#region Nested type: HandlePetCommandAction
-
 		/// <summary>
 		/// Handles pet command actions
 		/// </summary>
@@ -71,17 +65,17 @@ namespace DOL.GS.PacketHandler.Client.v168
 			/// <summary>
 			/// The pet aggro state
 			/// </summary>
-			protected readonly int m_aggroState;
+			protected readonly int _aggroState;
 
 			/// <summary>
 			/// The pet command
 			/// </summary>
-			protected readonly int m_command;
+			protected readonly int _command;
 
 			/// <summary>
 			/// The pet walk state
 			/// </summary>
-			protected readonly int m_walkState;
+			protected readonly int _walkState;
 
 			/// <summary>
 			/// Constructs a new HandlePetCommandAction
@@ -93,9 +87,9 @@ namespace DOL.GS.PacketHandler.Client.v168
 			public HandlePetCommandAction(GamePlayer actionSource, int aggroState, int walkState, int command)
 				: base(actionSource)
 			{
-				m_aggroState = aggroState;
-				m_walkState = walkState;
-				m_command = command;
+				_aggroState = aggroState;
+				_walkState = walkState;
+				_command = command;
 			}
 
 			/// <summary>
@@ -103,9 +97,9 @@ namespace DOL.GS.PacketHandler.Client.v168
 			/// </summary>
 			protected override void OnTick()
 			{
-				var player = (GamePlayer) m_actionSource;
+				var player = (GamePlayer)m_actionSource;
 
-				switch (m_aggroState)
+				switch (_aggroState)
 				{
 					case 0:
 						break; // ignore
@@ -119,12 +113,10 @@ namespace DOL.GS.PacketHandler.Client.v168
 						player.CommandNpcPassive();
 						break;
 					default:
-						if (Log.IsWarnEnabled)
-							Log.Warn("unknown aggro state " + m_aggroState + ", player=" + player.Name + "  version=" + player.Client.Version +
-							         "  client type=" + player.Client.ClientType);
+						Log.Warn($"unknown aggro state {_aggroState}, player={player.Name}  version={player.Client.Version}  client type={player.Client.ClientType}");
 						break;
 				}
-				switch (m_walkState)
+				switch (_walkState)
 				{
 					case 0:
 						break; // ignore
@@ -141,12 +133,10 @@ namespace DOL.GS.PacketHandler.Client.v168
 						player.CommandNpcComeHere();
 						break;
 					default:
-						if (Log.IsWarnEnabled)
-							Log.Warn("unknown walk state " + m_walkState + ", player=" + player.Name + "  version=" + player.Client.Version +
-							         "  client type=" + player.Client.ClientType);
+						Log.Warn($"unknown walk state {_walkState}, player={player.Name}  version={player.Client.Version}  client type={player.Client.ClientType}");
 						break;
 				}
-				switch (m_command)
+				switch (_command)
 				{
 					case 0:
 						break; // ignore
@@ -157,14 +147,10 @@ namespace DOL.GS.PacketHandler.Client.v168
 						player.CommandNpcRelease();
 						break;
 					default:
-						if (Log.IsWarnEnabled)
-							Log.Warn("unknown command state " + m_command + ", player=" + player.Name + "  version=" + player.Client.Version +
-							         "  client type=" + player.Client.ClientType);
+						Log.Warn($"unknown command state {_command}, player={player.Name}  version={player.Client.Version}  client type={player.Client.ClientType}");
 						break;
 				}
 			}
 		}
-
-		#endregion
 	}
 }

--- a/GameServer/packets/Client/168/PingRequestHandler.cs
+++ b/GameServer/packets/Client/168/PingRequestHandler.cs
@@ -36,11 +36,9 @@ namespace DOL.GS.PacketHandler.Client.v168
 		public void HandlePacket(GameClient client, GSPacketIn packet)
 		{
 			packet.Skip(4); //Skip the first 4 bytes
-			long pingDiff = (DateTime.Now.Ticks - client.PingTime)/1000;
 			client.PingTime = DateTime.Now.Ticks;
 			ulong timestamp = packet.ReadInt();
-
-			client.Out.SendPingReply(timestamp,packet.Sequence);
+			client.Out.SendPingReply(timestamp, packet.Sequence);
 		}
 	}
 }

--- a/GameServer/packets/Client/168/PlayerAppraiseItemRequestHandler.cs
+++ b/GameServer/packets/Client/168/PlayerAppraiseItemRequestHandler.cs
@@ -24,8 +24,6 @@ namespace DOL.GS.PacketHandler.Client.v168
 	[PacketHandlerAttribute(PacketHandlerType.TCP, eClientPackets.PlayerAppraiseItemRequest, "Player Appraise Item Request handler.", eClientStatus.PlayerInGame)]
 	public class PlayerAppraiseItemRequestHandler : IPacketHandler
 	{
-		#region IPacketHandler Members
-
 		public void HandlePacket(GameClient client, GSPacketIn packet)
 		{
 			uint X = packet.ReadInt();
@@ -35,10 +33,6 @@ namespace DOL.GS.PacketHandler.Client.v168
 
 			new AppraiseActionHandler(client.Player, item_slot).Start(1);
 		}
-
-		#endregion
-
-		#region Nested type: AppraiseActionHandler
 
 		/// <summary>
 		/// Handles item apprise actions
@@ -72,17 +66,11 @@ namespace DOL.GS.PacketHandler.Client.v168
 
 				InventoryItem item = player.Inventory.GetItem((eInventorySlot) m_slot);
 
-				if (player.TargetObject is GameMerchant)
-				{
-					((GameMerchant) player.TargetObject).OnPlayerAppraise(player, item, false);
-				}
-				else if (player.TargetObject is GameLotMarker)
-				{
-					((GameLotMarker) player.TargetObject).OnPlayerAppraise(player, item, false);
-				}
+				if (player.TargetObject is GameMerchant merchant)
+					merchant.OnPlayerAppraise(player, item, false);
+				else if (player.TargetObject is GameLotMarker lot)
+					lot.OnPlayerAppraise(player, item, false);
 			}
 		}
-
-		#endregion
 	}
 }

--- a/GameServer/packets/Client/168/PlayerAttackRequestHandler.cs
+++ b/GameServer/packets/Client/168/PlayerAttackRequestHandler.cs
@@ -22,8 +22,6 @@ namespace DOL.GS.PacketHandler.Client.v168
 	[PacketHandlerAttribute(PacketHandlerType.TCP, eClientPackets.PlayerAttackRequest, "Handles Player Attack Request", eClientStatus.PlayerInGame)]
 	public class PlayerAttackRequestHandler : IPacketHandler
 	{
-		#region IPacketHandler Members
-
 		public void HandlePacket(GameClient client, GSPacketIn packet)
 		{
 			var mode = (byte) packet.ReadByte();
@@ -32,10 +30,6 @@ namespace DOL.GS.PacketHandler.Client.v168
 
 			new AttackRequestHandler(client.Player, mode != 0, userAction).Start(1);
 		}
-
-		#endregion
-
-		#region Nested type: AttackRequestHandler
 
 		/// <summary>
 		/// Handles change attack mode requests
@@ -92,7 +86,5 @@ namespace DOL.GS.PacketHandler.Client.v168
 				}
 			}
 		}
-
-		#endregion
 	}
 }

--- a/GameServer/packets/Client/168/PlayerBonusesListRequestHandler.cs
+++ b/GameServer/packets/Client/168/PlayerBonusesListRequestHandler.cs
@@ -18,6 +18,7 @@
  */
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using DOL.GS;
 using DOL.Language;
@@ -40,14 +41,15 @@ namespace DOL.GS.PacketHandler.Client.v168
 
 			int code = packet.ReadByte();
 			if (code != 0)
-			{
-				if (log.IsWarnEnabled)
-					log.WarnFormat("bonuses button: code is other than zero ({0})", code);
-			}
+				log.Warn($"bonuses button: code is other than zero ({code})");
 
-			new RegionTimerAction<GamePlayer>(client.Player,
-			                                  p => p.Out.SendCustomTextWindow(LanguageMgr.GetTranslation(client.Account.Language, "PlayerBonusesListRequestHandler.HandlePacket.Bonuses")
-			                                                                  , new List<string>(client.Player.GetBonuses()))).Start(1);
+			new RegionTimerAction<GamePlayer>(
+				client.Player,
+				p => p.Out.SendCustomTextWindow(
+						LanguageMgr.GetTranslation(client.Account.Language, "PlayerBonusesListRequestHandler.HandlePacket.Bonuses"),
+						client.Player.GetBonuses().ToList()
+					)
+				).Start(1);
 		}
 	}
 }

--- a/GameServer/packets/Client/168/PlayerBuyRequestHandler.cs
+++ b/GameServer/packets/Client/168/PlayerBuyRequestHandler.cs
@@ -62,14 +62,14 @@ namespace DOL.GS.PacketHandler.Client.v168
 							return;
 
 						//Forward the buy process to the merchant
-						if (client.Player.TargetObject is GameMerchant)
+						if (client.Player.TargetObject is GameMerchant merchant)
 						{
 							//Let merchant choose what happens
-							((GameMerchant)client.Player.TargetObject).OnPlayerBuy(client.Player, item_slot, item_count);
+							merchant.OnPlayerBuy(client.Player, item_slot, item_count);
 						}
-						else if (client.Player.TargetObject is GameLotMarker)
+						else if (client.Player.TargetObject is GameLotMarker lot)
 						{
-							((GameLotMarker)client.Player.TargetObject).OnPlayerBuy(client.Player, item_slot, item_count);
+							lot.OnPlayerBuy(client.Player, item_slot, item_count);
 						}
 						break;
 					}

--- a/GameServer/packets/Client/168/PlayerCancelsEffectHandler.cs
+++ b/GameServer/packets/Client/168/PlayerCancelsEffectHandler.cs
@@ -26,24 +26,14 @@ namespace DOL.GS.PacketHandler.Client.v168
 	[PacketHandlerAttribute(PacketHandlerType.TCP, eClientPackets.PlayerCancelsEffect, "Handle Player Effect Cancel Request.", eClientStatus.PlayerInGame)]
 	public class PlayerCancelsEffectHandler : IPacketHandler
 	{
-		#region IPacketHandler Members
-
 		public void HandlePacket(GameClient client, GSPacketIn packet)
 		{
 			int effectID = packet.ReadShort();
 			if (client.Version <= GameClient.eClientVersion.Version1109)
-			{
 				new CancelEffectHandler(client.Player, effectID).Start(1);
-			}
 			else
-			{
 				new CancelEffectHandler1110(client.Player, effectID).Start(1);
-			}
 		}
-
-		#endregion
-
-		#region Nested type: CancelEffectHandler
 
 		/// <summary>
 		/// Handles players cancel effect actions
@@ -85,9 +75,7 @@ namespace DOL.GS.PacketHandler.Client.v168
 					}
 				}
 				if (found != null)
-				{
 					found.Cancel(true);
-				}
 			}
 		}
 
@@ -131,12 +119,8 @@ namespace DOL.GS.PacketHandler.Client.v168
 					}
 				}
 				if (found != null)
-				{
 					found.Cancel(true);
-				}
 			}
 		}
-
-		#endregion
 	}
 }

--- a/GameServer/packets/Client/168/PlayerCommandHandler.cs
+++ b/GameServer/packets/Client/168/PlayerCommandHandler.cs
@@ -31,10 +31,8 @@ namespace DOL.GS.PacketHandler.Client.v168
 			if(!ScriptMgr.HandleCommand(client, cmdLine))
 			{
 				if (cmdLine[0] == '&')
-				{
-					cmdLine = '/' + cmdLine.Remove(0, 1);
-				}
-				client.Out.SendMessage("No such command ("+cmdLine+")",eChatType.CT_System,eChatLoc.CL_SystemWindow);
+					cmdLine = "/" + cmdLine.Remove(0, 1);
+				client.Out.SendMessage($"No such command ({cmdLine})", eChatType.CT_System,eChatLoc.CL_SystemWindow);
 			}
 		}
 	}

--- a/GameServer/packets/Client/168/PlayerCreationRequestHandler.cs
+++ b/GameServer/packets/Client/168/PlayerCreationRequestHandler.cs
@@ -32,23 +32,31 @@ namespace DOL.GS.PacketHandler.Client.v168
 
 		public void HandlePacket(GameClient client, GSPacketIn packet)
 		{
-			ushort id = packet.ReadShort();
+			uint id = 0;
+			if (client.Version >= GameClient.eClientVersion.Version1126)
+				id = packet.ReadIntLowEndian();
+			else
+				id = packet.ReadShort();
 			GameClient target = WorldMgr.GetClientFromID(id);
-			if(target==null)
+			if (target == null)
 			{
-				if (log.IsWarnEnabled)
-					log.Warn(string.Format("Client {0}:{1} account {2} requested invalid client {3} --- disconnecting", client.SessionID, client.TcpEndpointAddress, client.Account == null ? "null" : client.Account.Name, id));
+				log.Warn($"Client {client.SessionID}:{client.TcpEndpointAddress} account {client.Account?.Name ?? "null"} requested invalid client {id} --- disconnecting");
 
 				client.Disconnect();
 				return;
 			}
 
-			//DOLConsole.WriteLine("player creation request "+target.Player.Name);
-			if(target.IsPlaying && target.Player!=null && target.Player.ObjectState==GameObject.eObjectState.Active)
+			// DOLConsole.WriteLine("player creation request "+target.Player.Name);
+			if (target.IsPlaying && target.Player != null && target.Player.ObjectState == GameObject.eObjectState.Active)
 			{
 				client.Out.SendPlayerCreate(target.Player);
 				client.Out.SendLivingEquipmentUpdate(target.Player);
 			}
+		}
+
+		public void _HandlePacket1126(GameClient client, GSPacketIn packet)
+		{
+			var id = packet.ReadIntLowEndian();
 		}
 	}
 }

--- a/GameServer/packets/Client/168/PlayerDismountRequestHandler.cs
+++ b/GameServer/packets/Client/168/PlayerDismountRequestHandler.cs
@@ -22,16 +22,10 @@ namespace DOL.GS.PacketHandler.Client.v168
 	[PacketHandlerAttribute(PacketHandlerType.TCP, eClientPackets.PlayerDismountRequest, "Handles Player Dismount Request.", eClientStatus.PlayerInGame)]
 	public class PlayerDismountRequestHandler : IPacketHandler
 	{
-		#region IPacketHandler Members
-
 		public void HandlePacket(GameClient client, GSPacketIn packet)
 		{
 			new DismountRequestHandler(client.Player).Start(1);
 		}
-
-		#endregion
-
-		#region Nested type: DismountRequestHandler
 
 		/// <summary>
 		/// Handles player dismount requests
@@ -62,7 +56,5 @@ namespace DOL.GS.PacketHandler.Client.v168
 				player.DismountSteed(false);
 			}
 		}
-
-		#endregion
 	}
 }

--- a/GameServer/packets/Client/168/PlayerGroundTargetHandler.cs
+++ b/GameServer/packets/Client/168/PlayerGroundTargetHandler.cs
@@ -21,8 +21,6 @@ namespace DOL.GS.PacketHandler.Client.v168
 	[PacketHandlerAttribute(PacketHandlerType.TCP, eClientPackets.PlayerGroundTarget, "Handles Player Ground Target Settings", eClientStatus.PlayerInGame)]
 	public class PlayerGroundTargetHandler : IPacketHandler
 	{
-		#region IPacketHandler Members
-
 		public void HandlePacket(GameClient client, GSPacketIn packet)
 		{
 			var groundX = (int) packet.ReadInt();
@@ -33,10 +31,6 @@ namespace DOL.GS.PacketHandler.Client.v168
 
 			new ChangeGroundTargetHandler(client.Player, groundX, groundY, groundZ, flag).Start(1);
 		}
-
-		#endregion
-
-		#region Nested type: ChangeGroundTargetHandler
 
 		/// <summary>
 		/// Handles ground target changes
@@ -118,7 +112,5 @@ namespace DOL.GS.PacketHandler.Client.v168
 				}
 			}
 		}
-
-		#endregion
 	}
 }

--- a/GameServer/packets/Client/168/PlayerHeadingUpdateHandler.cs
+++ b/GameServer/packets/Client/168/PlayerHeadingUpdateHandler.cs
@@ -34,10 +34,10 @@ namespace DOL.GS.PacketHandler.Client.v168
 
 		public void HandlePacket(GameClient client, GSPacketIn packet)
 		{
-			if (client == null || client.Player == null)
+			if (client?.Player == null)
 				return;
-
-			if (client.Player.ObjectState != GameObject.eObjectState.Active) return;
+			if (client.Player.ObjectState != GameObject.eObjectState.Active)
+				return;
 
 			ushort sessionId = packet.ReadShort(); // session ID
 			if (client.SessionID != sessionId)
@@ -47,73 +47,82 @@ namespace DOL.GS.PacketHandler.Client.v168
 			}
 
 			ushort head = packet.ReadShort();
+			var unk1 = (byte)packet.ReadByte(); // unknown
+			var flags = (byte)packet.ReadByte();
+			var steedSlot = (byte) packet.ReadByte();
+			var ridingFlag = (byte)packet.ReadByte();
+
 			client.Player.Heading = (ushort)(head & 0xFFF);
-			packet.Skip(1); // unknown
-			int flags = packet.ReadByte();
-//			client.Player.PetInView = ((flags & 0x04) != 0); // TODO
+			// client.Player.PetInView = ((flags & 0x04) != 0); // TODO
 			client.Player.GroundTargetInView = ((flags & 0x08) != 0);
 			client.Player.TargetInView = ((flags & 0x10) != 0);
 
-			byte[] con = packet.ToArray();
-            con[0] = (byte)(client.SessionID >> 8);
-            con[1] = (byte)(client.SessionID & 0xff);
-
-            if (!client.Player.IsAlive)
-			{
-				con[9] = 5; // set dead state
-			}
+			byte state = 0;
+			if (!client.Player.IsAlive)
+				state = 5; // set dead state
 			else if (client.Player.Steed != null && client.Player.Steed.ObjectState == GameObject.eObjectState.Active)
 			{
 				client.Player.Heading = client.Player.Steed.Heading;
-				con[9] = 6; // Set ride state
-				con[7] = (byte)(client.Player.Steed.RiderSlot(client.Player)); // there rider slot this player
-				con[2] = (byte)(client.Player.Steed.ObjectID >> 8); //heading = steed ID
-				con[3] = (byte)(client.Player.Steed.ObjectID & 0xFF);
+				state = 6; // Set ride state
+				steedSlot = (byte)client.Player.Steed.RiderSlot(client.Player); // there rider slot this player
+				head = (ushort)client.Player.Steed.ObjectID; // heading = steed ID
 			}
-			con[5] &= 0xC0; //11 00 00 00 = 0x80(Torch) + 0x40(Unknown), all other in view check's not need send anyone
+			else
+			{
+				if (client.Player.IsSwimming)
+					state = 1;
+				if (client.Player.IsClimbing)
+					state = 7;
+				if (client.Player.IsSitting)
+					state = 4;
+				if (client.Player.IsStrafing)
+					state |= 8;
+			}
+
+			byte flagcontent = 0;
 			if (client.Player.IsWireframe)
-			{
-				con[5] |= 0x01;
-			}
-			//stealth is set here
+				flagcontent |= 0x01;
 			if (client.Player.IsStealthed)
-			{
-				con[5] |= 0x02;
-			}
-			con[8] = (byte)((con[8] & 0x80) | client.Player.HealthPercent);
+				flagcontent |= 0x02;
+			if (client.Player.IsDiving)
+				flagcontent |= 0x04;
+			if (client.Player.IsTorchLighted)
+				flagcontent |= 0x80;
+
+			GSUDPPacketOut outpak190 = new GSUDPPacketOut(client.Out.GetPacketCode(eServerPackets.PlayerHeading));
+			outpak190.WriteShort((ushort) client.SessionID);
+			outpak190.WriteShort(head);
+			outpak190.WriteByte(unk1); // unknown
+			outpak190.WriteByte(flagcontent);
+			outpak190.WriteByte(steedSlot);
+			outpak190.WriteByte(ridingFlag);
+			outpak190.WriteByte((byte)(client.Player.HealthPercent + (client.Player.AttackState ? 0x80 : 0)));
+			outpak190.WriteByte(state);
+			outpak190.WriteByte(client.Player.ManaPercent);
+			outpak190.WriteByte(client.Player.EndurancePercent);
+			outpak190.WritePacketLength();
 
 			GSUDPPacketOut outpak = new GSUDPPacketOut(client.Out.GetPacketCode(eServerPackets.PlayerHeading));
-			//Now copy the whole content of the packet
-			outpak.Write(con, 0, /*con.Length*/10);
+			outpak.WriteShort((ushort)client.SessionID);
+			outpak.WriteShort(head);
+			outpak.WriteByte(steedSlot);
+			outpak.WriteByte(flagcontent);
+			outpak.WriteByte(0);
+			outpak.WriteByte(ridingFlag);
+			outpak.WriteByte((byte)(client.Player.HealthPercent + (client.Player.AttackState ? 0x80 : 0)));
+			outpak.WriteByte(client.Player.ManaPercent);
+			outpak.WriteByte(client.Player.EndurancePercent);
+			outpak.WriteByte(0); // unknown
 			outpak.WritePacketLength();
 
-			GSUDPPacketOut outpak190 = null;
-
-//			byte[] outp = outpak.GetBuffer();
-//			outpak = null;
-
-			foreach(GamePlayer player in client.Player.GetPlayersInRadius(WorldMgr.VISIBILITY_DISTANCE))
+			foreach (GamePlayer player in client.Player.GetPlayersInRadius(WorldMgr.VISIBILITY_DISTANCE))
 			{
 				if(player != null && player != client.Player)
 				{
-					if (player.Client.Version >= GameClient.eClientVersion.Version190)
-					{
-						if (outpak190 == null)
-						{
-	 						outpak190 = new GSUDPPacketOut(client.Out.GetPacketCode(eServerPackets.PlayerHeading));
-	 						byte[] con190 = (byte[]) con.Clone();
-							//Now copy the whole content of the packet
-							outpak190.Write(con190, 0, /*con190.Lenght*/10);
-							outpak190.WriteByte(client.Player.ManaPercent);
-							outpak190.WriteByte(client.Player.EndurancePercent);
-							outpak190.WritePacketLength();
-//							byte[] outp190 = outpak190.GetBuffer();
-//							outpak190 = null;// ?
-						}
-						player.Out.SendUDPRaw(outpak190);
-					}
+					if (player.Client.Version >= GameClient.eClientVersion.Version1124)
+						player.Out.SendUDP(outpak);
 					else
-						player.Out.SendUDPRaw(outpak);
+						player.Out.SendUDP(outpak190);
 				}
 			}
 		}

--- a/GameServer/packets/Client/168/PlayerInitRequestHandler.cs
+++ b/GameServer/packets/Client/168/PlayerInitRequestHandler.cs
@@ -38,16 +38,10 @@ namespace DOL.GS.PacketHandler.Client.v168
 		/// </summary>
 		private static readonly ILog Log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
 
-		#region IPacketHandler Members
-
 		public void HandlePacket(GameClient client, GSPacketIn packet)
 		{
 			new PlayerInitRequestAction(client.Player).Start(1);
 		}
-
-		#endregion
-
-		#region Nested type: PlayerInitRequestAction
 
 		/// <summary>
 		/// Handles player init requests
@@ -321,7 +315,5 @@ namespace DOL.GS.PacketHandler.Client.v168
 				return mobs;
 			}
 		}
-
-		#endregion
 	}
 }

--- a/GameServer/packets/Client/168/PlayerMarketSearchRequestHandler.cs
+++ b/GameServer/packets/Client/168/PlayerMarketSearchRequestHandler.cs
@@ -27,13 +27,13 @@ using log4net;
 
 namespace DOL.GS.PacketHandler.Client.v168
 {
-    [PacketHandlerAttribute(PacketHandlerType.TCP, eClientPackets.MarketSearchRequest, "Handles player market search", eClientStatus.PlayerInGame)]
-    public class PlayerMarketSearchRequestHandler : IPacketHandler
-    {
-        /// <summary>
-        /// Defines a logger for this class.
-        /// </summary>
-        private static readonly ILog log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+	[PacketHandlerAttribute(PacketHandlerType.TCP, eClientPackets.MarketSearchRequest, "Handles player market search", eClientStatus.PlayerInGame)]
+	public class PlayerMarketSearchRequestHandler : IPacketHandler
+	{
+		/// <summary>
+		/// Defines a logger for this class.
+		/// </summary>
+		private static readonly ILog log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
 
 		public void HandlePacket(GameClient client, GSPacketIn packet)
 		{
@@ -43,54 +43,45 @@ namespace DOL.GS.PacketHandler.Client.v168
 			if ((client.Player.TargetObject is IGameInventoryObject) == false)
 				return;
 
-			MarketSearch.SearchData search = new MarketSearch.SearchData();
-
-			search.name = packet.ReadString(64);
-			search.slot = (int)packet.ReadInt();
-			search.skill = (int)packet.ReadInt();
-			search.resist = (int)packet.ReadInt();
-			search.bonus = (int)packet.ReadInt();
-			search.hp = (int)packet.ReadInt();
-			search.power = (int)packet.ReadInt();
-			search.proc = (int)packet.ReadInt();
-			search.qtyMin = (int)packet.ReadInt();
-			search.qtyMax = (int)packet.ReadInt();
-			search.levelMin = (int)packet.ReadInt();
-			search.levelMax = (int)packet.ReadInt();
-			search.priceMin = (int)packet.ReadInt();
-			search.priceMax = (int)packet.ReadInt();
-			search.visual = (int)packet.ReadInt();
-			search.page = (byte)packet.ReadByte();
+			MarketSearch.SearchData search = new MarketSearch.SearchData
+			{
+				name = packet.ReadString(64),
+				slot = (int)packet.ReadInt(),
+				skill = (int)packet.ReadInt(),
+				resist = (int)packet.ReadInt(),
+				bonus = (int)packet.ReadInt(),
+				hp = (int)packet.ReadInt(),
+				power = (int)packet.ReadInt(),
+				proc = (int)packet.ReadInt(),
+				qtyMin = (int)packet.ReadInt(),
+				qtyMax = (int)packet.ReadInt(),
+				levelMin = (int)packet.ReadInt(),
+				levelMax = (int)packet.ReadInt(),
+				priceMin = (int)packet.ReadInt(),
+				priceMax = (int)packet.ReadInt(),
+				visual = (int)packet.ReadInt(),
+				page = (byte)packet.ReadByte()
+			};
 			byte unk1 = (byte)packet.ReadByte();
 			short unk2 = (short)packet.ReadShort();
-			byte unk3 = 0;
-			byte unk4 = 0;
-			byte unk5 = 0;
-			byte unk6 = 0;
-			byte unk7 = 0;
-			byte unk8 = 0;
 
-			if (client.Version >= GameClient.eClientVersion.Version198)
-			{
-				// Dunnerholl 2009-07-28 Version 1.98 introduced new options to Market search. 12 Bytes were added, but only 7 are in usage so far in my findings.
-				// update this, when packets change and keep in mind, that this code reflects only the 1.98 changes
-				search.armorType = search.page; // page is now used for the armorType (still has to be logged, i just checked that 2 means leather, 0 = standard
-				search.damageType = (byte)packet.ReadByte(); // 1=crush, 2=slash, 3=thrust
-				unk3 = (byte)packet.ReadByte();
-				unk4 = (byte)packet.ReadByte();
-				unk5 = (byte)packet.ReadByte();
-				search.playerCrafted = (byte)packet.ReadByte(); // 1 = show only Player crafted, 0 = all
-				// 3 bytes unused
-				packet.Skip(3);
-				search.page = (byte)packet.ReadByte(); // page is now sent here
-				unk6 = (byte)packet.ReadByte();
-				unk7 = (byte)packet.ReadByte();
-				unk8 = (byte)packet.ReadByte();
-			}
+			// Dunnerholl 2009-07-28 Version 1.98 introduced new options to Market search. 12 Bytes were added, but only 7 are in usage so far in my findings.
+			// update this, when packets change and keep in mind, that this code reflects only the 1.98 changes
+			search.armorType = search.page; // page is now used for the armorType (still has to be logged, i just checked that 2 means leather, 0 = standard
+			search.damageType = (byte)packet.ReadByte(); // 1=crush, 2=slash, 3=thrust
+			byte unk3 = (byte)packet.ReadByte();
+			byte unk4 = (byte)packet.ReadByte();
+			byte unk5 = (byte)packet.ReadByte();
+			search.playerCrafted = (byte)packet.ReadByte(); // 1 = show only Player crafted, 0 = all
+			packet.Skip(3); // 3 bytes unused
+			search.page = (byte)packet.ReadByte(); // page is now sent here
+			byte unk6 = (byte)packet.ReadByte();
+			byte unk7 = (byte)packet.ReadByte();
+			byte unk8 = (byte)packet.ReadByte();
 
 			search.clientVersion = client.Version.ToString();
 
 			(client.Player.TargetObject as IGameInventoryObject).SearchInventory(client.Player, search);
 		}
-    }
+	}
 }

--- a/GameServer/packets/Client/168/PlayerModifyTradeHandler.cs
+++ b/GameServer/packets/Client/168/PlayerModifyTradeHandler.cs
@@ -27,29 +27,29 @@ namespace DOL.GS.PacketHandler.Client.v168
 	{
 		public void HandlePacket(GameClient client, GSPacketIn packet)
 		{
-			byte isok =(byte) packet.ReadByte();
-			byte repair =(byte) packet.ReadByte();
-			byte combine =(byte) packet.ReadByte();
-			packet.ReadByte();//unknow
+			byte isok = (byte)packet.ReadByte();
+			byte repair = (byte)packet.ReadByte();
+			byte combine = (byte)packet.ReadByte();
+			packet.ReadByte(); // unknown
 
 			ITradeWindow trade = client.Player.TradeWindow;
 			if (trade == null)
 				return;
-			if (isok==0)
+			if (isok == 0)
 			{
 				trade.CloseTrade();
 			}
-			else if(isok==1)
+			else if (isok == 1)
 			{
-				if(trade.Repairing != (repair == 1)) trade.Repairing = (repair == 1);
-				if(trade.Combine != (combine == 1)) trade.Combine = (combine == 1);
-				
+				if (trade.Repairing != (repair == 1)) trade.Repairing = (repair == 1);
+				if (trade.Combine != (combine == 1)) trade.Combine = (combine == 1);
+
 				ArrayList tradeSlots = new ArrayList(10);
-				for (int i=0;i<10;i++)
+				for (int i = 0; i < 10; i++)
 				{
 					int slotPosition = packet.ReadByte();
 					InventoryItem item = client.Player.Inventory.GetItem((eInventorySlot)slotPosition);
-					if(item != null && ((item.IsDropable && item.IsTradable) || (client.Player.CanTradeAnyItem || client.Player.TradeWindow.Partner.CanTradeAnyItem)))
+					if (item != null && ((item.IsDropable && item.IsTradable) || (client.Player.CanTradeAnyItem || client.Player.TradeWindow.Partner.CanTradeAnyItem)))
 					{
 						tradeSlots.Add(item);
 					}
@@ -57,14 +57,14 @@ namespace DOL.GS.PacketHandler.Client.v168
 				trade.TradeItems = tradeSlots;
 
 				packet.ReadShort();
-				
-				int[] tradeMoney = new int[5];
-				for(int i=0;i<5;i++)
-					tradeMoney[i]=packet.ReadShort();
 
-				long money = Money.GetMoney(tradeMoney[0],tradeMoney[1],tradeMoney[2],tradeMoney[3],tradeMoney[4]);
+				int[] tradeMoney = new int[5];
+				for (int i = 0; i < 5; i++)
+					tradeMoney[i] = packet.ReadShort();
+
+				long money = Money.GetMoney(tradeMoney[0], tradeMoney[1], tradeMoney[2], tradeMoney[3], tradeMoney[4]);
 				trade.TradeMoney = money;
-				
+
 				trade.TradeUpdate();
 			}
 			else if (isok == 2)

--- a/GameServer/packets/Client/168/PlayerPickUpRequestHandler.cs
+++ b/GameServer/packets/Client/168/PlayerPickUpRequestHandler.cs
@@ -32,8 +32,8 @@ namespace DOL.GS.PacketHandler.Client.v168
 				return;
 			uint X = packet.ReadInt();
 			uint Y = packet.ReadInt();
-			ushort id =(ushort) packet.ReadShort();
-			ushort obj=(ushort) packet.ReadShort();
+			ushort id = packet.ReadShort();
+			ushort obj = packet.ReadShort();
 
 			GameObject target = client.Player.TargetObject;
 			if (target == null)
@@ -46,7 +46,7 @@ namespace DOL.GS.PacketHandler.Client.v168
 				client.Out.SendMessage(LanguageMgr.GetTranslation(client.Account.Language, "PlayerPickUpRequestHandler.HandlePacket.InvalidTarget"), eChatType.CT_System, eChatLoc.CL_SystemWindow);
 				return;
 			}
-			
+
 			client.Player.PickupObject(target, false);
 		}
 	}

--- a/GameServer/packets/Client/168/PlayerPositionUpdateHandler.cs
+++ b/GameServer/packets/Client/168/PlayerPositionUpdateHandler.cs
@@ -58,56 +58,39 @@ namespace DOL.GS.PacketHandler.Client.v168
 			    (client.ClientState != GameClient.eClientState.Playing))
 				return;
 
-			int environmentTick = Environment.TickCount;
-			int packetVersion;
-			if (client.Version > GameClient.eClientVersion.Version171)
+			if (client.Version >= GameClient.eClientVersion.Version1124)
 			{
-				packetVersion = 172;
-			}
-			else
-			{
-				packetVersion = 168;
+				_HandlePacket1124(client, packet);
+				return;
 			}
 
+			int environmentTick = Environment.TickCount;
 			int oldSpeed = client.Player.CurrentSpeed;
 
 			//read the state of the player
 			packet.Skip(2); //PID
-			ushort data = packet.ReadShort();
-			int speed = (data & 0x1FF);
+			ushort speedData = packet.ReadShort();
+			int speed = (speedData & 0x1FF);
 
 			//			if(!GameServer.ServerRules.IsAllowedDebugMode(client)
 			//				&& (speed > client.Player.MaxSpeed + SPEED_TOL))
 
 
-			if ((data & 0x200) != 0)
+			if ((speedData & 0x200) != 0)
 				speed = -speed;
 
 			if (client.Player.IsMezzed || client.Player.IsStunned)
-			{
 				// Nidel: updating client.Player.CurrentSpeed instead of speed
 				client.Player.CurrentSpeed = 0;
-			}
 			else
-			{
 				client.Player.CurrentSpeed = (short)speed;
-			}
 
-			client.Player.IsStrafing = ((data & 0xe000) != 0);
+			client.Player.IsStrafing = ((speedData & 0xe000) != 0);
 
 			int realZ = packet.ReadShort();
 			ushort xOffsetInZone = packet.ReadShort();
 			ushort yOffsetInZone = packet.ReadShort();
-			ushort currentZoneID;
-			if (packetVersion == 168)
-			{
-				currentZoneID = (ushort)packet.ReadByte();
-				packet.Skip(1); //0x00 padding for zoneID
-			}
-			else
-			{
-				currentZoneID = packet.ReadShort();
-			}
+			ushort currentZoneID = packet.ReadShort();
 
 
 			//Dinberg - Instance considerations.
@@ -233,13 +216,9 @@ namespace DOL.GS.PacketHandler.Client.v168
 			int tolerance = ServerProperties.Properties.CPS_TOLERANCE;
 
 			if (client.Player.Steed != null && client.Player.Steed.MaxSpeed > 0)
-			{
 				tolerance += client.Player.Steed.MaxSpeed;
-			}
 			else if (client.Player.MaxSpeed > 0)
-			{
 				tolerance += client.Player.MaxSpeed;
-			}
 
 			if (client.Player.IsJumping)
 			{
@@ -334,24 +313,20 @@ namespace DOL.GS.PacketHandler.Client.v168
 				client.Player.TempProperties.setProperty(LASTCPSTICK, environmentTick);
 			}
 
-			ushort headingflag = packet.ReadShort();
-			client.Player.Heading = (ushort)(headingflag & 0xFFF);
-			ushort flyingflag = packet.ReadShort();
-			byte flags = (byte)packet.ReadByte();
+			var headingflag = packet.ReadShort();
+			var flyingflag = packet.ReadShort();
+			var flags = (byte)packet.ReadByte();
 
+			client.Player.Heading = (ushort)(headingflag & 0xFFF);
 			if (client.Player.X != realX || client.Player.Y != realY)
-			{
 				client.Player.TempProperties.setProperty(LASTMOVEMENTTICK, client.Player.CurrentRegion.Time);
-			}
 			client.Player.X = realX;
 			client.Player.Y = realY;
 			client.Player.Z = realZ;
 
+			// update client zone information for waterlevel and diving
 			if (zoneChange)
-			{
-				// update client zone information for waterlevel and diving
 				client.Out.SendPlayerPositionAndObjectID();
-			}
 
 			// used to predict current position, should be before
 			// any calculation (like fall damage)
@@ -369,23 +344,13 @@ namespace DOL.GS.PacketHandler.Client.v168
 
 				// Check for left areas
 				if (oldAreas != null)
-				{
 					foreach (IArea area in oldAreas)
-					{
 						if (!newAreas.Contains(area))
-						{
 							area.OnPlayerLeave(client.Player);
-						}
-					}
-				}
 				// Check for entered areas
 				foreach (IArea area in newAreas)
-				{
 					if (oldAreas == null || !oldAreas.Contains(area))
-					{
 						area.OnPlayerEnter(client.Player);
-					}
-				}
 				// set current areas to new one...
 				client.Player.CurrentAreas = newAreas;
 				client.Player.AreaUpdateTick = client.Player.CurrentRegion.Time + 2000; // update every 2 seconds
@@ -393,9 +358,10 @@ namespace DOL.GS.PacketHandler.Client.v168
 			// End ---------- New Area System -----------
 
 
-			client.Player.TargetInView = ((flags & 0x10) != 0);
-			client.Player.GroundTargetInView = ((flags & 0x08) != 0);
-			client.Player.IsTorchLighted = ((flags & 0x80) != 0);
+			client.Player.TargetInView = (flags & 0x10) != 0;
+			client.Player.GroundTargetInView = (flags & 0x08) != 0;
+			client.Player.IsTorchLighted = (flags & 0x80) != 0;
+			client.Player.IsDiving = (flags & 0x02) != 0x00;
 			//7  6  5  4  3  2  1 0
 			//15 14 13 12 11 10 9 8
 			//                1 1
@@ -407,14 +373,11 @@ namespace DOL.GS.PacketHandler.Client.v168
 			int SHlastFly = client.Player.TempProperties.getProperty<int>(SHLASTFLY);
 			int SHlastStatus = client.Player.TempProperties.getProperty<int>(SHLASTSTATUS);
 			int SHcount = client.Player.TempProperties.getProperty<int>(SHSPEEDCOUNTER);
-			int status = (data & 0x1FF ^ data) >> 8;
+			int status = (speedData & 0x1FF ^ speedData) >> 8;
 			int fly = (flyingflag & 0x1FF ^ flyingflag) >> 8;
 
 			if (client.Player.IsJumping)
-			{
 				SHcount = 0;
-			}
-
 			if (SHlastTick != 0 && SHlastTick != environmentTick)
 			{
 				if (((SHlastStatus == status || (status & 0x8) == 0)) && ((fly & 0x80) != 0x80) && (SHlastFly == fly || (SHlastFly & 0x10) == (fly & 0x10) || !((((SHlastFly & 0x10) == 0x10) && ((fly & 0x10) == 0x0) && (flyingflag & 0x7FF) > 0))))
@@ -508,14 +471,13 @@ namespace DOL.GS.PacketHandler.Client.v168
 				}
 			}
 			else
-			{
 				SHlastTick = environmentTick;
-			}
 
-			int state = ((data >> 10) & 7);
+			int state = ((speedData >> 10) & 7);
 			client.Player.IsClimbing = (state == 7);
 			client.Player.IsSwimming = (state == 1);
-			if (state == 3 && client.Player.TempProperties.getProperty<bool>(GamePlayer.DEBUG_MODE_PROPERTY, false) == false && client.Player.IsAllowedToFly == false) //debugFly on, but player not do /debug on (hack)
+			// debugFly on, but player not do /debug on (hack)
+			if (state == 3 && !client.Player.TempProperties.getProperty(GamePlayer.DEBUG_MODE_PROPERTY, false) && !client.Player.IsAllowedToFly)
 			{
 				StringBuilder builder = new StringBuilder();
 				builder.Append("HACK_FLY");
@@ -579,14 +541,16 @@ namespace DOL.GS.PacketHandler.Client.v168
 			//**************//
 			//FALLING DAMAGE//
 			//**************//
-			if (GameServer.ServerRules.CanTakeFallDamage(client.Player) && client.Player.IsSwimming == false)
+			int fallSpeed = 0;
+			double fallDamage = 0;
+			if (GameServer.ServerRules.CanTakeFallDamage(client.Player) && !client.Player.IsSwimming)
 			{
 				int maxLastZ = client.Player.MaxLastZ;
 				/* Are we on the ground? */
 				if ((flyingflag >> 15) != 0)
 				{
 					int safeFallLevel = client.Player.GetAbilityLevel(Abilities.SafeFall);
-					int fallSpeed = (flyingflag & 0xFFF) - 100 * safeFallLevel; // 0x7FF fall speed and 0x800 bit = fall speed overcaped
+					fallSpeed = (flyingflag & 0xFFF) - 100 * safeFallLevel; // 0x7FF fall speed and 0x800 bit = fall speed overcaped
 					int fallMinSpeed = 400;
 					int fallDivide = 6;
 					if (client.Version >= GameClient.eClientVersion.Version188)
@@ -595,14 +559,14 @@ namespace DOL.GS.PacketHandler.Client.v168
 						fallDivide = 15;
 					}
 
-                    int fallPercent = Math.Min(99, (fallSpeed - (fallMinSpeed + 1)) / fallDivide);
+					int fallPercent = Math.Min(99, (fallSpeed - (fallMinSpeed + 1)) / fallDivide);
 
-                    if (fallSpeed > fallMinSpeed)
-                    {
-                        client.Out.SendMessage(LanguageMgr.GetTranslation(client.Account.Language, "PlayerPositionUpdateHandler.FallingDamage"),
-                        eChatType.CT_Damaged, eChatLoc.CL_SystemWindow);
-                        client.Player.CalcFallDamage(fallPercent);
-                    }
+					if (fallSpeed > fallMinSpeed)
+					{
+						client.Out.SendMessage(LanguageMgr.GetTranslation(client.Account.Language, "PlayerPositionUpdateHandler.FallingDamage"),
+						eChatType.CT_Damaged, eChatLoc.CL_SystemWindow);
+						fallDamage = client.Player.CalcFallDamage(fallPercent);
+					}
 
 					client.Player.MaxLastZ = client.Player.Z;
 				}
@@ -619,88 +583,123 @@ namespace DOL.GS.PacketHandler.Client.v168
 			}
 			//**************//
 
-			byte[] con168 = packet.ToArray();
-            con168[0] = (byte)(client.SessionID >> 8);
-            con168[1] = (byte)(client.SessionID & 0xff);
-
             //Riding is set here!
             if (client.Player.Steed != null && client.Player.Steed.ObjectState == GameObject.eObjectState.Active)
-			{
 				client.Player.Heading = client.Player.Steed.Heading;
 
-				con168[2] = 0x18; // Set ride flag 00011000
-				con168[3] = 0; // player speed = 0 while ride
-				con168[12] = (byte)(client.Player.Steed.ObjectID >> 8); //heading = steed ID
-				con168[13] = (byte)(client.Player.Steed.ObjectID & 0xFF);
-				con168[14] = (byte)0;
-				con168[15] = (byte)(client.Player.Steed.RiderSlot(client.Player)); // there rider slot this player
-			}
-			else if (!client.Player.IsAlive)
+			var outpak = new GSUDPPacketOut(client.Out.GetPacketCode(eServerPackets.PlayerPosition));
+			outpak.WriteShort((ushort)client.SessionID);
+			if (client.Player.Steed != null && client.Player.Steed.ObjectState == GameObject.eObjectState.Active)
+				outpak.WriteShort(0x1800);
+			else
 			{
-				con168[2] &= 0xE3; //11100011
-				con168[2] |= 0x14; //Set dead flag 00010100
+				var rSpeed = client.Player.IsIncapacitated ? 0 : client.Player.CurrentSpeed;
+				ushort content;
+				if (rSpeed < 0)
+					content = (ushort)((rSpeed < -511 ? 511 : -rSpeed) + 0x200);
+				else
+					content = (ushort)(rSpeed > 511 ? 511 : rSpeed);
+
+				if (!client.Player.IsAlive)
+					content |= 5 << 10;
+				else
+				{
+					ushort pState = 0;
+					if (client.Player.IsSwimming)
+						pState = 1;
+					if (client.Player.IsClimbing)
+						pState = 7;
+					if (client.Player.IsSitting)
+						pState = 4;
+					if (client.Player.IsStrafing)
+						pState |= 8;
+					content |= (ushort)(pState << 10);
+				}
+				outpak.WriteShort(content);
 			}
-			//diving is set here
-			con168[16] &= 0xFB; //11 11 10 11
-			if ((con168[16] & 0x02) != 0x00)
+			outpak.WriteShort((ushort)client.Player.Z);
+			outpak.WriteShort((ushort)(client.Player.X - client.Player.CurrentZone.XOffset));
+			outpak.WriteShort((ushort)(client.Player.Y - client.Player.CurrentZone.YOffset));
+			// Write Zone
+			outpak.WriteShort(client.Player.CurrentZone.ZoneSkinID);
+
+			// Copy Heading && Falling or Write Steed
+			if (client.Player.Steed != null && client.Player.Steed.ObjectState == GameObject.eObjectState.Active)
 			{
-				client.Player.IsDiving = true;
-				con168[16] |= 0x04;
+				outpak.WriteShort((ushort)client.Player.Steed.ObjectID);
+				outpak.WriteShort((ushort)client.Player.Steed.RiderSlot(client.Player));
 			}
 			else
-				client.Player.IsDiving = false;
+			{
+				// Set Player always on ground, this is an "anti lag" packet
+				ushort contenthead = (ushort)(client.Player.Heading + (true ? 0x1000 : 0));
+				outpak.WriteShort(contenthead);
+				outpak.WriteShort(0); // No Fall Speed.
+			}
 
-			con168[16] &= 0xFC; //11 11 11 00 cleared Wireframe & Stealth bits
+			// Write Flags
+			byte flagcontent = 0;
 			if (client.Player.IsWireframe)
-			{
-				con168[16] |= 0x01;
-			}
-			//stealth is set here
+				flagcontent |= 0x01;
 			if (client.Player.IsStealthed)
-			{
-				con168[16] |= 0x02;
-			}
+				flagcontent |= 0x02;
+			if (client.Player.IsDiving)
+				flagcontent |= 0x04;
+			if (client.Player.IsTorchLighted)
+				flagcontent |= 0x80;
+			outpak.WriteByte(flagcontent);
 
-			con168[17] = (byte)((con168[17] & 0x80) | client.Player.HealthPercent);
-			// zone ID has changed in 1.72, fix bytes 11 and 12
-			byte[] con172 = (byte[])con168.Clone();
-			if (packetVersion == 168)
-			{
-				// client sent v168 pos update packet, fix 172 version
-				con172[10] = 0;
-				con172[11] = con168[10];
-			}
-			else
-			{
-				// client sent v172 pos update packet, fix 168 version
-				con168[10] = con172[11];
-				con168[11] = 0;
-			}
+			// Write health + Attack
+			outpak.WriteByte((byte)(client.Player.HealthPercent + (client.Player.AttackState ? 0x80 : 0)));
 
-			GSUDPPacketOut outpak168 = new GSUDPPacketOut(client.Out.GetPacketCode(eServerPackets.PlayerPosition));
-			//Now copy the whole content of the packet
-			outpak168.Write(con168, 0, 18/*con168.Length*/);
-			outpak168.WritePacketLength();
+			// Write Remainings.
+			outpak.WriteByte(client.Player.ManaPercent);
+			outpak.WriteByte(client.Player.EndurancePercent);
+			var outpakArr = outpak.ToArray();
 
-			GSUDPPacketOut outpak172 = new GSUDPPacketOut(client.Out.GetPacketCode(eServerPackets.PlayerPosition));
-			//Now copy the whole content of the packet
-			outpak172.Write(con172, 0, 18/*con172.Length*/);
-			outpak172.WritePacketLength();
-
-			//			byte[] pak168 = outpak168.GetBuffer();
-			//			byte[] pak172 = outpak172.GetBuffer();
-			//			outpak168 = null;
-			//			outpak172 = null;
-			GSUDPPacketOut outpak190 = null;
-
+			var outpak190 = new GSUDPPacketOut(client.Out.GetPacketCode(eServerPackets.PlayerPosition));
+			outpak190.Write(outpakArr, 5, outpakArr.Length - 5);
+			outpak190.FillString(client.Player.CharacterClass.Name, 32);
+			outpak190.WriteByte((byte)(client.Player.RPFlag ? 1 : 0)); // roleplay flag, if == 1, show name (RP) with gray color
+			outpak190.WriteByte(0); // send last byte for 190+ packets
+			outpak190.WritePacketLength();
 
 			GSUDPPacketOut outpak1112 = new GSUDPPacketOut(client.Out.GetPacketCode(eServerPackets.PlayerPosition));
-			outpak1112.Write(con172, 0, 18/*con172.Length*/);
-			outpak1112.WriteByte(client.Player.ManaPercent);
-			outpak1112.WriteByte(client.Player.EndurancePercent);
+			outpak1112.Write(outpakArr, 5, outpakArr.Length - 5);
 			outpak1112.WriteByte((byte)(client.Player.RPFlag ? 1 : 0));
 			outpak1112.WriteByte(0); //outpak1112.WriteByte((con168.Length == 22) ? con168[21] : (byte)0);
 			outpak1112.WritePacketLength();
+
+			GSUDPPacketOut outpak1124 = new GSUDPPacketOut(client.Out.GetPacketCode(eServerPackets.PlayerPosition));
+			byte playerAction = 0x00;
+			if (client.Player.IsDiving)
+				playerAction |= 0x04;
+			if (client.Player.TargetInView)
+				playerAction |= 0x30;
+			if (client.Player.GroundTargetInView)
+				playerAction |= 0x08;
+			if (client.Player.IsTorchLighted)
+				playerAction |= 0x80;
+			if (client.Player.IsStealthed)
+				playerAction |= 0x02;
+			ushort playerState = 0;
+			outpak1124.WriteFloatLowEndian(client.Player.X);
+			outpak1124.WriteFloatLowEndian(client.Player.Y);
+			outpak1124.WriteFloatLowEndian(client.Player.Z);
+			outpak1124.WriteFloatLowEndian(client.Player.CurrentSpeed);
+			outpak1124.WriteFloatLowEndian(fallSpeed);
+			outpak1124.WriteShort((ushort)client.SessionID);
+			outpak1124.WriteShort(currentZoneID);
+			outpak1124.WriteShort(playerState);
+			outpak1124.WriteShort((ushort)(client.Player.Steed?.RiderSlot(client.Player) ?? 0)); // fall damage flag coming in, steed seat position going out
+			outpak1124.WriteShort(client.Player.Heading);
+			outpak1124.WriteByte(playerAction);
+			outpak1124.WriteByte((byte)(client.Player.RPFlag ? 1 : 0));
+			outpak1124.WriteByte(0);
+			outpak1124.WriteByte((byte)(client.Player.HealthPercent + (client.Player.AttackState ? 0x80 : 0)));
+			outpak1124.WriteByte(client.Player.ManaPercent);
+			outpak1124.WriteByte(client.Player.EndurancePercent);
+			outpak1124.WritePacketLength();
 
 
 			foreach (GamePlayer player in client.Player.GetPlayersInRadius(WorldMgr.VISIBILITY_DISTANCE))
@@ -732,34 +731,14 @@ namespace DOL.GS.PacketHandler.Client.v168
 				{
 					// Update Player Cache
 					player.Client.GameObjectUpdateArray[new Tuple<ushort, ushort>(client.Player.CurrentRegionID, (ushort)client.Player.ObjectID)] = GameTimer.GetTickCount();
-					
+
 					//forward the position packet like normal!
-					if (player.Client.Version >= GameClient.eClientVersion.Version1112)
-					{
-						player.Out.SendUDPRaw(outpak1112);
-					}
+					if (player.Client.Version >= GameClient.eClientVersion.Version1124)
+						player.Out.SendUDP(outpak1124);
+					else if (player.Client.Version >= GameClient.eClientVersion.Version1112)
+						player.Out.SendUDP(outpak1112);
 					else if (player.Client.Version >= GameClient.eClientVersion.Version190)
-					{
-						if (outpak190 == null)
-						{
-							outpak190 = new GSUDPPacketOut(client.Out.GetPacketCode(eServerPackets.PlayerPosition));
-							outpak190.Write(con172, 0, 18/*con172.Length*/);
-							outpak190.WriteByte(client.Player.ManaPercent);
-							outpak190.WriteByte(client.Player.EndurancePercent);
-							outpak190.FillString(client.Player.CharacterClass.Name, 32);
-							// roleplay flag, if == 1, show name (RP) with gray color
-							if (client.Player.RPFlag)
-								outpak190.WriteByte(1);
-							else outpak190.WriteByte(0);
-							outpak190.WriteByte((con168.Length == 54) ? con168[53] : (byte) 0); // send last byte for 190+ packets
-							outpak190.WritePacketLength();
-						}
-						player.Out.SendUDPRaw(outpak190);
-					}
-					else if (player.Client.Version >= GameClient.eClientVersion.Version172)
-						player.Out.SendUDPRaw(outpak172);
-					else
-						player.Out.SendUDPRaw(outpak168);
+						player.Out.SendUDP(outpak190);
 				}
 				else
 					player.Out.SendObjectDelete(client.Player); //remove the stealthed player from view
@@ -781,6 +760,503 @@ namespace DOL.GS.PacketHandler.Client.v168
 						client.Player.TradeWindow.CloseTrade();
 				}
 			}
+		}
+
+		private void _HandlePacket1124(GameClient client, GSPacketIn packet)
+		{
+			//Tiv: in very rare cases client send 0xA9 packet before sending S<=C 0xE8 player world initialize
+			if ((client.Player.ObjectState != GameObject.eObjectState.Active) ||
+				(client.ClientState != GameClient.eClientState.Playing))
+				return;
+
+			int environmentTick = Environment.TickCount;
+			int oldSpeed = client.Player.CurrentSpeed;
+
+			var newPlayerX = packet.ReadFloatLowEndian();
+			var newPlayerY = packet.ReadFloatLowEndian();
+			var newPlayerZ = packet.ReadFloatLowEndian();
+			var newPlayerSpeed = packet.ReadFloatLowEndian();
+			var newPlayerZSpeed = packet.ReadFloatLowEndian();
+			ushort sessionID = packet.ReadShort();
+			ushort currentZoneID = packet.ReadShort();
+			ushort playerState = packet.ReadShort();
+			ushort fallingDMG = packet.ReadShort();
+			ushort newHeading = packet.ReadShort();
+			byte playerAction = (byte)packet.ReadByte();
+			packet.Skip(2); // unknown bytes x2
+			byte playerHealth = (byte)packet.ReadByte();
+			// two trailing bytes, no data
+
+			//int speed = (newPlayerSpeed & 0x1FF);
+			//Flags1 = (eFlags1)playerState;
+			//Flags2 = (eFlags2)playerAction;                        
+
+			if (client.Player.IsMezzed || client.Player.IsStunned)
+				client.Player.CurrentSpeed = 0;
+			else
+				client.Player.CurrentSpeed = (short)newPlayerSpeed;
+			/*
+			client.Player.IsStrafing = Flags1 == eFlags1.STRAFELEFT || Flags1 == eFlags1.STRAFERIGHT;
+			client.Player.IsDiving = Flags2 == eFlags2.DIVING ? true : false;
+			client.Player.IsSwimming = Flags1 == eFlags1.SWIMMING ? true : false;
+			if (client.Player.IsRiding)
+				Flags1 = eFlags1.RIDING;
+			client.Player.IsClimbing = Flags1 == eFlags1.CLIMBING ? true : false;
+			if (!client.Player.IsAlive)
+				Flags1 = eFlags1.DEAD;*/
+
+			client.Player.IsJumping = ((playerAction & 0x40) != 0);
+			client.Player.IsStrafing = ((playerState & 0xe000) != 0);
+
+			Zone newZone = WorldMgr.GetZone(currentZoneID);
+			if (newZone == null)
+			{
+				if (!client.Player.TempProperties.getProperty("isbeingbanned", false))
+				{
+					log.Error(client.Player.Name + "'s position in unknown zone! => " + currentZoneID);
+					GamePlayer player = client.Player;
+					player.TempProperties.setProperty("isbeingbanned", true);
+					player.MoveToBind();
+				}
+
+				return; // TODO: what should we do? player lost in space
+			}
+
+			// move to bind if player fell through the floor
+			if (newPlayerZ == 0)
+			{
+				client.Player.MoveToBind();
+				return;
+			}
+
+			//int realX = newPlayerX;
+			//int realY = newPlayerY;
+			//int realZ = newPlayerZ;
+			bool zoneChange = newZone != client.Player.LastPositionUpdateZone;
+			if (zoneChange)
+			{
+				//If the region changes -> make sure we don't take any falling damage
+				if (client.Player.LastPositionUpdateZone != null && newZone.ZoneRegion.ID != client.Player.LastPositionUpdateZone.ZoneRegion.ID)
+				{
+					client.Player.MaxLastZ = int.MinValue;
+				}
+				// Update water level and diving flag for the new zone
+				client.Out.SendPlayerPositionAndObjectID();
+
+				/*
+				 * "You have entered Burial Tomb."
+				 * "Burial Tomb"
+				 * "Current area is adjusted for one level 1 player."
+				 * "Current area has a 50% instance bonus."
+				 */
+
+				string description = newZone.Description;
+				string screenDescription = description;
+
+				var translation = client.GetTranslation(newZone) as DBLanguageZone;
+				if (translation != null)
+				{
+					if (!Util.IsEmpty(translation.Description))
+						description = translation.Description;
+
+					if (!Util.IsEmpty(translation.ScreenDescription))
+						screenDescription = translation.ScreenDescription;
+				}
+
+				client.Out.SendMessage(LanguageMgr.GetTranslation(client.Account.Language, "PlayerPositionUpdateHandler.Entered", description),
+									   eChatType.CT_System, eChatLoc.CL_SystemWindow);
+				client.Out.SendMessage(screenDescription, eChatType.CT_ScreenCenterSmaller, eChatLoc.CL_SystemWindow);
+
+				client.Player.LastPositionUpdateZone = newZone;
+			}
+
+			int coordsPerSec = 0;
+			int jumpDetect = 0;
+			int timediff = Environment.TickCount - client.Player.LastPositionUpdateTick;
+			int distance = 0;
+
+			if (timediff > 0)
+			{
+				distance = client.Player.LastPositionUpdatePoint.GetDistanceTo(new Point3D(newPlayerX, newPlayerY, newPlayerZ));
+				coordsPerSec = distance * 1000 / timediff;
+
+				if (distance < 100 && client.Player.LastPositionUpdatePoint.Z > 0)
+				{
+					jumpDetect = (int)newPlayerZ - client.Player.LastPositionUpdatePoint.Z;
+				}
+			}
+
+			client.Player.LastPositionUpdateTick = Environment.TickCount;
+			client.Player.LastPositionUpdatePoint.X = (int)newPlayerX;
+			client.Player.LastPositionUpdatePoint.Y = (int)newPlayerY;
+			client.Player.LastPositionUpdatePoint.Z = (int)newPlayerZ;
+
+			int tolerance = ServerProperties.Properties.CPS_TOLERANCE;
+
+			if (client.Player.Steed != null && client.Player.Steed.MaxSpeed > 0)
+			{
+				tolerance += client.Player.Steed.MaxSpeed;
+			}
+			else if (client.Player.MaxSpeed > 0)
+			{
+				tolerance += client.Player.MaxSpeed;
+			}
+
+			if (client.Player.IsJumping)
+			{
+				coordsPerSec = 0;
+				jumpDetect = 0;
+				client.Player.IsJumping = false;
+			}
+
+			if (!client.Player.IsAllowedToFly && (coordsPerSec > tolerance || jumpDetect > ServerProperties.Properties.JUMP_TOLERANCE))
+			{
+				bool isHackDetected = true;
+
+				if (coordsPerSec > tolerance)
+				{
+					// check to see if CPS time tolerance is exceeded
+					int lastCPSTick = client.Player.TempProperties.getProperty<int>(LASTCPSTICK, 0);
+
+					if (environmentTick - lastCPSTick > ServerProperties.Properties.CPS_TIME_TOLERANCE)
+					{
+						isHackDetected = false;
+					}
+				}
+
+				if (isHackDetected)
+				{
+					StringBuilder builder = new StringBuilder();
+					builder.Append("MOVEHACK_DETECT");
+					builder.Append(": CharName=");
+					builder.Append(client.Player.Name);
+					builder.Append(" Account=");
+					builder.Append(client.Account.Name);
+					builder.Append(" IP=");
+					builder.Append(client.TcpEndpointAddress);
+					builder.Append(" CPS:=");
+					builder.Append(coordsPerSec);
+					builder.Append(" JT=");
+					builder.Append(jumpDetect);
+					ChatUtil.SendDebugMessage(client, builder.ToString());
+
+					if (client.Account.PrivLevel == 1)
+					{
+						GameServer.Instance.LogCheatAction(builder.ToString());
+
+						if (ServerProperties.Properties.ENABLE_MOVEDETECT)
+						{
+							if (ServerProperties.Properties.BAN_HACKERS && false) // banning disabled until this technique is proven accurate
+							{
+								DBBannedAccount b = new DBBannedAccount();
+								b.Author = "SERVER";
+								b.Ip = client.TcpEndpointAddress;
+								b.Account = client.Account.Name;
+								b.DateBan = DateTime.Now;
+								b.Type = "B";
+								b.Reason = string.Format("Autoban MOVEHACK:(CPS:{0}, JT:{1}) on player:{2}", coordsPerSec, jumpDetect, client.Player.Name);
+								GameServer.Database.AddObject(b);
+								GameServer.Database.SaveObject(b);
+
+								string message = "";
+
+								message = "You have been auto kicked and banned due to movement hack detection!";
+								for (int i = 0; i < 8; i++)
+								{
+									client.Out.SendMessage(message, eChatType.CT_Help, eChatLoc.CL_SystemWindow);
+									client.Out.SendMessage(message, eChatType.CT_Help, eChatLoc.CL_ChatWindow);
+								}
+
+								client.Out.SendPlayerQuit(true);
+								client.Player.SaveIntoDatabase();
+								client.Player.Quit(true);
+							}
+							else
+							{
+								string message = "";
+
+								message = "You have been auto kicked due to movement hack detection!";
+								for (int i = 0; i < 8; i++)
+								{
+									client.Out.SendMessage(message, eChatType.CT_Help, eChatLoc.CL_SystemWindow);
+									client.Out.SendMessage(message, eChatType.CT_Help, eChatLoc.CL_ChatWindow);
+								}
+
+								client.Out.SendPlayerQuit(true);
+								client.Player.SaveIntoDatabase();
+								client.Player.Quit(true);
+							}
+							client.Disconnect();
+							return;
+						}
+					}
+				}
+
+				client.Player.TempProperties.setProperty(LASTCPSTICK, environmentTick);
+			}
+			//client.Player.Heading = (ushort)(newHeading & 0xFFF); //patch 0024 expermental
+
+			if (client.Player.X != newPlayerX || client.Player.Y != newPlayerY)
+			{
+				client.Player.TempProperties.setProperty(LASTMOVEMENTTICK, client.Player.CurrentRegion.Time);
+			}
+
+			client.Player.X = (int)newPlayerX;
+			client.Player.Y = (int)newPlayerY;
+			client.Player.Z = (int)newPlayerZ;
+			client.Player.Heading = (ushort)(newHeading & 0xFFF);
+
+			// used to predict current position, should be before
+			// any calculation (like fall damage)
+			client.Player.MovementStartTick = Environment.TickCount; // experimental 0024
+
+			// Begin ---------- New Area System -----------
+			if (client.Player.CurrentRegion.Time > client.Player.AreaUpdateTick) // check if update is needed
+			{
+				var oldAreas = client.Player.CurrentAreas;
+
+				// Because we may be in an instance we need to do the area check from the current region
+				// rather than relying on the zone which is in the skinned region.  - Tolakram
+
+				var newAreas = client.Player.CurrentRegion.GetAreasOfZone(newZone, client.Player);
+
+				// Check for left areas
+				if (oldAreas != null)
+				{
+					foreach (IArea area in oldAreas)
+					{
+						if (!newAreas.Contains(area))
+						{
+							area.OnPlayerLeave(client.Player);
+						}
+					}
+				}
+				// Check for entered areas
+				foreach (IArea area in newAreas)
+				{
+					if (oldAreas == null || !oldAreas.Contains(area))
+					{
+						area.OnPlayerEnter(client.Player);
+					}
+				}
+				// set current areas to new one...
+				client.Player.CurrentAreas = newAreas;
+				client.Player.AreaUpdateTick = client.Player.CurrentRegion.Time + 2000; // update every 2 seconds
+			}
+			// End ---------- New Area System -----------
+
+
+			//client.Player.TargetInView = ((flags & 0x10) != 0);
+			//client.Player.IsDiving = ((playerAction & 0x02) != 0);
+			client.Player.TargetInView = ((playerAction & 0x30) != 0);
+			client.Player.GroundTargetInView = ((playerAction & 0x08) != 0);
+			client.Player.IsTorchLighted = ((playerAction & 0x80) != 0);
+			// patch 0069 player diving is 0x02, but will broadcast to other players as 0x04
+			// if player has a pet summoned, player action is sent by client as 0x04, but sending to other players this is skipped
+			client.Player.IsDiving = ((playerAction & 0x02) != 0);
+
+			int state = ((playerState >> 10) & 7);
+			client.Player.IsClimbing = (state == 7);
+			client.Player.IsSwimming = (state == 1);
+
+			//int status = (data & 0x1FF ^ data) >> 8;
+			//int fly = (flyingflag & 0x1FF ^ flyingflag) >> 8;
+			if (state == 3 && client.Player.TempProperties.getProperty<bool>(GamePlayer.DEBUG_MODE_PROPERTY, false) == false && !client.Player.IsAllowedToFly) //debugFly on, but player not do /debug on (hack)
+			{
+				StringBuilder builder = new StringBuilder();
+				builder.Append("HACK_FLY");
+				builder.Append(": CharName=");
+				builder.Append(client.Player.Name);
+				builder.Append(" Account=");
+				builder.Append(client.Account.Name);
+				builder.Append(" IP=");
+				builder.Append(client.TcpEndpointAddress);
+				GameServer.Instance.LogCheatAction(builder.ToString());
+				{
+					if (ServerProperties.Properties.BAN_HACKERS)
+					{
+						DBBannedAccount b = new DBBannedAccount();
+						b.Author = "SERVER";
+						b.Ip = client.TcpEndpointAddress;
+						b.Account = client.Account.Name;
+						b.DateBan = DateTime.Now;
+						b.Type = "B";
+						b.Reason = string.Format("Autoban flying hack: on player:{0}", client.Player.Name);
+						GameServer.Database.AddObject(b);
+						GameServer.Database.SaveObject(b);
+					}
+					string message = "";
+
+					message = "Client Hack Detected!";
+					for (int i = 0; i < 6; i++)
+					{
+						client.Out.SendMessage(message, eChatType.CT_System, eChatLoc.CL_SystemWindow);
+						client.Out.SendMessage(message, eChatType.CT_System, eChatLoc.CL_ChatWindow);
+					}
+					client.Out.SendPlayerQuit(true);
+					client.Disconnect();
+					return;
+				}
+			}
+			lock (client.Player.LastUniqueLocations)
+			{
+				GameLocation[] locations = client.Player.LastUniqueLocations;
+				GameLocation loc = locations[0];
+				if (loc.X != (int)newPlayerX || loc.Y != (int)newPlayerY || loc.Z != (int)newPlayerZ || loc.RegionID != client.Player.CurrentRegionID)
+				{
+					loc = locations[locations.Length - 1];
+					Array.Copy(locations, 0, locations, 1, locations.Length - 1);
+					locations[0] = loc;
+					loc.X = (int)newPlayerX;
+					loc.Y = (int)newPlayerY;
+					loc.Z = (int)newPlayerZ;
+					loc.Heading = client.Player.Heading;
+					loc.RegionID = client.Player.CurrentRegionID;
+				}
+			}
+
+			//FALLING DAMAGE
+
+			if (GameServer.ServerRules.CanTakeFallDamage(client.Player) && !client.Player.IsSwimming)
+			{
+				try
+				{
+					int maxLastZ = client.Player.MaxLastZ;
+
+					// Are we on the ground?
+					if ((fallingDMG >> 15) != 0)
+					{
+						int safeFallLevel = client.Player.GetAbilityLevel(Abilities.SafeFall);
+
+						var fallSpeed = (newPlayerZSpeed * -1) - (100 * safeFallLevel);
+
+						int fallDivide = 15;
+
+						var fallPercent = Math.Min(99, (fallSpeed - 501) / fallDivide);
+
+						if (fallSpeed > 500)
+						{
+							client.Out.SendMessage(LanguageMgr.GetTranslation(client.Account.Language, "PlayerPositionUpdateHandler.FallingDamage"), eChatType.CT_Damaged, eChatLoc.CL_SystemWindow);
+							client.Out.SendMessage(string.Format("You take {0}% of you max hits in damage.", fallPercent), eChatType.CT_Damaged, eChatLoc.CL_SystemWindow);
+							client.Out.SendMessage("You lose endurance", eChatType.CT_Damaged, eChatLoc.CL_SystemWindow);
+							client.Player.CalcFallDamage((int)fallPercent);
+						}
+
+						client.Player.MaxLastZ = client.Player.Z;
+					}
+					else if (maxLastZ < client.Player.Z || client.Player.IsRiding || newPlayerZSpeed > -150) // is riding, for dragonflys
+						client.Player.MaxLastZ = client.Player.Z;
+				}
+				catch
+				{
+					log.Warn("error when attempting to calculate fall damage");
+				}
+			}
+
+			ushort steedSeatPosition = 0;
+
+			if (client.Player.Steed != null && client.Player.Steed.ObjectState == GameObject.eObjectState.Active)
+			{
+				client.Player.Heading = client.Player.Steed.Heading;
+				newHeading = (ushort)client.Player.Steed.ObjectID;
+			}
+			else if ((playerState >> 10) == 4) // patch 0062 fix bug on release preventing players from receiving res sickness
+				client.Player.IsSitting = true;
+
+			GSUDPPacketOut outpak = new GSUDPPacketOut(client.Out.GetPacketCode(eServerPackets.PlayerPosition));
+			//patch 0069 test to fix player swim out byte flag
+			byte playerOutAction = 0x00;
+			if (client.Player.IsDiving)
+				playerOutAction |= 0x04;
+			if (client.Player.TargetInView)
+				playerOutAction |= 0x30;
+			if (client.Player.GroundTargetInView)
+				playerOutAction |= 0x08;
+			if (client.Player.IsTorchLighted)
+				playerOutAction |= 0x80;
+			if (client.Player.IsStealthed)
+				playerOutAction |= 0x02;
+
+			outpak.WriteFloatLowEndian(newPlayerX);
+			outpak.WriteFloatLowEndian(newPlayerY);
+			outpak.WriteFloatLowEndian(newPlayerZ);
+			outpak.WriteFloatLowEndian(newPlayerSpeed);
+			outpak.WriteFloatLowEndian(newPlayerZSpeed);
+			outpak.WriteShort(sessionID);
+			outpak.WriteShort(currentZoneID);
+			outpak.WriteShort(playerState);
+			outpak.WriteShort(steedSeatPosition); // fall damage flag coming in, steed seat position going out
+			outpak.WriteShort(newHeading);
+			outpak.WriteByte(playerOutAction);
+			outpak.WriteByte((byte)(client.Player.RPFlag ? 1 : 0));
+			outpak.WriteByte(0);
+			outpak.WriteByte((byte)(client.Player.HealthPercent + (client.Player.AttackState ? 0x80 : 0)));
+			outpak.WriteByte(client.Player.ManaPercent);
+			outpak.WriteByte(client.Player.EndurancePercent);
+			outpak.WritePacketLength();
+
+			var outpak190 = new GSUDPPacketOut(client.Out.GetPacketCode(eServerPackets.PlayerPosition));
+			outpak190.WriteShort((ushort)client.SessionID);
+			outpak190.WriteShort((ushort)(client.Player.CurrentSpeed & 0x1FF));
+			outpak190.WriteShort((ushort)newPlayerZ);
+			var xoff = (ushort)(newPlayerX - (client.Player.CurrentZone?.XOffset ?? 0));
+			outpak190.WriteShort(xoff);
+			var yoff = (ushort)(newPlayerY - (client.Player.CurrentZone?.YOffset ?? 0));
+			outpak190.WriteShort(yoff);
+			outpak190.WriteShort(currentZoneID);
+			outpak190.WriteShort(newHeading);
+			outpak190.WriteShort(steedSeatPosition);
+			outpak190.WriteByte(playerAction);
+			outpak190.WriteByte((byte)(client.Player.HealthPercent + (client.Player.AttackState ? 0x80 : 0)));
+			outpak190.WriteByte(client.Player.ManaPercent);
+			outpak190.WriteByte(client.Player.EndurancePercent);
+
+			var outpak1112 = new GSUDPPacketOut(client.Out.GetPacketCode(eServerPackets.PlayerPosition));
+			outpak1112.Write(outpak190.ToArray(), 0, (int)outpak190.Length);
+			outpak1112.WriteByte((byte)(client.Player.RPFlag ? 1 : 0));
+			outpak1112.WriteByte(0);
+			outpak1112.WritePacketLength();
+
+			outpak190.FillString(client.Player.CharacterClass.Name, 32);
+			outpak190.WriteByte((byte)(client.Player.RPFlag ? 1 : 0));
+			outpak190.WriteByte(0);
+			outpak190.WritePacketLength();
+
+			foreach (GamePlayer player in client.Player.GetPlayersInRadius(WorldMgr.VISIBILITY_DISTANCE))
+			{
+				if (player == null)
+					continue;
+				//No position updates for ourselves
+				if (player == client.Player)
+				{
+					// Update Player Cache (Client sending Packet is admitting he's already having it)
+					player.Client.GameObjectUpdateArray[new Tuple<ushort, ushort>(client.Player.CurrentRegionID, (ushort)client.Player.ObjectID)] = GameTimer.GetTickCount();
+					continue;
+				}
+				//no position updates in different houses
+				if ((client.Player.InHouse || player.InHouse) && player.CurrentHouse != client.Player.CurrentHouse)
+					continue;
+
+				if (!client.Player.IsStealthed || player.CanDetect(client.Player))
+				{
+					// Update Player Cache
+					player.Client.GameObjectUpdateArray[new Tuple<ushort, ushort>(client.Player.CurrentRegionID, (ushort)client.Player.ObjectID)] = GameTimer.GetTickCount();
+
+					if (player.Client.Version >= GameClient.eClientVersion.Version1124)
+						player.Out.SendUDP(outpak);
+					else if (player.Client.Version >= GameClient.eClientVersion.Version1112)
+						player.Out.SendUDP(outpak1112);
+					else
+						player.Out.SendUDP(outpak190);
+				}
+				else
+					player.Out.SendObjectDelete(client.Player); //remove the stealthed player from view
+			}
+
+			//handle closing of windows
+			//trade window
+			if (client.Player.TradeWindow?.Partner != null && !client.Player.IsWithinRadius(client.Player.TradeWindow.Partner, WorldMgr.GIVE_ITEM_DISTANCE))
+				client.Player.TradeWindow.CloseTrade();
 		}
 	}
 }

--- a/GameServer/packets/Client/168/PlayerSellRequestHandler.cs
+++ b/GameServer/packets/Client/168/PlayerSellRequestHandler.cs
@@ -47,15 +47,15 @@ namespace DOL.GS.PacketHandler.Client.v168
 				int itemCount = Math.Max(1, item.Count);
 				int packSize = Math.Max(1, item.PackSize);
 
-				if (client.Player.TargetObject is GameMerchant)
+				if (client.Player.TargetObject is GameMerchant merchant)
 				{
 					//Let the merchant choos how to handle the trade.
-					((GameMerchant)client.Player.TargetObject).OnPlayerSell(client.Player, item);
+					merchant.OnPlayerSell(client.Player, item);
 
 				}
-				else if (client.Player.TargetObject is GameLotMarker)
+				else if (client.Player.TargetObject is GameLotMarker lot)
 				{
-					((GameLotMarker)client.Player.TargetObject).OnPlayerSell(client.Player, item);
+					lot.OnPlayerSell(client.Player, item);
 				}
 			}
 		}

--- a/GameServer/packets/Client/168/PlayerSetMarketPrice.cs
+++ b/GameServer/packets/Client/168/PlayerSetMarketPrice.cs
@@ -42,8 +42,6 @@ namespace DOL.GS.PacketHandler.Client.v168
 			ushort unk2 = packet.ReadShort();
 			uint price = packet.ReadInt();
 
-			// ChatUtil.SendDebugMessage(client.Player, "PlayerSetMarketPriceHandler");
-
 			// only IGameInventoryObjects can handle set price commands
 			if (client.Player.TargetObject == null || (client.Player.TargetObject is IGameInventoryObject) == false)
 				return;

--- a/GameServer/packets/Client/168/PlayerSitRequest.cs
+++ b/GameServer/packets/Client/168/PlayerSitRequest.cs
@@ -21,18 +21,12 @@ namespace DOL.GS.PacketHandler.Client.v168
 	[PacketHandlerAttribute(PacketHandlerType.TCP, eClientPackets.PlayerSitRequest, "Handles Player Sit Request.", eClientStatus.PlayerInGame)]
 	public class PlayerSitRequestHandler : IPacketHandler
 	{
-		#region IPacketHandler Members
-
 		public void HandlePacket(GameClient client, GSPacketIn packet)
 		{
 			var status = (byte) packet.ReadByte();
 
 			new SitRequestHandler(client.Player, status != 0x00).Start(1);
 		}
-
-		#endregion
-
-		#region Nested type: SitRequestHandler
 
 		/// <summary>
 		/// Handles player sit requests
@@ -60,11 +54,8 @@ namespace DOL.GS.PacketHandler.Client.v168
 			protected override void OnTick()
 			{
 				var player = (GamePlayer) m_actionSource;
-
 				player.Sit(m_sit);
 			}
 		}
-
-		#endregion
 	}
 }

--- a/GameServer/packets/Client/168/PlayerTargetHandler.cs
+++ b/GameServer/packets/Client/168/PlayerTargetHandler.cs
@@ -27,8 +27,6 @@ namespace DOL.GS.PacketHandler.Client.v168
 	[PacketHandlerAttribute(PacketHandlerType.TCP, eClientPackets.PlayerTarget, "Handle Player Target Change.", eClientStatus.PlayerInGame)]
 	public class PlayerTargetHandler : IPacketHandler
 	{
-		#region IPacketHandler Members
-
 		/// <summary>
 		/// Handles every received packet
 		/// </summary>
@@ -49,10 +47,6 @@ namespace DOL.GS.PacketHandler.Client.v168
 
 			new ChangeTargetAction(client.Player, targetID, (flags & (0x4000 | 0x2000)) != 0, (flags & 0x8000) != 0).Start(1);
 		}
-
-		#endregion
-
-		#region Nested type: ChangeTargetAction
 
 		/// <summary>
 		/// Changes players target
@@ -126,8 +120,7 @@ namespace DOL.GS.PacketHandler.Client.v168
 					var gravestone = myTarget as GameGravestone;
 					if (gravestone == null || !gravestone.InternalID.Equals(player.InternalID))
 					{
-						player.Out.SendMessage("You are no longer targetting your grave. Your prayers fail.", eChatType.CT_System,
-						                       eChatLoc.CL_SystemWindow);
+						player.Out.SendMessage("You are no longer targetting your grave. Your prayers fail.", eChatType.CT_System, eChatLoc.CL_SystemWindow);
 						player.PrayTimerStop();
 					}
 				}
@@ -135,7 +128,5 @@ namespace DOL.GS.PacketHandler.Client.v168
 				GameEventMgr.Notify(GamePlayerEvent.ChangeTarget, player, null);
 			}
 		}
-
-		#endregion
 	}
 }

--- a/GameServer/packets/Client/168/QuestRemoveRequestHandler.cs
+++ b/GameServer/packets/Client/168/QuestRemoveRequestHandler.cs
@@ -54,8 +54,7 @@ namespace DOL.GS.PacketHandler.Client.v168
 				}
 			}
 
-			if (quest != null)
-				quest.AbortQuest();
+			quest?.AbortQuest();
 		}
 	}
 }

--- a/GameServer/packets/Client/168/QuestRewardChosenHandler.cs
+++ b/GameServer/packets/Client/168/QuestRewardChosenHandler.cs
@@ -28,8 +28,6 @@ namespace DOL.GS.PacketHandler.Client.v168
 	[PacketHandlerAttribute(PacketHandlerType.TCP, eClientPackets.QuestRewardChosen, "Quest Reward Choosing Handler", eClientStatus.PlayerInGame)]
 	public class QuestRewardChosenHandler : IPacketHandler
 	{
-		#region IPacketHandler Members
-
 		public void HandlePacket(GameClient client, GSPacketIn packet)
 		{
 			var response = (byte) packet.ReadByte();
@@ -51,10 +49,6 @@ namespace DOL.GS.PacketHandler.Client.v168
 
 			new QuestRewardChosenAction(client.Player, countChosen, itemsChosen, questGiverID, questID).Start(1);
 		}
-
-		#endregion
-
-		#region Nested type: QuestRewardChosenAction
 
 		/// <summary>
 		/// Send dialog response via Notify().
@@ -89,15 +83,12 @@ namespace DOL.GS.PacketHandler.Client.v168
 			/// </summary>
 			protected override void OnTick()
 			{
-				var player = (GamePlayer) m_actionSource;
+				var player = (GamePlayer)m_actionSource;
 
-				player.Notify(GamePlayerEvent.QuestRewardChosen, player,
-				              new QuestRewardChosenEventArgs(m_questGiverID, m_questID, m_countChosen, m_itemsChosen));
+				player.Notify(GamePlayerEvent.QuestRewardChosen, player, new QuestRewardChosenEventArgs(m_questGiverID, m_questID, m_countChosen, m_itemsChosen));
 
 				return;
 			}
 		}
-
-		#endregion
 	}
 }

--- a/GameServer/packets/Client/168/RegionChangeRequestHandler.cs
+++ b/GameServer/packets/Client/168/RegionChangeRequestHandler.cs
@@ -42,11 +42,9 @@ namespace DOL.GS.PacketHandler.Client.v168
 		/// </summary>
 		protected readonly Hashtable m_customJumpPointHandlers = new Hashtable();
 
-		#region IPacketHandler Members
-
 		public void HandlePacket(GameClient client, GSPacketIn packet)
 		{
-			ushort jumpSpotID = packet.ReadShort();
+			ushort jumpSpotId = packet.ReadShort();
 
 			eRealm targetRealm = client.Player.Realm;
 
@@ -57,20 +55,26 @@ namespace DOL.GS.PacketHandler.Client.v168
                 targetRealm = client.Player.CurrentZone.Realm;
 			}
 
-			var zonePoint =	GameServer.Database.SelectObjects<ZonePoint>("`Id` = @Id AND (`Realm` = @Realm OR `Realm` = @DefaultRealm OR `Realm` IS NULL)",
-			                                                             new [] { new QueryParameter("@Id", jumpSpotID), new QueryParameter("@Realm", (byte)targetRealm), new QueryParameter("@DefaultRealm", 0) }).FirstOrDefault();
+			var zonePoint =	GameServer.Database.SelectObjects<ZonePoint>(
+				"`Id` = @Id AND (`Realm` = @Realm OR `Realm` = @DefaultRealm OR `Realm` IS NULL)",
+				new [] {
+					new QueryParameter("@Id", jumpSpotId),
+					new QueryParameter("@Realm", (byte)targetRealm),
+					new QueryParameter("@DefaultRealm", 0)
+				})
+				.FirstOrDefault();
 
 			if (zonePoint == null || zonePoint.TargetRegion == 0)
 			{
-				ChatUtil.SendDebugMessage(client, "Invalid Jump (ZonePoint table): [" + jumpSpotID + "]" + ((zonePoint == null) ? ". Entry missing!" : ". TargetRegion is 0!"));
+				ChatUtil.SendDebugMessage(client, $"Invalid Jump (ZonePoint table): [{jumpSpotId}]{((zonePoint == null) ? ". Entry missing!" : ". TargetRegion is 0!")}");
 				zonePoint = new ZonePoint();
-				zonePoint.Id = jumpSpotID;
+				zonePoint.Id = jumpSpotId;
 			}
 
 			if (client.Account.PrivLevel > 1)
 			{
-				client.Out.SendMessage("JumpSpotID = " + jumpSpotID, eChatType.CT_System, eChatLoc.CL_SystemWindow);
-				client.Out.SendMessage("ZonePoint Target: Region = " + zonePoint.TargetRegion + ", ClassType = '" + zonePoint.ClassType + "'", eChatType.CT_System, eChatLoc.CL_SystemWindow);
+				client.Out.SendMessage($"JumpSpotID = {jumpSpotId}", eChatType.CT_System, eChatLoc.CL_SystemWindow);
+				client.Out.SendMessage($"ZonePoint Target: Region = {zonePoint.TargetRegion}, ClassType = \'{zonePoint.ClassType}\'", eChatType.CT_System, eChatLoc.CL_SystemWindow);
 			}
 
 			//Dinberg: Fix - some jump points are handled code side, such as instances.
@@ -90,9 +94,7 @@ namespace DOL.GS.PacketHandler.Client.v168
 						{
 							client.Out.SendMessage("This region has been disabled!", eChatType.CT_System, eChatLoc.CL_SystemWindow);
 							if (client.Account.PrivLevel == 1)
-							{
 								return;
-							}
 						}
 					}
 				}
@@ -166,10 +168,6 @@ namespace DOL.GS.PacketHandler.Client.v168
 
 			new RegionChangeRequestHandler(client.Player, zonePoint, customHandler).Start(1);
 		}
-
-		#endregion
-
-		#region Nested type: RegionChangeRequestHandler
 
 		/// <summary>
 		/// Handles player region change requests
@@ -260,7 +258,5 @@ namespace DOL.GS.PacketHandler.Client.v168
 				player.MoveTo(m_zonePoint.TargetRegion, m_zonePoint.TargetX, m_zonePoint.TargetY, m_zonePoint.TargetZ, m_zonePoint.TargetHeading);
 			}
 		}
-
-		#endregion
 	}
 }

--- a/GameServer/packets/Client/168/RegionListRequestHandler.cs
+++ b/GameServer/packets/Client/168/RegionListRequestHandler.cs
@@ -17,6 +17,7 @@
  *
  */
 using System;
+using System.Linq;
 
 namespace DOL.GS.PacketHandler.Client.v168
 {
@@ -25,6 +26,16 @@ namespace DOL.GS.PacketHandler.Client.v168
 	{
 		public void HandlePacket(GameClient client, GSPacketIn packet)
 		{
+			var slot = packet.ReadByte();
+			if (slot >= 0x14)
+				slot += 300 - 0x14;
+			else if (slot >= 0x0A)
+				slot += 200 - 0x0A;
+			else
+				slot += 100;
+			var character = client.Account.Characters.FirstOrDefault(c => c.AccountSlot == slot);
+			client.LoadPlayer(character);
+
 			client.Out.SendRegions();
 		}
 	}

--- a/GameServer/packets/Client/168/RemoveConcentrationEffectHandler.cs
+++ b/GameServer/packets/Client/168/RemoveConcentrationEffectHandler.cs
@@ -26,18 +26,12 @@ namespace DOL.GS.PacketHandler.Client.v168
 	[PacketHandlerAttribute(PacketHandlerType.TCP, eClientPackets.RemoveConcentrationEffect, "Handles Concentration Effect Remove Request", eClientStatus.PlayerInGame)]
 	public class RemoveConcentrationEffectHandler : IPacketHandler
 	{
-		#region IPacketHandler Members
-
 		public void HandlePacket(GameClient client, GSPacketIn packet)
 		{
 			int index = packet.ReadByte();
 
 			new CancelEffectHandler(client.Player, index).Start(1);
 		}
-
-		#endregion
-
-		#region Nested type: CancelEffectHandler
 
 		/// <summary>
 		/// Handles player cancel effect requests
@@ -76,13 +70,8 @@ namespace DOL.GS.PacketHandler.Client.v168
 					}
 				}
 
-				if (effect != null)
-				{
-					effect.Cancel(true);
-				}
+				effect?.Cancel(true);
 			}
 		}
-
-		#endregion
 	}
 }

--- a/GameServer/packets/Client/168/ShipHookpointInteract.cs
+++ b/GameServer/packets/Client/168/ShipHookpointInteract.cs
@@ -64,7 +64,7 @@ namespace DOL.GS.PacketHandler.Client.v168
 					}
 				default:
 					{
-						GameServer.KeepManager.Log.Error(string.Format("Unhandled ShipHookpointInteract client to server packet unk1 {0} objectOid {1} unk2 {2} slot {3} flag {4} currency {5} unk3 {6} unk4 {7} type {8} unk5 {9} unk6 {10}", unk1, objectOid, unk2, slot, flag, currency, unk3, unk4, type, unk5, unk6));
+						GameServer.KeepManager.Log.Error($"Unhandled ShipHookpointInteract client to server packet unk1 {unk1} objectOid {objectOid} unk2 {unk2} slot {slot} flag {flag} currency {currency} unk3 {unk3} unk4 {unk4} type {type} unk5 {unk5} unk6 {unk6}");
 						break;
 					}
 			}

--- a/GameServer/packets/Client/168/SiegeWeaponActionHandler.cs
+++ b/GameServer/packets/Client/168/SiegeWeaponActionHandler.cs
@@ -28,10 +28,11 @@ namespace DOL.GS.PacketHandler.Client.v168
 	{
 		public void HandlePacket(GameClient client, GSPacketIn packet)
 		{
-			packet.ReadShort();//unk
+			packet.ReadShort(); // unk
 			int action = packet.ReadByte();
-			int ammo = packet.ReadByte();//(ammo type if command = 'select ammo' ?)
-			if (client.Player.SiegeWeapon == null) return;
+			int ammo = packet.ReadByte(); // (ammo type if command = 'select ammo' ?)
+			if (client.Player.SiegeWeapon == null)
+				return;
 			if (client.Player.IsStealthed)
 			{
 				client.Out.SendMessage("You can't control a siege weapon while hidden!", eChatType.CT_System, eChatLoc.CL_SystemWindow);

--- a/GameServer/packets/Client/168/UDPInitRequestHandler.cs
+++ b/GameServer/packets/Client/168/UDPInitRequestHandler.cs
@@ -17,6 +17,7 @@
  *
  */
 using System;
+using System.Net;
 using System.Reflection;
 using log4net;
 
@@ -32,9 +33,20 @@ namespace DOL.GS.PacketHandler.Client.v168
 
 		public void HandlePacket(GameClient client, GSPacketIn packet)
 		{
-			string localIP = packet.ReadString(22);
-			ushort localPort = packet.ReadShort();
+			string localIP;
+			ushort localPort;
+			if (client.Version >= GameClient.eClientVersion.Version1124)
+			{
+				localIP = packet.ReadString(20);
+				localPort = packet.ReadShort();
+			}
+			else
+			{
+				localIP = packet.ReadString(22);
+				localPort = packet.ReadShort();
+			}
 			client.LocalIP = localIP;
+			client.UdpEndPoint = new IPEndPoint(IPAddress.Parse(localIP), localPort);
 			client.Out.SendUDPInitReply();
 		}
 	}

--- a/GameServer/packets/Client/168/UDPPingRequestHandler.cs
+++ b/GameServer/packets/Client/168/UDPPingRequestHandler.cs
@@ -41,10 +41,15 @@ namespace DOL.GS.PacketHandler.Client.v168
 		/// <returns>Non zero if function was successfull</returns>
 		public void HandlePacket(GameClient client, GSPacketIn packet)
 		{
-			string localIP = packet.ReadString(22);
-			ushort localPort = packet.ReadShort();
-			// TODO check changed localIP
-			client.LocalIP = localIP;
+			if (client.Version < GameClient.eClientVersion.Version1124)
+			{
+				string localIP = packet.ReadString(22);
+				ushort localPort = packet.ReadShort();
+				// TODO check changed localIP
+				client.LocalIP = localIP;
+			}
+			// unsure what this value is now thats sent in 1.125
+			// Its just a ping back letting the server know that UDP connection is still alive
 			client.UdpPingTime = DateTime.Now.Ticks;
 		}
 	}

--- a/GameServer/packets/Client/168/UseSkillHandler.cs
+++ b/GameServer/packets/Client/168/UseSkillHandler.cs
@@ -33,20 +33,22 @@ namespace DOL.GS.PacketHandler.Client.v168
 		/// </summary>
 		private static readonly ILog Log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
 
-		#region IPacketHandler Members
-
 		public void HandlePacket(GameClient client, GSPacketIn packet)
 		{
+			if (client.Version >= GameClient.eClientVersion.Version1124)
+			{
+				client.Player.X = (int)packet.ReadFloatLowEndian();
+				client.Player.Y = (int)packet.ReadFloatLowEndian();
+				client.Player.Z = (int)packet.ReadFloatLowEndian();
+				client.Player.CurrentSpeed = (short)packet.ReadFloatLowEndian();
+				client.Player.Heading = packet.ReadShort();
+			}
 			int flagSpeedData = packet.ReadShort();
 			int index = packet.ReadByte();
 			int type = packet.ReadByte();
 
 			new UseSkillAction(client.Player, flagSpeedData, index, type).Start(1);
 		}
-
-		#endregion
-
-		#region Nested type: UseSkillAction
 
 		/// <summary>
 		/// Handles player use skill actions
@@ -200,7 +202,5 @@ namespace DOL.GS.PacketHandler.Client.v168
 				}
 			}
 		}
-
-		#endregion
 	}
 }

--- a/GameServer/packets/Client/168/UseSlotHandler.cs
+++ b/GameServer/packets/Client/168/UseSlotHandler.cs
@@ -25,20 +25,22 @@ namespace DOL.GS.PacketHandler.Client.v168
 	[PacketHandlerAttribute(PacketHandlerType.TCP, eClientPackets.UseSlot, "Handle Player Use Slot Request.", eClientStatus.PlayerInGame)]
 	public class UseSlotHandler : IPacketHandler
 	{
-		#region IPacketHandler Members
-
 		public void HandlePacket(GameClient client, GSPacketIn packet)
 		{
+			if (client.Version >= GameClient.eClientVersion.Version1124)
+			{
+				client.Player.X = (int)packet.ReadFloatLowEndian();
+				client.Player.Y = (int)packet.ReadFloatLowEndian();
+				client.Player.Z = (int)packet.ReadFloatLowEndian();
+				client.Player.CurrentSpeed = (short)packet.ReadFloatLowEndian();
+				client.Player.Heading = packet.ReadShort();
+			}
 			int flagSpeedData = packet.ReadShort();
 			int slot = packet.ReadByte();
 			int type = packet.ReadByte();
 
 			new UseSlotAction(client.Player, flagSpeedData, slot, type).Start(1);
 		}
-
-		#endregion
-
-		#region Nested type: UseSlotAction
 
 		/// <summary>
 		/// Handles player use slot actions
@@ -94,7 +96,5 @@ namespace DOL.GS.PacketHandler.Client.v168
 				player.UseSlot(m_slot, m_useType);
 			}
 		}
-
-		#endregion
 	}
 }

--- a/GameServer/packets/Client/168/WorldInitRequestHandler.cs
+++ b/GameServer/packets/Client/168/WorldInitRequestHandler.cs
@@ -35,7 +35,7 @@ namespace DOL.GS.PacketHandler.Client.v168
 
 		public void HandlePacket(GameClient client, GSPacketIn packet)
 		{
-			if (client == null || client.Player == null)
+			if (client?.Player == null)
 				return;
 
 			client.UdpConfirm = false;

--- a/GameServer/packets/Client/168/checklosrequesthandler.cs
+++ b/GameServer/packets/Client/168/checklosrequesthandler.cs
@@ -22,21 +22,15 @@ namespace DOL.GS.PacketHandler.Client.v168
 	[PacketHandlerAttribute(PacketHandlerType.TCP, eClientPackets.CheckLOSRequest, "Handles a LoS Check Response", eClientStatus.PlayerInGame)]
 	public class CheckLOSResponseHandler : IPacketHandler
 	{
-		#region IPacketHandler Members
-
 		public void HandlePacket(GameClient client, GSPacketIn packet)
 		{
 			ushort checkerOID = packet.ReadShort();
 			ushort targetOID = packet.ReadShort();
 			ushort response = packet.ReadShort();
-			ushort unknow = packet.ReadShort();
+			packet.ReadShort();
 
 			new HandleCheckAction(client.Player, checkerOID, targetOID, response).Start(1);
 		}
-
-		#endregion
-
-		#region Nested type: HandleCheckAction
 
 		/// <summary>
 		/// Handles the LOS check response
@@ -78,30 +72,28 @@ namespace DOL.GS.PacketHandler.Client.v168
 			protected override void OnTick()
 			{
 				// Check for Old Callback first
-				
-				string key = string.Format("LOS C:0x{0} T:0x{1}", m_checkerOid, m_targetOid);
 
-				GamePlayer player = (GamePlayer) m_actionSource;
+				string key = $"LOS C:0x{m_checkerOid} T:0x{m_targetOid}";
+
+				GamePlayer player = (GamePlayer)m_actionSource;
 
 				CheckLOSResponse callback = player.TempProperties.getProperty<CheckLOSResponse>(key, null);
-				if (callback != null) 
+				if (callback != null)
 				{
-					callback(player, (ushort) m_response, (ushort) m_targetOid);
+					callback(player, (ushort)m_response, (ushort)m_targetOid);
 					player.TempProperties.removeProperty(key);
 				}
-				
-				string newkey = string.Format("LOSMGR C:0x{0} T:0x{1}", m_checkerOid, m_targetOid);
-				
+
+				string newkey = $"LOSMGR C:0x{m_checkerOid} T:0x{m_targetOid}";
+
 				CheckLOSMgrResponse new_callback = player.TempProperties.getProperty<CheckLOSMgrResponse>(newkey, null);
-				
-				if(new_callback != null)
+
+				if (new_callback != null)
 				{
-					new_callback(player, (ushort) m_response,  (ushort) m_checkerOid, (ushort) m_targetOid);
+					new_callback(player, (ushort)m_response, (ushort)m_checkerOid, (ushort)m_targetOid);
 					player.TempProperties.removeProperty(newkey);
 				}
 			}
 		}
-
-		#endregion
 	}
 }

--- a/GameServer/packets/Server/GSTCPPacketOut.cs
+++ b/GameServer/packets/Server/GSTCPPacketOut.cs
@@ -55,5 +55,10 @@ namespace DOL.GS.PacketHandler
 			base.WriteShort(0x00); //reserved for size
 			base.WriteByte(packetCode);
 		}
+
+		public override string ToString()
+		{
+			return base.ToString() + $": Size={Length - 3} ID=0x{m_packetCode:X2}";
+		}
 	}
 }

--- a/GameServer/packets/Server/GSUDPPacketOut.cs
+++ b/GameServer/packets/Server/GSUDPPacketOut.cs
@@ -62,5 +62,10 @@ namespace DOL.GS.PacketHandler
 
 			return (ushort)(Length-5);
 		}
+
+		public override string ToString()
+		{
+			return base.ToString() + $": Size={Length - 5} ID=0x{m_packetCode:X2}";
+		}
 	}
 }

--- a/GameServer/packets/Server/IPacketEncoding.cs
+++ b/GameServer/packets/Server/IPacketEncoding.cs
@@ -20,8 +20,16 @@ using System;
 
 namespace DOL.GS.PacketHandler
 {
+	public enum eEncryptionState
+	{
+		NotEncrypted = 0,
+		RSAEncrypted = 1,
+		PseudoRC4Encrypted = 2
+	}
+
 	public interface IPacketEncoding
 	{
+		eEncryptionState EncryptionState { get; set; }
 		byte[] DecryptPacket(byte[] content, bool udpPacket);
 		byte[] EncryptPacket(byte[] content, bool udpPacket);
 		byte[] SBox { get; set; }

--- a/GameServer/packets/Server/IPacketLib.cs
+++ b/GameServer/packets/Server/IPacketLib.cs
@@ -95,6 +95,7 @@ namespace DOL.GS.PacketHandler
 		Weather = 0x92,
 		DoorState = 0x99,
 		ClientRegions = 0x9E,
+		ClientRegion = 0xB1,
 		ObjectUpdate = 0xA1,
 		RemoveObject = 0xA2,
 		Quit = 0xA4,
@@ -139,6 +140,7 @@ namespace DOL.GS.PacketHandler
 		EmoteAnimation = 0xF9,
 		MoneyUpdate = 0xFA,
 		StatsUpdate = 0xFB,
+		CharacterOverview1126 = 0xFC,
 		CharacterOverview = 0xFD,
 		Realm = 0xFE,
 		MasterLevelWindow = 0x13,
@@ -633,7 +635,7 @@ namespace DOL.GS.PacketHandler
 		void SendPingReply(ulong timestamp, ushort sequence);
 		void SendRealm(eRealm realm);
 		void SendCharacterOverview(eRealm realm);
-		void SendDupNameCheckReply(string name, bool nameExists);
+		void SendDupNameCheckReply(string name, byte result);
 		void SendBadNameCheckReply(string name, bool bad);
 		void SendAttackMode(bool attackState);
 		void SendCharCreateReply(string name);
@@ -732,6 +734,7 @@ namespace DOL.GS.PacketHandler
 		void SendWeather(uint x, uint width, ushort speed, ushort fogdiffusion, ushort intensity);
 		void SendPlayerModelTypeChange(GamePlayer player, byte modelType);
 		void SendObjectDelete(GameObject obj);
+		void SendObjectDelete(ushort oid);
 		void SendObjectUpdate(GameObject obj);
 		void SendQuestListUpdate();
 		void SendQuestUpdate(AbstractQuest quest);

--- a/GameServer/packets/Server/PacketLib1104.cs
+++ b/GameServer/packets/Server/PacketLib1104.cs
@@ -322,7 +322,7 @@ namespace DOL.GS.PacketHandler
 			}
 		}
 		
-		public override void SendDupNameCheckReply(string name, bool nameExists)
+		public override void SendDupNameCheckReply(string name, byte nameExists)
 		{
 			if (m_gameClient == null || m_gameClient.Account == null)
 				return;
@@ -333,7 +333,7 @@ namespace DOL.GS.PacketHandler
 			{
 				pak.FillString(name, 30);
 				pak.FillString(m_gameClient.Account.Name, 24);
-				pak.WriteByte((byte)(nameExists ? 0x1 : 0x0));
+				pak.WriteByte(nameExists);
 				pak.Fill(0x0, 3);
 				SendTCP(pak);
 			}

--- a/GameServer/packets/Server/PacketLib1124.cs
+++ b/GameServer/packets/Server/PacketLib1124.cs
@@ -1,338 +1,6803 @@
 ﻿/*
- * DAWN OF LIGHT - The first free open source DAoC server emulator
- * 
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
- * 
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- * 
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
- *
- */
+* DAWN OF LIGHT - The first free open source DAoC server emulator
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public License
+* as published by the Free Software Foundation; either version 2
+* of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, write to the Free Software
+* Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+*
+*/
+#define NOENCRYPTION
 using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.IO;
 using System.Reflection;
+
+using DOL.Database;
+using DOL.Language;
+using DOL.AI.Brain;
+using DOL.GS.Behaviour;
+using DOL.GS.Effects;
+using DOL.GS.Housing;
+using DOL.GS.Keeps;
+using DOL.GS.PlayerTitles;
+using DOL.GS.Quests;
+using DOL.GS.RealmAbilities;
+using DOL.GS.Spells;
+using DOL.GS.Styles;
+
 using log4net;
+
 
 namespace DOL.GS.PacketHandler
 {
 	[PacketLib(1124, GameClient.eClientVersion.Version1124)]
-	public class PacketLib1124 : PacketLib1123
+	public class PacketLib1124 : AbstractPacketLib, IPacketLib
 	{
-        private static readonly ILog log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+		private static readonly ILog log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+		protected static int MAX_NAME_LENGTH = 55;
+		private const int MaxPacketLength = 2048;
+		private const ushort MAX_STORY_LENGTH = 1000;   // Via trial and error, 1.108 client.
+														// Often will cut off text around 990 but longer strings do not result in any errors. -Tolakram
+		protected byte icons;
+		public byte Icons
+		{
+			get { return icons; }
+		}
+		private byte WarlockChamberEffectId(GameSpellEffect effect)
+		{
+			return 0; // ??
+		}
 
-        /// <summary>
+		/// <summary>
+		/// Property to enable "forced" Tooltip send when Update are made to player skills, or player effects.
+		/// This can be controlled through server propertiers !
+		/// </summary>
+		public virtual bool ForceTooltipUpdate
+		{
+			get { return ServerProperties.Properties.USE_NEW_TOOLTIP_FORCEDUPDATE; }
+		}
+
+		protected string BuildTaskString()
+		{
+			if (m_gameClient.Player == null)
+				return "";
+
+			AbstractTask task = m_gameClient.Player.Task;
+			AbstractMission pMission = m_gameClient.Player.Mission;
+
+			AbstractMission gMission = null;
+			if (m_gameClient.Player.Group != null)
+				gMission = m_gameClient.Player.Group.Mission;
+
+			AbstractMission rMission = null;
+
+			//all the task info is sent in name field
+
+			string taskStr = "";
+			if (task == null)
+				taskStr = "You have no current personal task.\n";
+			else taskStr = "[" + task.Name + "] " + task.Description + ".\n";
+
+			string personalMission = "";
+			if (pMission != null)
+				personalMission = "[" + pMission.Name + "] " + pMission.Description + ".\n";
+
+			string groupMission = "";
+			if (gMission != null)
+				groupMission = "[" + gMission.Name + "] " + gMission.Description + ".\n";
+
+			string realmMission = "";
+			if (rMission != null)
+				realmMission = "[" + rMission.Name + "]" + " " + rMission.Description + ".\n";
+
+			string name = taskStr + personalMission + groupMission + realmMission;
+
+			if (name.Length > ushort.MaxValue)
+			{
+				if (log.IsWarnEnabled)
+					log.Warn("Task packet name is too long for 1.71 clients (" + name.Length + ") '" + name + "'");
+				name = name.Substring(0, ushort.MaxValue);
+			}
+			if (name.Length > 2048 - 10)
+			{
+				name = name.Substring(0, 2048 - 10 - name.Length);
+			}
+
+			return name;
+		}
+		/// <summary>
+		/// The bow prepare animation
+		/// </summary>
+		public virtual int BowPrepare
+		{
+			get { return 0x3E80; }
+		}
+
+		/// <summary>
+		/// one dual weapon hit animation
+		/// </summary>
+		public virtual int OneDualWeaponHit
+		{
+			get { return 0x3E81; }
+		}
+
+		/// <summary>
+		/// both dual weapons hit animation
+		/// </summary>
+		public virtual int BothDualWeaponHit
+		{
+			get { return 0x3E82; }
+		}
+
+		/// <summary>
+		/// The bow shoot animation
+		/// </summary>
+		public virtual int BowShoot
+		{
+			get { return 0x3E83; }
+		}
+		/// <summary>
 		/// Constructs a new PacketLib for Client Version 1.124
 		/// </summary>
 		/// <param name="client">the gameclient this lib is associated with</param>
-		public PacketLib1124(GameClient client)
-			: base(client)
+		public PacketLib1124(GameClient client) : base(client)
 		{
+			icons = 1;
 		}
 
-        /// <summary>
+		public virtual void CheckLengthHybridSkillsPacket(ref GSTCPPacketOut pak, ref int maxSkills, ref int first)
+		{
+			if (pak.Length > 1500)
+			{
+				pak.Position = 4;
+				pak.WriteByte((byte)(maxSkills - first));
+				pak.WriteByte((byte)(first == 0 ? 99 : 0x03)); //subtype
+				pak.WriteByte((byte)first);
+				SendTCP(pak);
+				pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.VariousUpdate));
+				pak.WriteByte(0x01); //subcode
+				pak.WriteByte((byte)maxSkills); //number of entry
+				pak.WriteByte(0x03); //subtype
+				pak.WriteByte((byte)first);
+				first = maxSkills;
+			}
+			maxSkills++;
+		}
+		public virtual void SendAttackMode(bool attackState)
+		{
+			if (m_gameClient.Player == null)
+				return;
+
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.AttackMode)))
+			{
+				pak.WriteByte((byte)(attackState ? 0x01 : 0x00));
+				pak.Fill(0x00, 3);
+
+				SendTCP(pak);
+			}
+		}
+		public virtual void SendBadNameCheckReply(string name, bool bad)
+		{
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.BadNameCheckReply)))
+			{
+				pak.FillString(name, 30);
+				pak.FillString(m_gameClient.Account.Name, 20);
+				pak.WriteByte((byte)(bad ? 0x0 : 0x1));
+				pak.Fill(0x0, 3);
+				SendTCP(pak);
+			}
+		}
+		public virtual void SendBlinkPanel(byte flag)
+		{
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.VisualEffect)))
+			{
+				GamePlayer player = base.m_gameClient.Player;
+
+				pak.WriteShort((ushort)player.ObjectID);
+				pak.WriteByte((byte)8);
+				pak.WriteByte((byte)flag);
+				pak.WriteByte((byte)0);
+
+				SendTCP(pak);
+			}
+		}
+		public virtual void SendCharacterOverview(eRealm realm)
+		{
+			if (realm < eRealm._FirstPlayerRealm || realm > eRealm._LastPlayerRealm)
+			{
+				throw new Exception("CharacterOverview requested for unknown realm " + realm);
+			}
+
+			int firstSlot = (byte)realm * 100;
+
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.CharacterOverview)))
+			{
+				pak.FillString(m_gameClient.Account.Name, 24);
+
+				if (m_gameClient.Account.Characters == null)
+				{
+					pak.Fill(0x0, 1880);
+				}
+				else
+				{
+					Dictionary<int, DOLCharacters> charsBySlot = new Dictionary<int, DOLCharacters>();
+					foreach (DOLCharacters c in m_gameClient.Account.Characters)
+					{
+						try
+						{
+							charsBySlot.Add(c.AccountSlot, c);
+						}
+						catch (Exception ex)
+						{
+							log.Error("SendCharacterOverview - Duplicate char in slot? Slot: " + c.AccountSlot + ", Account: " + c.AccountName, ex);
+						}
+					}
+					var itemsByOwnerID = new Dictionary<string, Dictionary<eInventorySlot, InventoryItem>>();
+
+					if (charsBySlot.Any())
+					{
+						var allItems = GameServer.Database.SelectObjects<InventoryItem>("`OwnerID` = @OwnerID AND `SlotPosition` >= @MinEquipable AND `SlotPosition` <= @MaxEquipable",
+																						charsBySlot.Select(kv => new[] { new QueryParameter("@OwnerID", kv.Value.ObjectId), new QueryParameter("@MinEquipable", (int)eInventorySlot.MinEquipable), new QueryParameter("@MaxEquipable", (int)eInventorySlot.MaxEquipable) }))
+							.SelectMany(objs => objs);
+
+						foreach (InventoryItem item in allItems)
+						{
+							try
+							{
+								if (!itemsByOwnerID.ContainsKey(item.OwnerID))
+									itemsByOwnerID.Add(item.OwnerID, new Dictionary<eInventorySlot, InventoryItem>());
+
+								itemsByOwnerID[item.OwnerID].Add((eInventorySlot)item.SlotPosition, item);
+							}
+							catch (Exception ex)
+							{
+								log.Error("SendCharacterOverview - Duplicate item on character? OwnerID: " + item.OwnerID + ", SlotPosition: " + item.SlotPosition + ", Account: " + m_gameClient.Account.Name, ex);
+							}
+						}
+					}
+
+					for (int i = firstSlot; i < (firstSlot + 10); i++)
+					{
+						DOLCharacters c = null;
+						if (!charsBySlot.TryGetValue(i, out c))
+						{
+							pak.Fill(0x0, 188);
+						}
+						else
+						{
+							Dictionary<eInventorySlot, InventoryItem> charItems = null;
+
+							if (!itemsByOwnerID.TryGetValue(c.ObjectId, out charItems))
+								charItems = new Dictionary<eInventorySlot, InventoryItem>();
+
+							byte extensionTorso = 0;
+							byte extensionGloves = 0;
+							byte extensionBoots = 0;
+
+							InventoryItem item = null;
+
+							if (charItems.TryGetValue(eInventorySlot.TorsoArmor, out item))
+								extensionTorso = item.Extension;
+
+							if (charItems.TryGetValue(eInventorySlot.HandsArmor, out item))
+								extensionGloves = item.Extension;
+
+							if (charItems.TryGetValue(eInventorySlot.FeetArmor, out item))
+								extensionBoots = item.Extension;
+
+							pak.Fill(0x00, 4);//new heading bytes in from 1.99 relocated in 1.104
+							pak.FillString(c.Name, 24);
+							pak.WriteByte(0x01);
+							pak.WriteByte((byte)c.EyeSize);
+							pak.WriteByte((byte)c.LipSize);
+							pak.WriteByte((byte)c.EyeColor);
+							pak.WriteByte((byte)c.HairColor);
+							pak.WriteByte((byte)c.FaceType);
+							pak.WriteByte((byte)c.HairStyle);
+							pak.WriteByte((byte)((extensionBoots << 4) | extensionGloves));
+							pak.WriteByte((byte)((extensionTorso << 4) | (c.IsCloakHoodUp ? 0x1 : 0x0)));
+							pak.WriteByte((byte)c.CustomisationStep); //1 = auto generate config, 2= config ended by player, 3= enable config to player
+							pak.WriteByte((byte)c.MoodType);
+							pak.Fill(0x0, 13); //0 String
+
+							string locationDescription = string.Empty;
+							Region region = WorldMgr.GetRegion((ushort)c.Region);
+							if (region != null)
+							{
+								locationDescription = m_gameClient.GetTranslatedSpotDescription(region, c.Xpos, c.Ypos, c.Zpos);
+							}
+							pak.FillString(locationDescription, 24);
+
+							string classname = "";
+							if (c.Class != 0)
+								classname = ((eCharacterClass)c.Class).ToString();
+							pak.FillString(classname, 24);
+
+							string racename = m_gameClient.RaceToTranslatedName(c.Race, c.Gender);
+							pak.FillString(racename, 24);
+
+							pak.WriteByte((byte)c.Level);
+							pak.WriteByte((byte)c.Class);
+							pak.WriteByte((byte)c.Realm);
+							pak.WriteByte((byte)((((c.Race & 0x10) << 2) + (c.Race & 0x0F)) | (c.Gender << 4))); // race max value can be 0x1F
+							pak.WriteShortLowEndian((ushort)c.CurrentModel);
+							pak.WriteByte((byte)c.Region);
+							if (region == null || (int)m_gameClient.ClientType > region.Expansion)
+								pak.WriteByte(0x00);
+							else
+								pak.WriteByte((byte)(region.Expansion + 1)); //0x04-Cata zone, 0x05 - DR zone
+							pak.WriteInt(0x0); // Internal database ID
+							pak.WriteByte((byte)c.Strength);
+							pak.WriteByte((byte)c.Dexterity);
+							pak.WriteByte((byte)c.Constitution);
+							pak.WriteByte((byte)c.Quickness);
+							pak.WriteByte((byte)c.Intelligence);
+							pak.WriteByte((byte)c.Piety);
+							pak.WriteByte((byte)c.Empathy);
+							pak.WriteByte((byte)c.Charisma);
+
+							InventoryItem rightHandWeapon = null;
+							charItems.TryGetValue(eInventorySlot.RightHandWeapon, out rightHandWeapon);
+							InventoryItem leftHandWeapon = null;
+							charItems.TryGetValue(eInventorySlot.LeftHandWeapon, out leftHandWeapon);
+							InventoryItem twoHandWeapon = null;
+							charItems.TryGetValue(eInventorySlot.TwoHandWeapon, out twoHandWeapon);
+							InventoryItem distanceWeapon = null;
+							charItems.TryGetValue(eInventorySlot.DistanceWeapon, out distanceWeapon);
+
+							InventoryItem helmet = null;
+							charItems.TryGetValue(eInventorySlot.HeadArmor, out helmet);
+							InventoryItem gloves = null;
+							charItems.TryGetValue(eInventorySlot.HandsArmor, out gloves);
+							InventoryItem boots = null;
+							charItems.TryGetValue(eInventorySlot.FeetArmor, out boots);
+							InventoryItem torso = null;
+							charItems.TryGetValue(eInventorySlot.TorsoArmor, out torso);
+							InventoryItem cloak = null;
+							charItems.TryGetValue(eInventorySlot.Cloak, out cloak);
+							InventoryItem legs = null;
+							charItems.TryGetValue(eInventorySlot.LegsArmor, out legs);
+							InventoryItem arms = null;
+							charItems.TryGetValue(eInventorySlot.ArmsArmor, out arms);
+
+							pak.WriteShortLowEndian((ushort)(helmet != null ? helmet.Model : 0));
+							pak.WriteShortLowEndian((ushort)(gloves != null ? gloves.Model : 0));
+							pak.WriteShortLowEndian((ushort)(boots != null ? boots.Model : 0));
+
+							ushort rightHandColor = 0;
+							if (rightHandWeapon != null)
+							{
+								rightHandColor = (ushort)(rightHandWeapon.Emblem != 0 ? rightHandWeapon.Emblem : rightHandWeapon.Color);
+							}
+							pak.WriteShortLowEndian(rightHandColor);
+
+							pak.WriteShortLowEndian((ushort)(torso != null ? torso.Model : 0));
+							pak.WriteShortLowEndian((ushort)(cloak != null ? cloak.Model : 0));
+							pak.WriteShortLowEndian((ushort)(legs != null ? legs.Model : 0));
+							pak.WriteShortLowEndian((ushort)(arms != null ? arms.Model : 0));
+
+							ushort helmetColor = 0;
+							if (helmet != null)
+							{
+								helmetColor = (ushort)(helmet.Emblem != 0 ? helmet.Emblem : helmet.Color);
+							}
+							pak.WriteShortLowEndian(helmetColor);
+
+							ushort glovesColor = 0;
+							if (gloves != null)
+							{
+								glovesColor = (ushort)(gloves.Emblem != 0 ? gloves.Emblem : gloves.Color);
+							}
+							pak.WriteShortLowEndian(glovesColor);
+
+							ushort bootsColor = 0;
+							if (boots != null)
+							{
+								bootsColor = (ushort)(boots.Emblem != 0 ? boots.Emblem : boots.Color);
+							}
+							pak.WriteShortLowEndian(bootsColor);
+
+							ushort leftHandWeaponColor = 0;
+							if (leftHandWeapon != null)
+							{
+								leftHandWeaponColor = (ushort)(leftHandWeapon.Emblem != 0 ? leftHandWeapon.Emblem : leftHandWeapon.Color);
+							}
+							pak.WriteShortLowEndian(leftHandWeaponColor);
+
+							ushort torsoColor = 0;
+							if (torso != null)
+							{
+								torsoColor = (ushort)(torso.Emblem != 0 ? torso.Emblem : torso.Color);
+							}
+							pak.WriteShortLowEndian(torsoColor);
+
+							ushort cloakColor = 0;
+							if (cloak != null)
+							{
+								cloakColor = (ushort)(cloak.Emblem != 0 ? cloak.Emblem : cloak.Color);
+							}
+							pak.WriteShortLowEndian(cloakColor);
+
+							ushort legsColor = 0;
+							if (legs != null)
+							{
+								legsColor = (ushort)(legs.Emblem != 0 ? legs.Emblem : legs.Color);
+							}
+							pak.WriteShortLowEndian(legsColor);
+
+							ushort armsColor = 0;
+							if (arms != null)
+							{
+								armsColor = (ushort)(arms.Emblem != 0 ? arms.Emblem : arms.Color);
+							}
+							pak.WriteShortLowEndian(armsColor);
+
+							//weapon models
+
+							pak.WriteShortLowEndian((ushort)(rightHandWeapon != null ? rightHandWeapon.Model : 0));
+							pak.WriteShortLowEndian((ushort)(leftHandWeapon != null ? leftHandWeapon.Model : 0));
+							pak.WriteShortLowEndian((ushort)(twoHandWeapon != null ? twoHandWeapon.Model : 0));
+							pak.WriteShortLowEndian((ushort)(distanceWeapon != null ? distanceWeapon.Model : 0));
+
+							if (c.ActiveWeaponSlot == (byte)DOL.GS.GameLiving.eActiveWeaponSlot.TwoHanded)
+							{
+								pak.WriteByte(0x02);
+								pak.WriteByte(0x02);
+							}
+							else if (c.ActiveWeaponSlot == (byte)DOL.GS.GameLiving.eActiveWeaponSlot.Distance)
+							{
+								pak.WriteByte(0x03);
+								pak.WriteByte(0x03);
+							}
+							else
+							{
+								byte righthand = 0xFF;
+								byte lefthand = 0xFF;
+
+								if (rightHandWeapon != null)
+									righthand = 0x00;
+
+								if (leftHandWeapon != null)
+									lefthand = 0x01;
+
+								pak.WriteByte(righthand);
+								pak.WriteByte(lefthand);
+							}
+
+							if (region == null || region.Expansion != 1)
+								pak.WriteByte(0x00);
+							else
+								pak.WriteByte(0x01); //0x01=char in SI zone, classic client can't "play"
+
+							pak.WriteByte((byte)c.Constitution);
+						}
+
+					}
+				}
+
+				pak.Fill(0x0, 94);
+				SendTCP(pak);
+			}
+		}
+		public virtual void SendCharCreateReply(string name)
+		{
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.CharacterCreateReply)))
+			{
+				pak.FillString(name, 24);
+				SendTCP(pak);
+			}
+		}
+		public virtual void SendCharResistsUpdate()
+		{
+			if (m_gameClient.Player == null)
+				return;
+
+			eResist[] updateResists =
+			{
+				eResist.Crush,
+				eResist.Slash,
+				eResist.Thrust,
+				eResist.Heat,
+				eResist.Cold,
+				eResist.Matter,
+				eResist.Body,
+				eResist.Spirit,
+				eResist.Energy,
+			};
+
+			int[] racial = new int[updateResists.Length];
+			int[] caps = new int[updateResists.Length];
+
+			int cap = (m_gameClient.Player.Level >> 1) + 1;
+			for (int i = 0; i < updateResists.Length; i++)
+			{
+				caps[i] = cap;
+			}
+
+
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.StatsUpdate)))
+			{
+
+				// racial resists
+				for (int i = 0; i < updateResists.Length; i++)
+				{
+					racial[i] = SkillBase.GetRaceResist(m_gameClient.Player.Race, updateResists[i]);
+					pak.WriteShort((ushort)racial[i]);
+				}
+
+				// buffs/debuffs only; remove base, item bonus, RA bonus, race bonus
+				for (int i = 0; i < updateResists.Length; i++)
+				{
+					int mod = m_gameClient.Player.GetModified((eProperty)updateResists[i]);
+					int buff = mod - racial[i] - m_gameClient.Player.AbilityBonus[(int)updateResists[i]] - Math.Min(caps[i], m_gameClient.Player.ItemBonus[(int)updateResists[i]]);
+					pak.WriteShort((ushort)buff);
+				}
+
+				// item bonuses
+				for (int i = 0; i < updateResists.Length; i++)
+				{
+					pak.WriteShort((ushort)(m_gameClient.Player.ItemBonus[(int)updateResists[i]]));
+				}
+
+				// item caps
+				for (int i = 0; i < updateResists.Length; i++)
+				{
+					pak.WriteByte((byte)caps[i]);
+				}
+
+				// RA bonuses
+				for (int i = 0; i < updateResists.Length; i++)
+				{
+					pak.WriteByte((byte)(m_gameClient.Player.AbilityBonus[(int)updateResists[i]]));
+				}
+
+				pak.WriteByte(0xFF); // FF if resists packet
+				pak.WriteByte(0);
+				pak.WriteShort(0);
+				pak.WriteShort(0);
+
+				SendTCP(pak);
+			}
+		}
+		public virtual void SendCharStatsUpdate()
+		{
+			if (m_gameClient.Player == null)
+				return;
+
+			eStat[] updateStats =
+			{
+				eStat.STR,
+				eStat.DEX,
+				eStat.CON,
+				eStat.QUI,
+				eStat.INT,
+				eStat.PIE,
+				eStat.EMP,
+				eStat.CHR,
+			};
+
+			int[] baseStats = new int[updateStats.Length];
+			int[] modStats = new int[updateStats.Length];
+			int[] itemCaps = new int[updateStats.Length];
+
+			int itemCap = (int)(m_gameClient.Player.Level * 1.5);
+			int bonusCap = (int)(m_gameClient.Player.Level / 2 + 1);
+			for (int i = 0; i < updateStats.Length; i++)
+			{
+				int cap = itemCap;
+				switch ((eProperty)updateStats[i])
+				{
+					case eProperty.Strength:
+						cap += m_gameClient.Player.ItemBonus[(int)eProperty.StrCapBonus];
+						break;
+					case eProperty.Dexterity:
+						cap += m_gameClient.Player.ItemBonus[(int)eProperty.DexCapBonus];
+						break;
+					case eProperty.Constitution:
+						cap += m_gameClient.Player.ItemBonus[(int)eProperty.ConCapBonus];
+						break;
+					case eProperty.Quickness:
+						cap += m_gameClient.Player.ItemBonus[(int)eProperty.QuiCapBonus];
+						break;
+					case eProperty.Intelligence:
+						cap += m_gameClient.Player.ItemBonus[(int)eProperty.IntCapBonus];
+						break;
+					case eProperty.Piety:
+						cap += m_gameClient.Player.ItemBonus[(int)eProperty.PieCapBonus];
+						break;
+					case eProperty.Charisma:
+						cap += m_gameClient.Player.ItemBonus[(int)eProperty.ChaCapBonus];
+						break;
+					case eProperty.Empathy:
+						cap += m_gameClient.Player.ItemBonus[(int)eProperty.EmpCapBonus];
+						break;
+					default: break;
+				}
+
+				if (updateStats[i] == m_gameClient.Player.CharacterClass.ManaStat)
+					cap += m_gameClient.Player.ItemBonus[(int)eProperty.AcuCapBonus];
+
+				itemCaps[i] = Math.Min(cap, itemCap + bonusCap);
+			}
+
+
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.StatsUpdate)))
+			{
+
+				// base
+				for (int i = 0; i < updateStats.Length; i++)
+				{
+					baseStats[i] = m_gameClient.Player.GetBaseStat(updateStats[i]);
+
+					if (updateStats[i] == eStat.CON)
+						baseStats[i] -= m_gameClient.Player.TotalConstitutionLostAtDeath;
+
+					pak.WriteShort((ushort)baseStats[i]);
+				}
+
+				pak.WriteShort(0);
+
+				// buffs/debuffs only; remove base, item bonus, RA bonus, class bonus
+				for (int i = 0; i < updateStats.Length; i++)
+				{
+					modStats[i] = m_gameClient.Player.GetModified((eProperty)updateStats[i]);
+
+					int abilityBonus = m_gameClient.Player.AbilityBonus[(int)updateStats[i]];
+
+					int acuityItemBonus = 0;
+					if (updateStats[i] == m_gameClient.Player.CharacterClass.ManaStat)
+					{
+						if (m_gameClient.Player.CharacterClass.ID != (int)eCharacterClass.Scout && m_gameClient.Player.CharacterClass.ID != (int)eCharacterClass.Hunter && m_gameClient.Player.CharacterClass.ID != (int)eCharacterClass.Ranger)
+						{
+							abilityBonus += m_gameClient.Player.AbilityBonus[(int)eProperty.Acuity];
+
+							if (m_gameClient.Player.CharacterClass.ClassType != eClassType.PureTank)
+								acuityItemBonus = m_gameClient.Player.ItemBonus[(int)eProperty.Acuity];
+						}
+					}
+
+					int buff = modStats[i] - baseStats[i];
+					buff -= abilityBonus;
+					buff -= Math.Min(itemCaps[i], m_gameClient.Player.ItemBonus[(int)updateStats[i]] + acuityItemBonus);
+
+					pak.WriteShort((ushort)buff);
+				}
+
+				pak.WriteShort(0);
+
+				// item bonuses
+				for (int i = 0; i < updateStats.Length; i++)
+				{
+					int acuityItemBonus = 0;
+
+					if (updateStats[i] == m_gameClient.Player.CharacterClass.ManaStat)
+					{
+						if (m_gameClient.Player.CharacterClass.ID != (int)eCharacterClass.Scout && m_gameClient.Player.CharacterClass.ID != (int)eCharacterClass.Hunter && m_gameClient.Player.CharacterClass.ID != (int)eCharacterClass.Ranger)
+						{
+
+							if (m_gameClient.Player.CharacterClass.ClassType != eClassType.PureTank)
+								acuityItemBonus = m_gameClient.Player.ItemBonus[(int)eProperty.Acuity];
+						}
+					}
+
+					pak.WriteShort((ushort)(m_gameClient.Player.ItemBonus[(int)updateStats[i]] + acuityItemBonus));
+				}
+
+				pak.WriteShort(0);
+
+				// item caps
+				for (int i = 0; i < updateStats.Length; i++)
+				{
+					pak.WriteByte((byte)itemCaps[i]);
+				}
+
+				pak.WriteByte(0);
+
+				// RA bonuses
+				for (int i = 0; i < updateStats.Length; i++)
+				{
+					int acuityItemBonus = 0;
+					if (m_gameClient.Player.CharacterClass.ClassType != eClassType.PureTank && (int)updateStats[i] == (int)m_gameClient.Player.CharacterClass.ManaStat)
+					{
+						if (m_gameClient.Player.CharacterClass.ID != (int)eCharacterClass.Scout && m_gameClient.Player.CharacterClass.ID != (int)eCharacterClass.Hunter && m_gameClient.Player.CharacterClass.ID != (int)eCharacterClass.Ranger)
+						{
+							acuityItemBonus = m_gameClient.Player.AbilityBonus[(int)eProperty.Acuity];
+						}
+					}
+					pak.WriteByte((byte)(m_gameClient.Player.AbilityBonus[(int)updateStats[i]] + acuityItemBonus));
+				}
+
+				pak.WriteByte(0);
+
+				//Why don't we and mythic use this class bonus byte?
+				//pak.Fill(0, 9);
+				//if (_gameClient.Player.CharacterClass.ID == (int)eCharacterClass.Vampiir)
+				//	pak.WriteByte((byte)(_gameClient.Player.Level - 5)); // Vampire bonuses
+				//else
+				pak.WriteByte(0x00); // FF if resists packet
+				pak.WriteByte((byte)m_gameClient.Player.TotalConstitutionLostAtDeath);
+				pak.WriteShort((ushort)m_gameClient.Player.MaxHealth);
+				pak.WriteShort(0);
+
+				SendTCP(pak);
+			}
+		}
+		public virtual void SendConcentrationList()
+		{
+			if (m_gameClient.Player == null)
+				return;
+
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.ConcentrationList)))
+			{
+				lock (m_gameClient.Player.ConcentrationEffects)
+				{
+					pak.WriteByte((byte)(m_gameClient.Player.ConcentrationEffects.Count));
+					pak.WriteByte(0); // unknown
+					pak.WriteByte(0); // unknown
+					pak.WriteByte(0); // unknown
+
+					for (int i = 0; i < m_gameClient.Player.ConcentrationEffects.Count; i++)
+					{
+						IConcentrationEffect effect = m_gameClient.Player.ConcentrationEffects[i];
+						pak.WriteByte((byte)i);
+						pak.WriteByte(0); // unknown
+						pak.WriteByte(effect.Concentration);
+						pak.WriteShort(effect.Icon);
+						if (effect.Name.Length > 14)
+							pak.WritePascalString(effect.Name.Substring(0, 12) + "..");
+						else
+							pak.WritePascalString(effect.Name);
+						if (effect.OwnerName.Length > 14)
+							pak.WritePascalString(effect.OwnerName.Substring(0, 12) + "..");
+						else
+							pak.WritePascalString(effect.OwnerName);
+					}
+				}
+				SendTCP(pak);
+			}
+
+			SendStatusUpdate(); // send status update for convinience, mostly the conc has changed
+		}
+		public virtual void SendConsignmentMerchantMoney(long money)
+		{
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.ConsignmentMerchantMoney)))
+			{
+				pak.WriteByte((byte)Money.GetCopper(money));
+				pak.WriteByte((byte)Money.GetSilver(money));
+				pak.WriteShort((ushort)Money.GetGold(money));
+
+				// Yes, these are sent in reverse order! - tolakram confirmed 1.98 - 1.109
+				pak.WriteShort((ushort)Money.GetMithril(money));
+				pak.WriteShort((ushort)Money.GetPlatinum(money));
+
+				SendTCP(pak);
+			}
+		}
+		public virtual void SendCombatAnimation(GameObject attacker, GameObject defender, ushort weaponID, ushort shieldID, int style, byte stance, byte result, byte targetHealthPercent)
+		{
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.CombatAnimation)))
+			{
+				if (attacker != null)
+					pak.WriteShort((ushort)attacker.ObjectID);
+				else
+					pak.WriteShort(0x00);
+
+				if (defender != null)
+					pak.WriteShort((ushort)defender.ObjectID);
+				else
+					pak.WriteShort(0x00);
+
+				pak.WriteShort(weaponID);
+				pak.WriteShort(shieldID);
+				pak.WriteShortLowEndian((ushort)style);
+				pak.WriteByte(stance);
+				pak.WriteByte(result);
+
+				// If Health Percent is invalid get the living Health.
+				if (defender is GameLiving && targetHealthPercent > 100)
+				{
+					targetHealthPercent = (defender as GameLiving).HealthPercent;
+				}
+
+				pak.WriteByte(targetHealthPercent);
+				pak.WriteByte(0);//unk
+				SendTCP(pak);
+			}
+		}
+		public virtual void SendControlledHorse(GamePlayer player, bool flag)
+		{
+			if (player == null || player.ObjectState != GameObject.eObjectState.Active)
+				return;
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.ControlledHorse)))
+			{
+				if (!flag || !player.HasHorse)
+				{
+					pak.WriteShort((ushort)player.ObjectID);
+					pak.Fill(0x00, 6);
+				}
+				else
+				{
+					pak.WriteShort((ushort)player.ObjectID);
+					pak.WriteByte(player.ActiveHorse.ID);
+					if (player.ActiveHorse.BardingColor == 0 && player.ActiveHorse.Barding != 0 && player.Guild != null)
+					{
+						int newGuildBitMask = (player.Guild.Emblem & 0x010000) >> 9;
+						pak.WriteByte((byte)(player.ActiveHorse.Barding | newGuildBitMask));
+						pak.WriteShort((ushort)player.Guild.Emblem);
+					}
+					else
+					{
+						pak.WriteByte(player.ActiveHorse.Barding);
+						pak.WriteShort(player.ActiveHorse.BardingColor);
+					}
+
+					pak.WriteByte(player.ActiveHorse.Saddle);
+					pak.WriteByte(player.ActiveHorse.SaddleColor);
+				}
+				SendTCP(pak);
+			}
+		}
+		public virtual void SendCrash(string str)
+		{
+			using (var pak = new GSTCPPacketOut(0x86))
+			{
+				pak.WriteByte(0xFF);
+				pak.WritePascalString(str);
+				SendTCP(pak);
+			}
+		}
+		public virtual void SendCustomTextWindow(string caption, IList<string> text)
+		{
+			if (text == null)
+				return;
+
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.DetailWindow)))
+			{
+				pak.WriteByte(0); // new in 1.75
+				pak.WriteByte(0); // new in 1.81
+				if (caption == null)
+					caption = "";
+				if (caption.Length > byte.MaxValue)
+					caption = caption.Substring(0, byte.MaxValue);
+				pak.WritePascalString(caption); //window caption
+
+				WriteCustomTextWindowData(pak, text);
+
+				//Trailing Zero!
+				pak.WriteByte(0);
+				SendTCP(pak);
+			}
+		}
+
+		/// <summary>
+		/// New system in v1.110+ for delve info. delve is cached by client in extra file, stored locally.
+		/// </summary>
+		/// <param name="info"></param>
+		public virtual void SendDelveInfo(string info)
+		{
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.DelveInfo)))
+			{
+				pak.WriteString(info, 2048);
+				pak.WriteByte(0); // 0-terminated
+				SendTCP(pak);
+			}
+		}
+
+		public virtual void SendDupNameCheckReply(string name, byte result)
+		{
+			if (m_gameClient == null || m_gameClient.Account == null)
+				return;
+
+			// This presents the user with Name Not Allowed which may not be correct but at least it prevents duplicate char creation
+			// - tolakram
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.DupNameCheckReply)))
+			{
+				pak.FillString(name, 30);
+				pak.FillString(m_gameClient.Account.Name, 24);
+				pak.WriteByte(result);
+				pak.Fill(0x0, 3);
+				SendTCP(pak);
+			}
+		}
+		public virtual void SendEnterHouse(House house)
+		{
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.HouseEnter)))
+			{
+				pak.WriteShort((ushort)house.HouseNumber);
+				pak.WriteShort((ushort)25000);         //constant!
+				pak.WriteInt((uint)house.X);
+				pak.WriteInt((uint)house.Y);
+				pak.WriteShort((ushort)house.Heading); //useless/ignored by client.
+				pak.WriteByte(0x00);
+				pak.WriteByte((byte)(house.GetGuildEmblemFlags() | (house.Emblem & 0x010000) >> 14));//new Guild Emblem
+				pak.WriteShort((ushort)house.Emblem);   //emblem
+				pak.WriteByte(0x00);
+				pak.WriteByte(0x00);
+				pak.WriteByte((byte)house.Model);
+				pak.WriteByte(0x00);
+				pak.WriteByte(0x00);
+				pak.WriteByte(0x00);
+				pak.WriteByte((byte)house.Rug1Color);
+				pak.WriteByte((byte)house.Rug2Color);
+				pak.WriteByte((byte)house.Rug3Color);
+				pak.WriteByte((byte)house.Rug4Color);
+				pak.WriteByte(0x00);
+				pak.WriteByte(0x00); // houses codemned ?
+				pak.WriteShort(0); // 0xFFBF = condemned door model
+				pak.WriteByte(0x00);
+
+				SendTCP(pak);
+			}
+		}
+		public virtual void SendFindGroupWindowUpdate(GamePlayer[] list)
+		{
+			if (m_gameClient.Player == null)
+				return;
+
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.FindGroupUpdate)))
+			{
+				if (list != null)
+				{
+					pak.WriteByte((byte)list.Length);
+					byte nbleader = 0;
+					byte nbsolo = 0x1E;
+					foreach (GamePlayer player in list)
+					{
+						if (player.Group != null)
+						{
+							pak.WriteByte(nbleader++);
+						}
+						else
+						{
+							pak.WriteByte(nbsolo++);
+						}
+						pak.WriteByte(player.Level);
+						pak.WritePascalString(player.Name);
+						pak.WriteString(player.CharacterClass.Name, 4);
+						//Dinberg:Instances - We use ZoneSkinID to bluff our way to victory and
+						//trick the client for positioning objects (as IDs are hard coded).
+						if (player.CurrentZone != null)
+							pak.WriteShort(player.CurrentZone.ZoneSkinID);
+						else
+							pak.WriteShort(0); // ?
+						pak.WriteByte(0); // duration
+						pak.WriteByte(0); // objective
+						pak.WriteByte(0);
+						pak.WriteByte(0);
+						pak.WriteByte((byte)(player.Group != null ? 1 : 0));
+						pak.WriteByte(0);
+					}
+				}
+				else
+				{
+					pak.WriteByte(0);
+				}
+				SendTCP(pak);
+			}
+		}
+		public virtual void SendGameOpenReply()
+		{
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.GameOpenReply)))
+			{
+				pak.WriteByte(0x00);
+				SendTCP(pak);
+			}
+		}
+		public virtual void SendGarden(House house)
+		{
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.HouseChangeGarden)))
+			{
+				pak.WriteShort((ushort)house.HouseNumber);
+				pak.WriteShort(0); // sheduled for repossession (in hours) new in 1.89b+
+				pak.WriteByte((byte)house.OutdoorItems.Count);
+				pak.WriteByte(0x80);
+
+				foreach (var entry in house.OutdoorItems.OrderBy(entry => entry.Key))
+				{
+					OutdoorItem item = entry.Value;
+					pak.WriteByte((byte)entry.Key);
+					pak.WriteShort((ushort)item.Model);
+					pak.WriteByte((byte)item.Position);
+					pak.WriteByte((byte)item.Rotation);
+				}
+
+				SendTCP(pak);
+			}
+
+			// Update cache
+			m_gameClient.HouseUpdateArray.UpdateIfExists(new Tuple<ushort, ushort>(house.RegionID, (ushort)house.HouseNumber), GameTimer.GetTickCount());
+		}
+		public virtual void SendGarden(House house, int i)
+		{
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.HouseChangeGarden)))
+			{
+				pak.WriteShort((ushort)house.HouseNumber);
+				pak.WriteShort(0); // sheduled for repossession (in hours) new in 1.89b+
+				pak.WriteByte(0x01);
+				pak.WriteByte(0x00); // update
+				OutdoorItem item = (OutdoorItem)house.OutdoorItems[i];
+				pak.WriteByte((byte)i);
+				pak.WriteShort((ushort)item.Model);
+				pak.WriteByte((byte)item.Position);
+				pak.WriteByte((byte)item.Rotation);
+				SendTCP(pak);
+			}
+
+			// Update cache
+			m_gameClient.HouseUpdateArray.UpdateIfExists(new Tuple<ushort, ushort>(house.RegionID, (ushort)house.HouseNumber), GameTimer.GetTickCount());
+		}
+		public virtual void SendGroupWindowUpdate()
+		{
+			if (m_gameClient.Player == null) return;
+
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.VariousUpdate)))
+			{
+				pak.WriteByte(0x06);
+
+				Group group = m_gameClient.Player.Group;
+				if (group == null)
+				{
+					pak.WriteByte(0x00);
+				}
+				else
+				{
+					pak.WriteByte(group.MemberCount);
+				}
+
+				pak.WriteByte(0x01);
+				pak.WriteByte(0x00);
+
+				if (group != null)
+				{
+					foreach (GameLiving living in group.GetMembersInTheGroup())
+					{
+						bool sameRegion = living.CurrentRegion == m_gameClient.Player.CurrentRegion;
+
+						pak.WriteByte(living.Level);
+						if (sameRegion)
+						{
+							pak.WriteByte(living.HealthPercentGroupWindow);
+							pak.WriteByte(living.ManaPercent);
+							pak.WriteByte(living.EndurancePercent); //new in 1.69
+
+							byte playerStatus = 0;
+							if (!living.IsAlive)
+								playerStatus |= 0x01;
+							if (living.IsMezzed)
+								playerStatus |= 0x02;
+							if (living.IsDiseased)
+								playerStatus |= 0x04;
+							if (SpellHelper.FindEffectOnTarget(living, "DamageOverTime") != null)
+								playerStatus |= 0x08;
+							if (living is GamePlayer && ((GamePlayer)living).Client.ClientState == GameClient.eClientState.Linkdead)
+								playerStatus |= 0x10;
+							if (living.CurrentRegion != m_gameClient.Player.CurrentRegion)
+								playerStatus |= 0x20;
+
+							pak.WriteByte(playerStatus);
+							// 0x00 = Normal , 0x01 = Dead , 0x02 = Mezzed , 0x04 = Diseased , 
+							// 0x08 = Poisoned , 0x10 = Link Dead , 0x20 = In Another Region
+
+							pak.WriteShort((ushort)living.ObjectID);//or session id?
+						}
+						else
+						{
+							pak.WriteInt(0x20);
+							pak.WriteShort(0);
+						}
+						pak.WritePascalString(living.Name);
+						pak.WritePascalString(living is GamePlayer ? ((GamePlayer)living).CharacterClass.Name : "NPC");//classname
+					}
+				}
+				SendTCP(pak);
+			}
+		}
+		public virtual void SendHookPointStore(GameKeepHookPoint hookPoint)
+		{
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.KeepComponentHookpointStore)))
+			{
+
+				pak.WriteShort((ushort)hookPoint.Component.AbstractKeep.KeepID);
+				pak.WriteShort((ushort)hookPoint.Component.ID);
+				pak.WriteShort((ushort)hookPoint.ID);
+				pak.Fill(0x01, 3);
+				HookPointInventory inventory;
+				if (hookPoint.ID > 0x80) inventory = HookPointInventory.YellowHPInventory; //oil
+				else if (hookPoint.ID > 0x60) inventory = HookPointInventory.GreenHPInventory;//big siege
+				else if (hookPoint.ID > 0x40) inventory = HookPointInventory.LightGreenHPInventory; //small siege
+				else if (hookPoint.ID > 0x20) inventory = HookPointInventory.BlueHPInventory;//npc
+				else inventory = HookPointInventory.RedHPInventory;//guard
+
+				pak.WriteByte((byte)inventory.GetAllItems().Count);//count
+				pak.WriteShort(0);
+				int i = 0;
+				foreach (HookPointItem item in inventory.GetAllItems())
+				{
+					//TODO : must be quite like the merchant item.
+					//the problem is to change how it is done maybe make the hookpoint item inherit from an interface in common with itemtemplate. have to think to that.
+					pak.WriteByte((byte)i);
+					i++;
+					if (item.GameObjectType == "GameKeepGuard")//TODO: hack wrong must think how design thing to have merchante of gameobject(living or item)
+						pak.WriteShort(0);
+					else
+						pak.WriteShort(item.Flag);
+					pak.WriteShort(0);
+					pak.WriteShort(0);
+					pak.WriteShort(0);
+					pak.WriteInt((uint)item.Gold);
+					pak.WriteShort(item.Icon);
+					pak.WritePascalString(item.Name);//item sell
+				}
+				SendTCP(pak);
+			}
+		}
+		public virtual void SendHouse(House house)
+		{
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.HouseCreate)))
+			{
+				pak.WriteShort((ushort)house.HouseNumber);
+				pak.WriteShort((ushort)house.Z);
+				pak.WriteInt((uint)house.X);
+				pak.WriteInt((uint)house.Y);
+				pak.WriteShort((ushort)house.Heading);
+				pak.WriteShort((ushort)house.PorchRoofColor);
+				int flagPorchAndGuildEmblem = (house.Emblem & 0x010000) >> 13;//new Guild Emblem
+				if (house.Porch)
+					flagPorchAndGuildEmblem |= 1;
+				if (house.OutdoorGuildBanner)
+					flagPorchAndGuildEmblem |= 2;
+				if (house.OutdoorGuildShield)
+					flagPorchAndGuildEmblem |= 4;
+				pak.WriteShort((ushort)flagPorchAndGuildEmblem);
+				pak.WriteShort((ushort)house.Emblem);
+				pak.WriteShort(0); // new in 1.89b+ (scheduled for resposession XXX hourses ago)
+				pak.WriteByte((byte)house.Model);
+				pak.WriteByte((byte)house.RoofMaterial);
+				pak.WriteByte((byte)house.WallMaterial);
+				pak.WriteByte((byte)house.DoorMaterial);
+				pak.WriteByte((byte)house.TrussMaterial);
+				pak.WriteByte((byte)house.PorchMaterial);
+				pak.WriteByte((byte)house.WindowMaterial);
+				pak.WriteByte(0);
+				pak.WriteShort(0); // new in 1.89b+
+				pak.WritePascalString(house.Name);
+
+				SendTCP(pak);
+			}
+
+			// Update cache
+			m_gameClient.HouseUpdateArray[new Tuple<ushort, ushort>(house.RegionID, (ushort)house.HouseNumber)] = GameTimer.GetTickCount();
+		}
+		public virtual void SendHouseOccupied(House house, bool flagHouseOccuped)
+		{
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.HouseChangeGarden)))
+			{
+				pak.WriteShort((ushort)house.HouseNumber);
+				pak.WriteShort(0); // sheduled for repossession (in hours) new in 1.89b+
+				pak.WriteByte(0x00);
+				pak.WriteByte((byte)(flagHouseOccuped ? 1 : 0));
+
+				SendTCP(pak);
+			}
+
+			// Update cache
+			m_gameClient.HouseUpdateArray.UpdateIfExists(new Tuple<ushort, ushort>(house.RegionID, (ushort)house.HouseNumber), GameTimer.GetTickCount());
+		}
+		public virtual void SendHexEffect(GamePlayer player, byte effect1, byte effect2, byte effect3, byte effect4, byte effect5)
+		{
+			if (player == null)
+				return;
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.VisualEffect)))
+			{
+				pak.WriteShort((ushort)player.ObjectID);
+				pak.WriteByte(0x3); // show Hex
+				pak.WriteByte(effect1);
+				pak.WriteByte(effect2);
+				pak.WriteByte(effect3);
+				pak.WriteByte(effect4);
+				pak.WriteByte(effect5);
+
+				SendTCP(pak);
+			}
+		}
+		/// <summary>
+		/// New inventory update handler. This handler takes into account that
+		/// a slot on the client isn't necessarily the same as a slot on the
+		/// server, e.g. house vaults.
+		/// </summary>
+		/// <param name="updateItems"></param>
+		/// <param name="windowType"></param>
+		public virtual void SendInventoryItemsUpdate(IDictionary<int, InventoryItem> updateItems, eInventoryWindowType windowType)
+		{
+			if (m_gameClient.Player == null)
+				return;
+			if (updateItems == null)
+				updateItems = new Dictionary<int, InventoryItem>();
+			if (updateItems.Count <= ServerProperties.Properties.MAX_ITEMS_PER_PACKET)
+			{
+				SendInventoryItemsPartialUpdate(updateItems, windowType);
+				return;
+			}
+
+			var items = new Dictionary<int, InventoryItem>(ServerProperties.Properties.MAX_ITEMS_PER_PACKET);
+			foreach (var item in updateItems)
+			{
+				items.Add(item.Key, item.Value);
+				if (items.Count >= ServerProperties.Properties.MAX_ITEMS_PER_PACKET)
+				{
+					SendInventoryItemsPartialUpdate(items, windowType);
+					items.Clear();
+					windowType = eInventoryWindowType.Update;
+				}
+			}
+
+			if (items.Count > 0)
+				SendInventoryItemsPartialUpdate(items, windowType);
+		}
+		/// <summary>
+		/// Sends inventory items to the client.  If windowType is one of the client inventory windows then the client
+		/// will display the window.  Once the window is displayed to the client all handling of items in the window
+		/// is done in the move item request handlers
+		/// </summary>
+		/// <param name="items"></param>
+		/// <param name="windowType"></param>
+		protected virtual void SendInventoryItemsPartialUpdate(IDictionary<int, InventoryItem> items, eInventoryWindowType windowType)
+		{
+			//ChatUtil.SendDebugMessage(_gameClient, string.Format("SendItemsPartialUpdate: windowType: {0}, {1}", windowType, items == null ? "nothing" : items[0].Name));
+
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.InventoryUpdate)))
+			{
+				GameVault houseVault = m_gameClient.Player.ActiveInventoryObject as GameVault;
+				pak.WriteByte((byte)(items.Count));
+				pak.WriteByte(0x00); // new in 189b+, show shield in left hand
+				pak.WriteByte((byte)((m_gameClient.Player.IsCloakInvisible ? 0x01 : 0x00) | (m_gameClient.Player.IsHelmInvisible ? 0x02 : 0x00))); // new in 189b+, cloack/helm visibility
+				if (windowType == eInventoryWindowType.HouseVault && houseVault != null)
+					pak.WriteByte((byte)(houseVault.Index + 1));    // Add the vault number to the window caption
+				else
+					pak.WriteByte((byte)((m_gameClient.Player.IsCloakHoodUp ? 0x01 : 0x00) | (int)m_gameClient.Player.ActiveQuiverSlot)); //bit0 is hood up bit4 to 7 is active quiver
+																																	  // ^ in 1.89b+, 0 bit - showing hooded cloack, if not hooded not show cloack at all ?
+				pak.WriteByte(m_gameClient.Player.VisibleActiveWeaponSlots);
+				pak.WriteByte((byte)windowType);
+				foreach (var entry in items)
+				{
+					pak.WriteByte((byte)(entry.Key));
+					WriteItemData(pak, entry.Value);
+				}
+				SendTCP(pak);
+			}
+		}
+		/// <summary>
+		/// Legacy inventory update. This handler silently
+		/// assumes that a slot on the client matches a slot on the server.
+		/// </summary>
+		/// <param name="slots"></param>
+		/// <param name="preAction"></param>
+		protected virtual void SendInventorySlotsUpdateRange(ICollection<int> slots, eInventoryWindowType windowType)
+		{
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.InventoryUpdate)))
+			{
+				GameVault houseVault = m_gameClient.Player.ActiveInventoryObject as GameVault;
+
+				pak.WriteByte((byte)(slots == null ? 0 : slots.Count));
+				pak.WriteByte(0); // CurrentSpeed & 0xFF (not used for player, only for NPC)
+				pak.WriteByte((byte)((m_gameClient.Player.IsCloakInvisible ? 0x01 : 0x00) | (m_gameClient.Player.IsHelmInvisible ? 0x02 : 0x00))); // new in 189b+, cloack/helm visibility
+
+				if (windowType == eInventoryWindowType.HouseVault && houseVault != null)
+				{
+					pak.WriteByte((byte)(houseVault.Index + 1));    // Add the vault number to the window caption
+				}
+				else
+				{
+					pak.WriteByte((byte)((m_gameClient.Player.IsCloakHoodUp ? 0x01 : 0x00) | (int)m_gameClient.Player.ActiveQuiverSlot)); //bit0 is hood up bit4 to 7 is active quiver
+				}
+
+				pak.WriteByte((byte)m_gameClient.Player.VisibleActiveWeaponSlots);
+				pak.WriteByte((byte)windowType);
+
+				if (slots != null)
+				{
+					foreach (int updatedSlot in slots)
+					{
+						if (updatedSlot >= (int)eInventorySlot.Consignment_First && updatedSlot <= (int)eInventorySlot.Consignment_Last)
+						{
+							log.Error("PacketLib198:SendInventorySlotsUpdateBase - GameConsignmentMerchant inventory is no longer cached with player.  Use a Dictionary<int, InventoryItem> instead.");
+							pak.WriteByte((byte)(updatedSlot - (int)eInventorySlot.Consignment_First + (int)eInventorySlot.HousingInventory_First));
+						}
+						else
+						{
+							pak.WriteByte((byte)(updatedSlot));
+						}
+
+						WriteItemData(pak, m_gameClient.Player.Inventory.GetItem((eInventorySlot)(updatedSlot)));
+
+					}
+				}
+
+				SendTCP(pak);
+			}
+		}
+		public virtual void SendKeepClaim(IGameKeep keep, byte flag)
+		{
+			if (m_gameClient.Player == null || keep == null)
+				return;
+
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.KeepClaim)))
+			{
+
+				pak.WriteShort((ushort)keep.KeepID);
+				pak.WriteByte(flag);//0-Info,1-KeepTargetLevel,2-KeepLordType,4-Release
+				pak.WriteByte((byte)1); //Keep Lord Type: always melee, type is no longer used
+				pak.WriteByte((byte)ServerProperties.Properties.MAX_KEEP_LEVEL);
+				pak.WriteByte((byte)keep.Level);
+				SendTCP(pak);
+			}
+		}
+		/// <summary>
+		/// Default Keep Model changed for 1.1115
+		/// </summary>
+		/// <param name="keep"></param>
+		public virtual void SendKeepInfo(IGameKeep keep)
+		{
+			if (m_gameClient.Player == null)
+				return;
+
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.KeepInfo)))
+			{
+				pak.WriteShort((ushort)keep.KeepID);
+				pak.WriteShort(0);
+				pak.WriteInt((uint)keep.X);
+				pak.WriteInt((uint)keep.Y);
+				pak.WriteShort((ushort)keep.Heading);
+				pak.WriteByte((byte)keep.Realm);
+				pak.WriteByte((byte)keep.Level);//level
+				pak.WriteShort(0);//unk
+				pak.WriteByte(0);//model // patch 0072
+				pak.WriteByte(0);//unk
+
+				SendTCP(pak);
+			}
+		}
+		public virtual void SendKeepRealmUpdate(IGameKeep keep)
+		{
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.KeepRealmUpdate)))
+			{
+
+				pak.WriteShort((ushort)keep.KeepID);
+				pak.WriteByte((byte)keep.Realm);
+				pak.WriteByte((byte)keep.Level);
+				SendTCP(pak);
+			}
+		}
+		public virtual void SendClearKeepComponentHookPoint(IGameKeepComponent component, int selectedHookPointIndex)
+		{
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.KeepComponentHookpointUpdate)))
+			{
+				pak.WriteShort((ushort)component.Keep.KeepID);
+				pak.WriteShort((ushort)component.ID);
+				pak.WriteByte((byte)0);
+				pak.WriteByte((byte)selectedHookPointIndex);
+				SendTCP(pak);
+			}
+		}
+		public virtual void SendKeepComponentInfo(IGameKeepComponent keepComponent)
+		{
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.KeepComponentInfo)))
+			{
+
+				pak.WriteShort((ushort)keepComponent.Keep.KeepID);
+				pak.WriteShort((ushort)keepComponent.ID);
+				pak.WriteInt((uint)keepComponent.ObjectID);
+				pak.WriteByte((byte)keepComponent.Skin);
+				pak.WriteByte((byte)(keepComponent.ComponentX));//relative to keep
+				pak.WriteByte((byte)(keepComponent.ComponentY));//relative to keep
+				pak.WriteByte((byte)keepComponent.ComponentHeading);
+				pak.WriteByte((byte)keepComponent.Height);
+				pak.WriteByte(keepComponent.HealthPercent);
+				byte flag = keepComponent.Status;
+				if (keepComponent.IsRaized) // Only for towers
+					flag |= 0x04;
+				if (flag == 0x00 && keepComponent.Climbing)
+					flag = 0x02;
+				pak.WriteByte(flag);
+				pak.WriteByte(0x00); //unk
+				SendTCP(pak);
+			}
+		}
+		public virtual void SendKeepComponentDetailUpdate(IGameKeepComponent keepComponent)
+		{
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.KeepComponentDetailUpdate)))
+			{
+				pak.WriteShort((ushort)keepComponent.Keep.KeepID);
+				pak.WriteShort((ushort)keepComponent.ID);
+				pak.WriteByte((byte)keepComponent.Height);
+				pak.WriteByte(keepComponent.HealthPercent);
+				byte flag = keepComponent.Status;
+
+				if (keepComponent.IsRaized) // Only for towers
+					flag |= 0x04;
+
+				if (flag == 0x00 && keepComponent.Climbing)
+					flag = 0x02;
+
+				pak.WriteByte(flag);
+				pak.WriteByte(0x00);//unk
+				SendTCP(pak);
+			}
+		}
+		public virtual void SendKeepComponentRemove(IGameKeepComponent keepComponent)
+		{
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.KeepComponentRemove)))
+			{
+				pak.WriteShort((ushort)keepComponent.Keep.KeepID);
+				pak.WriteShort((ushort)keepComponent.ID);
+				SendTCP(pak);
+			}
+		}
+		public virtual void SendKeepComponentUpdate(IGameKeep keep, bool LevelUp)
+		{
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.KeepComponentUpdate)))
+			{
+
+				pak.WriteShort((ushort)keep.KeepID);
+				pak.WriteByte((byte)keep.Realm);
+				pak.WriteByte((byte)keep.Level);
+				pak.WriteByte((byte)keep.SentKeepComponents.Count);
+				foreach (IGameKeepComponent component in keep.SentKeepComponents)
+				{
+					byte m_flag = (byte)component.Height;
+					if (component.Status == 0 && component.Climbing)
+						m_flag |= 0x80;
+					if (component.IsRaized) // Only for towers
+						m_flag |= 0x10;
+					if (LevelUp)
+						m_flag |= 0x20;
+					if (!component.IsAlive)
+						m_flag |= 0x40;
+					pak.WriteByte(m_flag);
+				}
+				pak.WriteByte((byte)0);//unk
+				SendTCP(pak);
+			}
+		}
+		public virtual void SendKeepComponentInteract(IGameKeepComponent component)
+		{
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.KeepComponentInteractResponse)))
+			{
+				pak.WriteShort((ushort)component.Keep.KeepID);
+				pak.WriteByte((byte)component.Keep.Realm);
+				pak.WriteByte(component.HealthPercent);
+
+				pak.WriteByte(component.Keep.EffectiveLevel(component.Keep.Level));
+				pak.WriteByte(component.Keep.EffectiveLevel((byte)ServerProperties.Properties.MAX_KEEP_LEVEL));
+				//guild
+				pak.WriteByte((byte)1); //Keep Type: always melee here, type is no longer used
+
+				if (component.Keep.Guild != null)
+				{
+					pak.WriteString(component.Keep.Guild.Name);
+				}
+				pak.WriteByte(0);
+				SendTCP(pak);
+			}
+		}
+
+		public virtual void SendKeepComponentHookPoint(IGameKeepComponent component, int selectedHookPointIndex)
+		{
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.KeepComponentHookpointUpdate)))
+			{
+				pak.WriteShort((ushort)component.Keep.KeepID);
+				pak.WriteShort((ushort)component.ID);
+				ArrayList freeHookpoints = new ArrayList();
+				foreach (GameKeepHookPoint hookPt in component.HookPoints.Values)
+				{
+					if (hookPt.IsFree) freeHookpoints.Add(hookPt);
+				}
+				pak.WriteByte((byte)freeHookpoints.Count);
+				pak.WriteByte((byte)selectedHookPointIndex);
+				foreach (GameKeepHookPoint hookPt in freeHookpoints)//have to sort by index?
+				{
+					pak.WriteByte((byte)hookPt.ID);
+				}
+				SendTCP(pak);
+			}
+		}
+		public virtual void SendKeepRemove(IGameKeep keep)
+		{
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.KeepRemove)))
+			{
+
+				pak.WriteShort((ushort)keep.KeepID);
+				SendTCP(pak);
+			}
+		}
+		public virtual void SendLivingEquipmentUpdate(GameLiving living)
+		{
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.EquipmentUpdate)))
+			{
+
+				ICollection<InventoryItem> items = null;
+				if (living.Inventory != null)
+					items = living.Inventory.VisibleItems;
+
+				pak.WriteShort((ushort)living.ObjectID);
+				pak.WriteByte((byte)living.VisibleActiveWeaponSlots);
+				pak.WriteByte((byte)living.CurrentSpeed); // new in 189b+, speed
+				pak.WriteByte((byte)((living.IsCloakInvisible ? 0x01 : 0x00) | (living.IsHelmInvisible ? 0x02 : 0x00))); // new in 189b+, cloack/helm visibility
+				pak.WriteByte((byte)((living.IsCloakHoodUp ? 0x01 : 0x00) | (int)living.ActiveQuiverSlot)); //bit0 is hood up bit4 to 7 is active quiver
+
+				if (items != null)
+				{
+					pak.WriteByte((byte)items.Count);
+					foreach (InventoryItem item in items)
+					{
+						ushort model = (ushort)(item.Model & 0x1FFF);
+						int slot = item.SlotPosition;
+						//model = GetModifiedModel(model);
+						int texture = item.Emblem != 0 ? item.Emblem : item.Color;
+						if (item.SlotPosition == Slot.LEFTHAND || item.SlotPosition == Slot.CLOAK) // for test only cloack and shield
+							slot = slot | ((texture & 0x010000) >> 9); // slot & 0x80 if new emblem
+						pak.WriteByte((byte)slot);
+						if ((texture & ~0xFF) != 0)
+							model |= 0x8000;
+						else if ((texture & 0xFF) != 0)
+							model |= 0x4000;
+						if (item.Effect != 0)
+							model |= 0x2000;
+
+						pak.WriteShort(model);
+
+						if (item.SlotPosition > Slot.RANGED || item.SlotPosition < Slot.RIGHTHAND)
+							pak.WriteByte((byte)item.Extension);
+
+						if ((texture & ~0xFF) != 0)
+							pak.WriteShort((ushort)texture);
+						else if ((texture & 0xFF) != 0)
+							pak.WriteByte((byte)texture);
+						if (item.Effect != 0)
+							pak.WriteShort((byte)item.Effect); // effect changed to short
+					}
+				}
+				else
+				{
+					pak.WriteByte(0x00);
+				}
+				SendTCP(pak);
+			}
+		}
+		public virtual void SendLivingDataUpdate(GameLiving living, bool updateStrings)
+		{
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.ObjectDataUpdate)))
+			{
+				pak.WriteShort((ushort)living.ObjectID);
+				pak.WriteByte(0);
+				pak.WriteByte(living.Level);
+				GamePlayer player = living as GamePlayer;
+				if (player != null)
+				{
+					pak.WritePascalString(GameServer.ServerRules.GetPlayerGuildName(m_gameClient.Player, player));
+					pak.WritePascalString(GameServer.ServerRules.GetPlayerLastName(m_gameClient.Player, player));
+				}
+				else if (!updateStrings)
+				{
+					pak.WriteByte(0xFF);
+				}
+				else
+				{
+					pak.WritePascalString(living.GuildName);
+					pak.WritePascalString(living.Name);
+				}
+				SendTCP(pak);
+			}
+		}
+		public virtual void SendLoginDenied(eLoginError et)
+		{
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.LoginDenied)))
+			{
+				pak.WriteByte((byte)et); // Error Code
+										 /*
+									 if(is_si)
+										 pak.WriteByte(0x32);
+									 else
+										 pak.WriteByte(0x31);
+										  */
+				pak.WriteByte(0x01);
+				pak.WriteByte(ParseVersion((int)m_gameClient.Version, true));
+				pak.WriteByte(ParseVersion((int)m_gameClient.Version, false));
+				//pak.WriteByte(build);
+				pak.WriteByte(0x00);
+				SendTCP(pak);
+			}
+		}
+		public virtual void SendLoginGranted()
+		{
+			//[Freya] Nidel: Can use realm button in character selection screen
+
+			if (ServerProperties.Properties.ALLOW_ALL_REALMS || m_gameClient.Account.PrivLevel > (int)ePrivLevel.Player)
+			{
+				SendLoginGranted(1);
+			}
+			else
+			{
+				SendLoginGranted(GameServer.ServerRules.GetColorHandling(m_gameClient));
+			}
+		}
+		public virtual void SendLoginGranted(byte color)
+		{
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.LoginGranted)))
+			{
+				pak.WritePascalString(m_gameClient.Account.Name);
+				pak.WritePascalString(GameServer.Instance.Configuration.ServerNameShort); //server name
+				pak.WriteByte(0x0C); //Server ID
+				pak.WriteByte(color);
+				pak.WriteByte(0x00);
+				pak.WriteByte(0x00);
+				SendTCP(pak);
+			}
+		}
+		public virtual void SendMarketExplorerWindow()
+		{
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.MarketExplorerWindow)))
+			{
+				pak.WriteByte(255);
+				pak.Fill(0, 3);
+				SendTCP(pak);
+			}
+		}
+
+		public virtual void SendMarketExplorerWindow(IList<InventoryItem> items, byte page, byte maxpage)
+		{
+			if (m_gameClient == null || m_gameClient.Player == null)
+				return;
+
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.MarketExplorerWindow)))
+			{
+				pak.WriteByte((byte)items.Count);
+				pak.WriteByte(page);
+				pak.WriteByte(maxpage);
+				pak.WriteByte(0);
+				foreach (InventoryItem item in items)
+				{
+					pak.WriteByte((byte)items.IndexOf(item));
+					pak.WriteByte((byte)item.Level);
+					int value1; // some object types use this field to display count
+					int value2; // some object types use this field to display count
+					switch (item.Object_Type)
+					{
+						case (int)eObjectType.Arrow:
+						case (int)eObjectType.Bolt:
+						case (int)eObjectType.Poison:
+						case (int)eObjectType.GenericItem:
+							value1 = item.PackSize;
+							value2 = item.SPD_ABS; break;
+						case (int)eObjectType.Thrown:
+							value1 = item.DPS_AF;
+							value2 = item.PackSize; break;
+						case (int)eObjectType.Instrument:
+							value1 = (item.DPS_AF == 2 ? 0 : item.DPS_AF); // 0x00 = Lute ; 0x01 = Drum ; 0x03 = Flute
+							value2 = 0; break; // unused
+						case (int)eObjectType.Shield:
+							value1 = item.Type_Damage;
+							value2 = item.DPS_AF; break;
+						case (int)eObjectType.GardenObject:
+						case (int)eObjectType.HouseWallObject:
+						case (int)eObjectType.HouseFloorObject:
+							value1 = 0;
+							value2 = item.SPD_ABS; break;
+						default:
+							value1 = item.DPS_AF;
+							value2 = item.SPD_ABS; break;
+					}
+					pak.WriteByte((byte)value1);
+					pak.WriteByte((byte)value2);
+					if (item.Object_Type == (int)eObjectType.GardenObject)
+						pak.WriteByte((byte)(item.DPS_AF));
+					else
+						pak.WriteByte((byte)(item.Hand << 6));
+					pak.WriteByte((byte)((item.Type_Damage > 3 ? 0 : item.Type_Damage << 6) | item.Object_Type));
+					pak.WriteByte((byte)(m_gameClient.Player.HasAbilityToUseItem(item.Template) ? 0 : 1));
+					pak.WriteShort((ushort)(item.PackSize > 1 ? item.Weight * item.PackSize : item.Weight));
+					pak.WriteByte((byte)item.ConditionPercent);
+					pak.WriteByte((byte)item.DurabilityPercent);
+					pak.WriteByte((byte)item.Quality);
+					pak.WriteByte((byte)item.Bonus);
+					pak.WriteShort((ushort)item.Model);
+					if (item.Emblem != 0)
+						pak.WriteShort((ushort)item.Emblem);
+					else
+						pak.WriteShort((ushort)item.Color);
+					pak.WriteShort((byte)item.Effect);
+					pak.WriteShort(item.OwnerLot);//lot
+					pak.WriteInt((uint)item.SellPrice);
+
+					if (ServerProperties.Properties.CONSIGNMENT_USE_BP)
+					{
+						string bpPrice = "";
+						if (item.SellPrice > 0)
+							bpPrice = "[" + item.SellPrice.ToString() + " BP";
+
+						if (item.Count > 1)
+							pak.WritePascalString(item.Count + " " + item.Name);
+						else if (item.PackSize > 1)
+							pak.WritePascalString(item.PackSize + " " + item.Name + bpPrice);
+						else
+							pak.WritePascalString(item.Name + bpPrice);
+					}
+					else
+					{
+						if (item.Count > 1)
+							pak.WritePascalString(item.Count + " " + item.Name);
+						else if (item.PackSize > 1)
+							pak.WritePascalString(item.PackSize + " " + item.Name);
+						else
+							pak.WritePascalString(item.Name);
+					}
+				}
+
+				SendTCP(pak);
+			}
+		}
+		public virtual void SendMasterLevelWindow(byte ml)
+		{
+			if (m_gameClient == null || m_gameClient.Player == null)
+				return;
+
+			// If required ML=0 then send current player ML data
+			byte mlToSend = (byte)(ml == 0 ? (m_gameClient.Player.MLLevel == 0 ? 1 : m_gameClient.Player.MLLevel) : ml);
+
+			if (mlToSend > GamePlayer.ML_MAX_LEVEL)
+				mlToSend = GamePlayer.ML_MAX_LEVEL;
+
+			double mlXPPercent = 0;
+			double mlStepPercent = 0;
+
+			if (m_gameClient.Player.MLLevel < 10)
+			{
+				mlXPPercent = 100.0 * m_gameClient.Player.MLExperience / m_gameClient.Player.GetMLExperienceForLevel(m_gameClient.Player.MLLevel + 1);
+				if (m_gameClient.Player.GetStepCountForML((byte)(m_gameClient.Player.MLLevel + 1)) > 0)
+				{
+					mlStepPercent = 100.0 * m_gameClient.Player.GetCountMLStepsCompleted((byte)(m_gameClient.Player.MLLevel + 1)) / m_gameClient.Player.GetStepCountForML((byte)(m_gameClient.Player.MLLevel + 1));
+				}
+			}
+			else
+			{
+				mlXPPercent = 100.0; // ML10 has no MLXP, so always 100%
+			}
+
+			using (GSTCPPacketOut pak = new GSTCPPacketOut((byte)eServerPackets.MasterLevelWindow))
+			{
+				pak.WriteByte((byte)mlXPPercent); // MLXP (blue bar)
+				pak.WriteByte((byte)Math.Min(mlStepPercent, 100)); // Step percent (red bar)
+				pak.WriteByte((byte)(m_gameClient.Player.MLLevel + 1)); // ML level + 1
+				pak.WriteByte(0);
+				pak.WriteShort((ushort)0); // exp1 ? new in 1.90
+				pak.WriteShort((ushort)0); // exp2 ? new in 1.90
+				pak.WriteByte(ml);
+
+				// ML level completion is displayed client side for Step 11
+				for (int i = 1; i < 11; i++)
+				{
+					string description = m_gameClient.Player.GetMLStepDescription(mlToSend, i);
+					pak.WritePascalString(description);
+				}
+
+				pak.WriteByte(0);
+				SendTCP(pak);
+			}
+		}
+		public virtual void SendMessage(string msg, eChatType type, eChatLoc loc)
+		{
+			if (m_gameClient.ClientState == GameClient.eClientState.CharScreen)
+				return;
+
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.Message)))
+			{
+				pak.WriteShort(0xFFFF);
+				pak.WriteShort((ushort)m_gameClient.SessionID);
+				pak.WriteByte((byte)type);
+				pak.Fill(0x0, 3);
+
+				string str;
+				if (loc == eChatLoc.CL_ChatWindow)
+					str = "@@";
+				else if (loc == eChatLoc.CL_PopupWindow)
+					str = "##";
+				else
+					str = "";
+
+				pak.WriteString(str + msg);
+				SendTCP(pak);
+			}
+		}
+		public virtual void SendMinotaurRelicMapRemove(byte id)
+		{
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.MinotaurRelicMapRemove)))
+			{
+				pak.WriteIntLowEndian((uint)id);
+				SendTCP(pak);
+			}
+		}
+
+		public virtual void SendMinotaurRelicMapUpdate(byte id, ushort region, int x, int y, int z)
+		{
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.MinotaurRelicMapUpdate)))
+			{
+
+				pak.WriteIntLowEndian((uint)id);
+				pak.WriteIntLowEndian((uint)region);
+				pak.WriteIntLowEndian((uint)x);
+				pak.WriteIntLowEndian((uint)y);
+				pak.WriteIntLowEndian((uint)z);
+
+				SendTCP(pak);
+			}
+		}
+
+		public virtual void SendMinotaurRelicWindow(GamePlayer player, int effect, bool flag)
+		{
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.VisualEffect)))
+			{
+
+				pak.WriteShort((ushort)player.ObjectID);
+				pak.WriteByte((byte)13);
+				if (flag)
+				{
+					pak.WriteByte(0);
+					pak.WriteInt((uint)effect);
+				}
+				else
+				{
+					pak.WriteByte(1);
+					pak.WriteInt((uint)effect);
+				}
+
+				SendTCP(pak);
+			}
+		}
+
+		public virtual void SendMinotaurRelicBarUpdate(GamePlayer player, int xp)
+		{
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.VisualEffect)))
+			{
+
+				pak.WriteShort((ushort)player.ObjectID);
+				pak.WriteByte((byte)14);
+				pak.WriteByte(0);
+				//4k maximum
+				if (xp > 4000) xp = 4000;
+				if (xp < 0) xp = 0;
+
+				pak.WriteInt((uint)xp);
+
+				SendTCP(pak);
+			}
+		}
+		/// <summary>
+		/// Send non hybrid and advanced spell lines
+		/// </summary>
+		public virtual void SendNonHybridSpellLines()
+		{
+			GamePlayer player = m_gameClient.Player;
+			if (player == null)
+				return;
+
+			List<Tuple<SpellLine, List<Skill>>> spellsXLines = player.GetAllUsableListSpells(true);
+
+			int lineIndex = 0;
+			foreach (var spXsl in spellsXLines)
+			{
+				// Prepare packet
+				using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.VariousUpdate)))
+				{
+					// Add Line Header
+					pak.WriteByte(0x02); //subcode
+					pak.WriteByte((byte)(spXsl.Item2.Count + 1)); //number of entry
+					pak.WriteByte(0x02); //subtype
+					pak.WriteByte((byte)lineIndex); //number of line
+
+					pak.WriteShortLowEndian(0); // level, not used when spell line
+					pak.WriteShort((ushort)spXsl.Item1.InternalID); //new 1.112
+					pak.WriteShort(0); // icon, not used when spell line
+					pak.WritePascalString(spXsl.Item1.Name);
+
+					// Add All Spells...
+					foreach (Skill sk in spXsl.Item2)
+					{
+						if (sk is Spell)
+						{
+							Spell sp = (Spell)sk;
+							pak.WriteShortLowEndian((byte)sp.Level);
+							pak.WriteShort((ushort)sp.InternalID); //new 1.112
+							pak.WriteShort(sp.Icon);
+							pak.WritePascalString(sp.Name);
+						}
+						else
+						{
+							int reqLevel = 1;
+							if (sk is Style)
+								reqLevel = ((Style)sk).SpecLevelRequirement;
+							else if (sk is Ability)
+								reqLevel = ((Ability)sk).SpecLevelRequirement;
+
+							pak.WriteShortLowEndian((ushort)((byte)reqLevel + (sk is Style ? 512 : 256)));
+							pak.WriteShort((ushort)sk.InternalID); //new 1.112
+							pak.WriteShort(sk.Icon);
+							pak.WritePascalString(sk.Name);
+						}
+					}
+
+					// Send
+					SendTCP(pak);
+				}
+
+				lineIndex++;
+			}
+
+			// Footer packet
+			using (GSTCPPacketOut pak3 = new GSTCPPacketOut(GetPacketCode(eServerPackets.VariousUpdate)))
+			{
+				pak3.WriteByte(0x02); //subcode
+				pak3.WriteByte(0x00);
+				pak3.WriteByte(99); //subtype (new subtype 99 in 1.80e)
+				pak3.WriteByte(0x00);
+				SendTCP(pak3);
+			}
+
+			if (ForceTooltipUpdate)
+				SendForceTooltipUpdate(spellsXLines.SelectMany(e => e.Item2));
+		}
+		public virtual void SendNPCCreate(GameNPC npc)
+		{
+
+			if (m_gameClient.Player == null || npc.IsVisibleTo(m_gameClient.Player) == false)
+				return;
+
+			//Added by Suncheck - Mines are not shown to enemy players
+			if (npc is GameMine)
+			{
+				if (GameServer.ServerRules.IsAllowedToAttack((npc as GameMine).Owner, m_gameClient.Player, true))
+				{
+					return;
+				}
+			}
+
+			if (npc is GameMovingObject)
+			{
+				SendMovingObjectCreate(npc as GameMovingObject);
+				return;
+			}
+
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.NPCCreate)))
+			{
+				int speed = 0;
+				ushort speedZ = 0;
+				if (npc == null)
+					return;
+				if (!npc.IsAtTargetPosition)
+				{
+					speed = npc.CurrentSpeed;
+					speedZ = (ushort)npc.TickSpeedZ;
+				}
+				pak.WriteShort((ushort)npc.ObjectID);
+				pak.WriteShort((ushort)(speed));
+				pak.WriteShort(npc.Heading);
+				pak.WriteShort((ushort)npc.Z);
+				pak.WriteInt((uint)npc.X);
+				pak.WriteInt((uint)npc.Y);
+				pak.WriteShort(speedZ);
+				pak.WriteShort(npc.Model);
+				pak.WriteByte(npc.Size);
+				byte level = npc.GetDisplayLevel(m_gameClient.Player);
+				if ((npc.Flags & GameNPC.eFlags.STATUE) != 0)
+				{
+					level |= 0x80;
+				}
+				pak.WriteByte(level);
+
+				byte flags = (byte)(GameServer.ServerRules.GetLivingRealm(m_gameClient.Player, npc) << 6);
+				if ((npc.Flags & GameNPC.eFlags.GHOST) != 0) flags |= 0x01;
+				if (npc.Inventory != null) flags |= 0x02; //If mob has equipment, then only show it after the client gets the 0xBD packet
+				if ((npc.Flags & GameNPC.eFlags.PEACE) != 0) flags |= 0x10;
+				if ((npc.Flags & GameNPC.eFlags.FLYING) != 0) flags |= 0x20;
+				if ((npc.Flags & GameNPC.eFlags.TORCH) != 0) flags |= 0x04;
+
+				pak.WriteByte(flags);
+				pak.WriteByte(0x20); //TODO this is the default maxstick distance
+
+				string add = "";
+				byte flags2 = 0x00;
+				IControlledBrain brain = npc.Brain as IControlledBrain;
+
+				if (brain != null)
+				{
+					flags2 |= 0x80; // have Owner
+				}
+
+				if ((npc.Flags & GameNPC.eFlags.CANTTARGET) != 0)
+					if (m_gameClient.Account.PrivLevel > 1) add += "-DOR"; // indicates DOR flag for GMs
+					else flags2 |= 0x01;
+				if ((npc.Flags & GameNPC.eFlags.DONTSHOWNAME) != 0)
+					if (m_gameClient.Account.PrivLevel > 1) add += "-NON"; // indicates NON flag for GMs
+					else flags2 |= 0x02;
+
+				if ((npc.Flags & GameNPC.eFlags.STEALTH) > 0)
+					flags2 |= 0x04;
+
+				eQuestIndicator questIndicator = npc.GetQuestIndicator(m_gameClient.Player);
+
+				if (questIndicator == eQuestIndicator.Available)
+					flags2 |= 0x08;//hex 8 - quest available
+				if (questIndicator == eQuestIndicator.Finish)
+					flags2 |= 0x10;//hex 16 - quest finish
+								   //flags2 |= 0x20;//hex 32 - water mob?
+								   //flags2 |= 0x40;//hex 64 - unknown
+								   //flags2 |= 0x80;//hex 128 - has owner
+
+
+				pak.WriteByte(flags2); // flags 2
+
+				byte flags3 = 0x00;
+				if (questIndicator == eQuestIndicator.Lesson)
+					flags3 |= 0x01;
+				if (questIndicator == eQuestIndicator.Lore)
+					flags3 |= 0x02;
+				if (questIndicator == eQuestIndicator.Pending) // new? patch 0031
+					flags3 |= 0x20;
+				pak.WriteByte(flags3); // new in 1.71 (region instance ID from StoC_0x20) OR flags 3?
+				pak.WriteShort(0x00); // new in 1.71 unknown
+
+				string name = npc.Name;
+				string guildName = npc.GuildName;
+
+				LanguageDataObject translation = LanguageMgr.GetTranslation(m_gameClient, npc);
+				if (translation != null)
+				{
+					if (!Util.IsEmpty(((DBLanguageNPC)translation).Name))
+						name = ((DBLanguageNPC)translation).Name;
+
+					if (!Util.IsEmpty(((DBLanguageNPC)translation).GuildName))
+						guildName = ((DBLanguageNPC)translation).GuildName;
+				}
+
+				if (name.Length + add.Length + 2 > 47) // clients crash with too long names
+					name = name.Substring(0, 47 - add.Length - 2);
+				if (add.Length > 0)
+					name = string.Format("[{0}]{1}", name, add);
+
+				pak.WritePascalString(name);
+
+				if (guildName.Length > 47)
+					pak.WritePascalString(guildName.Substring(0, 47));
+				else pak.WritePascalString(guildName);
+
+				pak.WriteByte(0x00);
+				SendTCP(pak);
+			}
+			/* removed, hack fix for client spamming requests for npcupdates/ creates
+            if (_gameClient.Player.Client.Version < _gameClient.eClientVersion.Version1124) 
+            {   // Update Cache
+                _gameClient.GameObjectUpdateArray[new Tuple<ushort, ushort>(npc.CurrentRegionID, (ushort)npc.ObjectID)] = 0;
+            }*/
+		}
+		public virtual void SendNPCsQuestEffect(GameNPC npc, eQuestIndicator indicator)
+		{
+			if (m_gameClient.Player == null || npc == null)
+				return;
+
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.VisualEffect)))
+			{
+
+				pak.WriteShort((ushort)npc.ObjectID);
+				pak.WriteByte(0x7); // Quest visual effect
+				pak.WriteByte((byte)indicator);
+				pak.WriteInt(0);
+
+				SendTCP(pak);
+			}
+		}
+		public virtual void SendObjectCreate(GameObject obj)
+		{
+			if (obj == null)
+				return;
+
+			if (obj.IsVisibleTo(m_gameClient.Player) == false)
+				return;
+
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.ObjectCreate)))
+			{
+				pak.WriteShort((ushort)obj.ObjectID);
+
+				if (obj is GameStaticItem)
+					pak.WriteShort((ushort)(obj as GameStaticItem).Emblem);
+				else
+					pak.WriteShort(0);
+
+				pak.WriteShort(obj.Heading);
+				pak.WriteShort((ushort)obj.Z);
+				pak.WriteInt((uint)obj.X);
+				pak.WriteInt((uint)obj.Y);
+				int flag = ((byte)obj.Realm & 3) << 4;
+				ushort model = obj.Model;
+				if (obj.IsUnderwater)
+				{
+					if (obj is GameNPC)
+						model |= 0x8000;
+					else
+						flag |= 0x01; // Underwater
+				}
+				pak.WriteShort(model);
+				if (obj is Keeps.GameKeepBanner)
+					flag |= 0x08;
+				if (obj is GameStaticItemTimed && m_gameClient.Player != null && ((GameStaticItemTimed)obj).IsOwner(m_gameClient.Player))
+					flag |= 0x04;
+				pak.WriteShort((ushort)flag);
+				if (obj is GameStaticItem)
+				{
+					int newEmblemBitMask = ((obj as GameStaticItem).Emblem & 0x010000) << 9;
+					pak.WriteInt((uint)newEmblemBitMask);//TODO other bits
+				}
+				else pak.WriteInt(0);
+
+				string name = obj.Name;
+				LanguageDataObject translation = null;
+				if (obj is GameStaticItem)
+				{
+					translation = LanguageMgr.GetTranslation(m_gameClient, (GameStaticItem)obj);
+					if (translation != null)
+					{
+						if (obj is WorldInventoryItem)
+						{
+							//if (!Util.IsEmpty(((DBLanguageItem)translation).Name))
+							//    name = ((DBLanguageItem)translation).Name;
+						}
+						else
+						{
+							if (!Util.IsEmpty(((DBLanguageGameObject)translation).Name))
+								name = ((DBLanguageGameObject)translation).Name;
+						}
+					}
+				}
+				pak.WritePascalString(name.Length > 48 ? name.Substring(0, 48) : name);
+
+				if (obj is IDoor)
+				{
+					pak.WriteByte(4);
+					pak.WriteInt((uint)(obj as IDoor).DoorID);
+				}
+				else pak.WriteByte(0x00);
+				SendTCP(pak);
+			}
+
+			// Update Object Cache
+			m_gameClient.GameObjectUpdateArray[new Tuple<ushort, ushort>(obj.CurrentRegionID, (ushort)obj.ObjectID)] = GameTimer.GetTickCount();
+		}
+		public virtual void SendObjectGuildID(GameObject obj, Guild guild)
+		{
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.ObjectGuildID)))
+			{
+				pak.WriteShort((ushort)obj.ObjectID);
+				if (guild == null)
+					pak.WriteInt(0x00);
+				else
+				{
+					pak.WriteShort(guild.ID);
+					pak.WriteShort(guild.ID);
+				}
+				pak.WriteShort(0x00); //seems random, not used by the client
+				SendTCP(pak);
+			}
+		}
+		public virtual void SendObjectRemove(GameObject obj)
+		{
+			// Remove from cache
+			if (m_gameClient.GameObjectUpdateArray.ContainsKey(new Tuple<ushort, ushort>(obj.CurrentRegionID, (ushort)obj.ObjectID)))
+			{
+				long dummy;
+				m_gameClient.GameObjectUpdateArray.TryRemove(new Tuple<ushort, ushort>(obj.CurrentRegionID, (ushort)obj.ObjectID), out dummy);
+			}
+
+			int oType = 0;
+			if (obj is GamePlayer)
+				oType = 2;
+			else if (obj is GameNPC)
+				oType = (((GameLiving)obj).IsAlive ? 1 : 0);
+
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.RemoveObject)))
+			{
+				pak.WriteShort((ushort)obj.ObjectID);
+				pak.WriteShort((ushort)oType);
+				SendTCP(pak);
+			}
+
+		}
+		public virtual void SendObjectUpdate(GameObject obj)
+		{
+			Zone z = obj.CurrentZone;
+
+			if (z == null ||
+				m_gameClient.Player == null ||
+				m_gameClient.Player.IsVisibleTo(obj) == false)
+			{
+				return;
+			}
+
+			var xOffsetInZone = (ushort)(obj.X - z.XOffset);
+			var yOffsetInZone = (ushort)(obj.Y - z.YOffset);
+			ushort xOffsetInTargetZone = 0;
+			ushort yOffsetInTargetZone = 0;
+			ushort zOffsetInTargetZone = 0;
+
+			int speed = 0;
+			ushort targetZone = 0;
+			byte flags = 0;
+			int targetOID = 0;
+			if (obj is GameNPC)
+			{
+				var npc = obj as GameNPC;
+				flags = (byte)(GameServer.ServerRules.GetLivingRealm(m_gameClient.Player, npc) << 6);
+
+				if (m_gameClient.Account.PrivLevel < 2)
+				{
+					// no name only if normal player
+					if ((npc.Flags & GameNPC.eFlags.CANTTARGET) != 0)
+						flags |= 0x01;
+					if ((npc.Flags & GameNPC.eFlags.DONTSHOWNAME) != 0)
+						flags |= 0x02;
+				}
+				if ((npc.Flags & GameNPC.eFlags.STATUE) != 0)
+				{
+					flags |= 0x01;
+				}
+				if (npc.IsUnderwater)
+				{
+					flags |= 0x10;
+				}
+				if ((npc.Flags & GameNPC.eFlags.FLYING) != 0)
+				{
+					flags |= 0x20;
+				}
+
+				if (npc.IsMoving && !npc.IsAtTargetPosition)
+				{
+					speed = npc.CurrentSpeed;
+					if (npc.TargetPosition.X != 0 || npc.TargetPosition.Y != 0 || npc.TargetPosition.Z != 0)
+					{
+						Zone tz = npc.CurrentRegion.GetZone(npc.TargetPosition.X, npc.TargetPosition.Y);
+						if (tz != null)
+						{
+							xOffsetInTargetZone = (ushort)(npc.TargetPosition.X - tz.XOffset);
+							yOffsetInTargetZone = (ushort)(npc.TargetPosition.Y - tz.YOffset);
+							zOffsetInTargetZone = (ushort)(npc.TargetPosition.Z);
+							//Dinberg:Instances - zoneSkinID for object positioning clientside.
+							targetZone = tz.ZoneSkinID;
+						}
+					}
+
+					if (speed > 0x07FF)
+					{
+						speed = 0x07FF;
+					}
+					else if (speed < 0)
+					{
+						speed = 0;
+					}
+				}
+
+				GameObject target = npc.TargetObject;
+				if (npc.AttackState && target != null && target.ObjectState == GameObject.eObjectState.Active && !npc.IsTurningDisabled)
+					targetOID = (ushort)target.ObjectID;
+			}
+
+			using (GSUDPPacketOut pak = new GSUDPPacketOut(GetPacketCode(eServerPackets.ObjectUpdate)))
+			{
+				pak.WriteShort((ushort)speed);
+
+				if (obj is GameNPC)
+				{
+					pak.WriteShort((ushort)(obj.Heading & 0xFFF));
+				}
+				else
+				{
+					pak.WriteShort(obj.Heading);
+				}
+				pak.WriteShort(xOffsetInZone);
+				pak.WriteShort(xOffsetInTargetZone);
+				pak.WriteShort(yOffsetInZone);
+				pak.WriteShort(yOffsetInTargetZone);
+				pak.WriteShort((ushort)obj.Z);
+				pak.WriteShort(zOffsetInTargetZone);
+				pak.WriteShort((ushort)obj.ObjectID);
+				pak.WriteShort((ushort)targetOID);
+				//health
+				if (obj is GameLiving)
+				{
+					pak.WriteByte((obj as GameLiving).HealthPercent);
+				}
+				else
+				{
+					pak.WriteByte(0);
+				}
+				//Dinberg:Instances - zoneskinID for positioning of objects clientside.
+				flags |= (byte)(((z.ZoneSkinID & 0x100) >> 6) | ((targetZone & 0x100) >> 5));
+				pak.WriteByte(flags);
+				pak.WriteByte((byte)z.ZoneSkinID);
+				//Dinberg:Instances - targetZone already accomodates for this feat.
+				pak.WriteByte((byte)targetZone);
+				SendUDP(pak);
+			}
+			// Update Cache
+			m_gameClient.GameObjectUpdateArray[new Tuple<ushort, ushort>(obj.CurrentRegionID, (ushort)obj.ObjectID)] = GameTimer.GetTickCount();
+
+			if (obj is GameNPC)
+			{
+				(obj as GameNPC).NPCUpdatedCallback();
+			}
+		}
+
+		public virtual void SendPetWindow(GameLiving pet, ePetWindowAction windowAction, eAggressionState aggroState, eWalkState walkState)
+		{
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.PetWindow)))
+			{
+				pak.WriteShort((ushort)(pet == null ? 0 : pet.ObjectID));
+				pak.WriteByte(0x00); //unused
+				pak.WriteByte(0x00); //unused
+				switch (windowAction) //0-released, 1-normal, 2-just charmed? | Roach: 0-close window, 1-update window, 2-create window
+				{
+					case ePetWindowAction.Open: pak.WriteByte(2); break;
+					case ePetWindowAction.Update: pak.WriteByte(1); break;
+					default: pak.WriteByte(0); break;
+				}
+				switch (aggroState) //1-aggressive, 2-defensive, 3-passive
+				{
+					case eAggressionState.Aggressive: pak.WriteByte(1); break;
+					case eAggressionState.Defensive: pak.WriteByte(2); break;
+					case eAggressionState.Passive: pak.WriteByte(3); break;
+					default: pak.WriteByte(0); break;
+				}
+				switch (walkState) //1-follow, 2-stay, 3-goto, 4-here
+				{
+					case eWalkState.Follow: pak.WriteByte(1); break;
+					case eWalkState.Stay: pak.WriteByte(2); break;
+					case eWalkState.GoTarget: pak.WriteByte(3); break;
+					case eWalkState.ComeHere: pak.WriteByte(4); break;
+					default: pak.WriteByte(0); break;
+				}
+				pak.WriteByte(0x00); //unused
+
+				if (pet != null)
+				{
+					lock (pet.EffectList)
+					{
+						ArrayList icons = new ArrayList();
+						foreach (IGameEffect effect in pet.EffectList)
+						{
+							if (icons.Count >= 8)
+								break;
+							if (effect.Icon == 0)
+								continue;
+							icons.Add(effect.Icon);
+						}
+						pak.WriteByte((byte)icons.Count); // effect count
+														  // 0x08 - null terminated - (byte) list of shorts - spell icons on pet
+						foreach (ushort icon in icons)
+						{
+							pak.WriteShort(icon);
+						}
+					}
+				}
+				else
+					pak.WriteByte((byte)0); // effect count
+				SendTCP(pak);
+			}
+		}
+		public virtual void SendPingReply(ulong timestamp, ushort sequence)
+		{
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.PingReply)))
+			{
+				pak.WriteInt((uint)timestamp);
+				pak.Fill(0x00, 4);
+				pak.WriteShort((ushort)(sequence + 1));
+				pak.Fill(0x00, 6);
+				SendTCP(pak);
+			}
+		}
+		public virtual void SendPlayerCreate(GamePlayer playerToCreate)
+		{
+			if (playerToCreate == null)
+			{
+				if (log.IsErrorEnabled)
+					log.Error("SendPlayerCreate: playerToCreate == null");
+				return;
+			}
+
+			if (m_gameClient.Player == null)
+			{
+				if (log.IsErrorEnabled)
+					log.Error("SendPlayerCreate: _gameClient.Player == null");
+				return;
+			}
+
+			Region playerRegion = playerToCreate.CurrentRegion;
+			if (playerRegion == null)
+			{
+				if (log.IsWarnEnabled)
+					log.Warn("SendPlayerCreate: playerRegion == null");
+				return;
+			}
+
+			Zone playerZone = playerToCreate.CurrentZone;
+			if (playerZone == null)
+			{
+				if (log.IsWarnEnabled)
+					log.Warn("SendPlayerCreate: playerZone == null");
+				return;
+			}
+
+			if (playerToCreate.IsVisibleTo(m_gameClient.Player) == false)
+				return;
+
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.PlayerCreate172)))
+			{
+				pak.WriteFloatLowEndian(playerToCreate.X);
+				pak.WriteFloatLowEndian(playerToCreate.Y);
+				pak.WriteFloatLowEndian(playerToCreate.Z);
+				pak.WriteShort((ushort)playerToCreate.Client.SessionID);
+				pak.WriteShort((ushort)playerToCreate.ObjectID);
+				pak.WriteShort(playerToCreate.Heading);
+				pak.WriteShort(playerToCreate.Model);
+				pak.WriteByte(playerToCreate.GetDisplayLevel(m_gameClient.Player));
+
+				int flags = (GameServer.ServerRules.GetLivingRealm(m_gameClient.Player, playerToCreate) & 0x03) << 2;
+				if (playerToCreate.IsAlive == false) flags |= 0x01;
+				if (playerToCreate.IsUnderwater) flags |= 0x02; //swimming
+				if (playerToCreate.IsStealthed) flags |= 0x10;
+				if (playerToCreate.IsWireframe) flags |= 0x20;
+				if (playerToCreate.CharacterClass.ID == (int)eCharacterClass.Vampiir) flags |= 0x40; //Vamp fly
+				pak.WriteByte((byte)flags);
+
+				pak.WriteByte(playerToCreate.GetFaceAttribute(eCharFacePart.EyeSize)); //1-4 = Eye Size / 5-8 = Nose Size
+				pak.WriteByte(playerToCreate.GetFaceAttribute(eCharFacePart.LipSize)); //1-4 = Ear size / 5-8 = Kin size
+				pak.WriteByte(playerToCreate.GetFaceAttribute(eCharFacePart.MoodType)); //1-4 = Ear size / 5-8 = Kin size
+				pak.WriteByte(playerToCreate.GetFaceAttribute(eCharFacePart.EyeColor)); //1-4 = Skin Color / 5-8 = Eye Color                
+				pak.WriteByte(playerToCreate.GetFaceAttribute(eCharFacePart.HairColor)); //Hair: 1-4 = Color / 5-8 = unknown
+				pak.WriteByte(playerToCreate.GetFaceAttribute(eCharFacePart.FaceType)); //1-4 = Unknown / 5-8 = Face type
+				pak.WriteByte(playerToCreate.GetFaceAttribute(eCharFacePart.HairStyle)); //1-4 = Unknown / 5-8 = Hair Style
+
+				pak.WriteByte(0x00); // new in 1.74
+				pak.WriteByte(0x00); //unknown
+				pak.WriteByte(0x00); //unknown
+				pak.WritePascalString(GameServer.ServerRules.GetPlayerName(m_gameClient.Player, playerToCreate));
+				pak.WritePascalString(GameServer.ServerRules.GetPlayerGuildName(m_gameClient.Player, playerToCreate));
+				pak.WritePascalString(GameServer.ServerRules.GetPlayerLastName(m_gameClient.Player, playerToCreate));
+				//RR 12 / 13
+				pak.WritePascalString(GameServer.ServerRules.GetPlayerPrefixName(m_gameClient.Player, playerToCreate));
+				pak.WritePascalString(GameServer.ServerRules.GetPlayerTitle(m_gameClient.Player, playerToCreate)); // new in 1.74, NewTitle
+				if (playerToCreate.IsOnHorse)
+				{
+					pak.WriteByte(playerToCreate.ActiveHorse.ID);
+					if (playerToCreate.ActiveHorse.BardingColor == 0 && playerToCreate.ActiveHorse.Barding != 0 && playerToCreate.Guild != null)
+					{
+						int newGuildBitMask = (playerToCreate.Guild.Emblem & 0x010000) >> 9;
+						pak.WriteByte((byte)(playerToCreate.ActiveHorse.Barding | newGuildBitMask));
+						pak.WriteShortLowEndian((ushort)playerToCreate.Guild.Emblem);
+					}
+					else
+					{
+						pak.WriteByte(playerToCreate.ActiveHorse.Barding);
+						pak.WriteShort(playerToCreate.ActiveHorse.BardingColor);
+					}
+					pak.WriteByte(playerToCreate.ActiveHorse.Saddle);
+					pak.WriteByte(playerToCreate.ActiveHorse.SaddleColor);
+				}
+				else
+				{
+					pak.WriteByte(0); // trailing zero
+				}
+
+				SendTCP(pak);
+			}
+
+			// Update Cache
+			m_gameClient.GameObjectUpdateArray[new Tuple<ushort, ushort>(playerToCreate.CurrentRegionID, (ushort)playerToCreate.ObjectID)] = GameTimer.GetTickCount();
+
+			SendObjectGuildID(playerToCreate, playerToCreate.Guild); //used for nearest friendly/enemy object buttons and name colors on PvP server
+
+			if (playerToCreate.GuildBanner != null)
+			{
+				SendRvRGuildBanner(playerToCreate, true);
+			}
+		}
+
+		/// <summary>
 		/// This is used to build a server side "Position Object"
 		/// Usually Position Packet Should only be relayed
-		/// The only purpose of this method is refreshing postion when there is Lag        
+		/// The only purpose of this method is refreshing postion when there is Lag
+		/// </summary>
+		/// <param name="player"></param>
+		public virtual void SendPlayerForgedPosition(GamePlayer player)
+		{
+			// doesn't work in 1.124+
+			return;
+			using (GSUDPPacketOut pak = new GSUDPPacketOut(GetPacketCode(eServerPackets.PlayerPosition)))
+			{
+				int heading = 4096 + player.Heading;
+				pak.WriteFloatLowEndian(player.X);
+				pak.WriteFloatLowEndian(player.Y);
+				pak.WriteFloatLowEndian(player.Z);
+				pak.WriteFloatLowEndian(player.CurrentSpeed);
+				pak.WriteInt(0); // needs to be Zspeed
+				pak.WriteShort((ushort)player.Client.SessionID);
+				pak.WriteShort(player.CurrentZone.ZoneSkinID);
+				// Write Speed
+				if (player.Steed != null && player.Steed.ObjectState == GameObject.eObjectState.Active)
+				{
+					player.Heading = player.Steed.Heading;
+					pak.WriteShort(0x1800);
+				}
+				else
+				{
+					short rSpeed = player.CurrentSpeed;
+					if (player.IsIncapacitated)
+						rSpeed = 0;
+
+					ushort content;
+					if (rSpeed < 0)
+					{
+						content = (ushort)((Math.Abs(rSpeed) > 511 ? 511 : Math.Abs(rSpeed)) + 0x200);
+					}
+					else
+					{
+						content = (ushort)(rSpeed > 511 ? 511 : rSpeed);
+					}
+
+					if (!player.IsAlive)
+					{
+						content += 5 << 10;
+					}
+					else
+					{
+						ushort state = 0;
+
+						if (player.IsSwimming)
+							state = 1;
+
+						if (player.IsClimbing)
+							state = 7;
+
+						if (player.IsSitting)
+							state = 4;
+
+						content += (ushort)(state << 10);
+					}
+
+					content += (ushort)(player.IsStrafing ? 1 << 13 : 0 << 13);
+
+					pak.WriteShort(content);
+				}
+
+				pak.WriteByte(0);
+				pak.WriteByte(0);
+				pak.WriteShort((ushort)heading);
+				// Write Flags
+				byte flagcontent = 0;
+
+				if (player.IsDiving)
+				{
+					flagcontent += 0x04;
+				}
+
+				if (player.IsWireframe)
+				{
+					flagcontent += 0x01;
+				}
+
+				if (player.IsStealthed)
+				{
+					flagcontent += 0x02;
+				}
+
+				if (player.IsTorchLighted)
+				{
+					flagcontent += 0x80;
+				}
+
+				pak.WriteByte(flagcontent);
+				pak.WriteByte((byte)(player.RPFlag ? 1 : 0));
+				pak.WriteByte(0);
+				pak.WriteByte(player.HealthPercent);
+				pak.WriteByte(player.ManaPercent);
+				pak.WriteByte(player.EndurancePercent);
+				SendUDP(pak);
+			}
+
+			// Update Cache
+			m_gameClient.GameObjectUpdateArray[new Tuple<ushort, ushort>(player.CurrentRegionID, (ushort)player.ObjectID)] = GameTimer.GetTickCount();
+		}
+
+		public virtual void SendPlayerFreeLevelUpdate()
+		{
+			GamePlayer player = m_gameClient.Player;
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.VisualEffect)))
+			{
+				pak.WriteShort((ushort)player.ObjectID);
+				pak.WriteByte(0x09); // subcode
+
+				byte flag = player.FreeLevelState;
+
+				TimeSpan t = new TimeSpan((long)(DateTime.Now.Ticks - player.LastFreeLeveled.Ticks));
+
+				ushort time = 0;
+				//time is in minutes
+				switch (player.Realm)
+				{
+					case eRealm.Albion:
+						time = (ushort)((ServerProperties.Properties.FREELEVEL_DAYS_ALBION * 24 * 60) - t.TotalMinutes);
+						break;
+					case eRealm.Midgard:
+						time = (ushort)((ServerProperties.Properties.FREELEVEL_DAYS_MIDGARD * 24 * 60) - t.TotalMinutes);
+						break;
+					case eRealm.Hibernia:
+						time = (ushort)((ServerProperties.Properties.FREELEVEL_DAYS_HIBERNIA * 24 * 60) - t.TotalMinutes);
+						break;
+				}
+
+				//flag 1 = above level, 2 = elligable, 3= time until, 4 = level and time until, 5 = level until
+				pak.WriteByte(flag); //flag
+				pak.WriteShort(0); //unknown
+				pak.WriteShort(time); //time
+				SendTCP(pak);
+			}
+		}
+		public virtual void SendPlayerInitFinished(byte mobs)
+		{
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.CharacterInitFinished)))
+			{
+				pak.WriteByte(mobs);
+				SendTCP(pak);
+			}
+		}
+		public virtual void SendPlayerJump(bool headingOnly)
+		{
+			if (m_gameClient.Player == null)
+				return;
+
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.CharacterJump)))
+			{
+				pak.WriteInt((uint)(headingOnly ? 0 : m_gameClient.Player.X));
+				pak.WriteInt((uint)(headingOnly ? 0 : m_gameClient.Player.Y));
+				pak.WriteShort((ushort)m_gameClient.Player.ObjectID);
+				pak.WriteShort((ushort)(headingOnly ? 0 : m_gameClient.Player.Z));
+				pak.WriteShort(m_gameClient.Player.Heading);
+				if (m_gameClient.Player.InHouse == false || m_gameClient.Player.CurrentHouse == null)
+				{
+					pak.WriteShort(0);
+				}
+				else
+				{
+					pak.WriteShort((ushort)m_gameClient.Player.CurrentHouse.HouseNumber);
+				}
+				SendTCP(pak);
+			}
+		}
+
+		public virtual void SendPlayerPositionAndObjectID()
+		{
+			if (m_gameClient.Player == null) return;
+
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.PositionAndObjectID)))
+			{
+				pak.WriteFloatLowEndian(m_gameClient.Player.X);
+				pak.WriteFloatLowEndian(m_gameClient.Player.Y);
+				pak.WriteFloatLowEndian(m_gameClient.Player.Z);
+				pak.WriteShort((ushort)m_gameClient.Player.ObjectID); //This is the player's objectid not Sessionid!!!
+				pak.WriteShort(m_gameClient.Player.Heading);
+
+				int flags = 0;
+				Zone zone = m_gameClient.Player.CurrentZone;
+				if (zone == null) return;
+
+				if (m_gameClient.Player.CurrentZone.IsDivingEnabled)
+					flags = 0x80 | (m_gameClient.Player.IsUnderwater ? 0x01 : 0x00);
+
+				if (zone.IsDungeon)
+				{
+					pak.WriteShort((ushort)(zone.XOffset / 0x2000));
+					pak.WriteShort((ushort)(zone.YOffset / 0x2000));
+				}
+				else
+				{
+					pak.WriteShort(0);
+					pak.WriteShort(0);
+				}
+				//Dinberg - Changing to allow instances...
+				pak.WriteShort(m_gameClient.Player.CurrentRegion.Skin);
+				pak.WriteByte((byte)(flags));
+				if (m_gameClient.Player.CurrentRegion.IsHousing)
+				{
+					pak.WritePascalString(GameServer.Instance.Configuration.ServerName); //server name
+				}
+				else pak.WriteByte(0);
+				pak.WriteByte(0); // rest is unknown for now
+				pak.WriteByte(0); // flag?
+				pak.WriteByte(0); // flag? these seemingly randomly have a value, most common is last 2 bytes are 34 08 
+				pak.WriteByte(0); // flag?
+				SendTCP(pak);
+			}
+		}
+
+		public virtual void SendPlayerQuit(bool totalOut)
+		{
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.Quit)))
+			{
+				pak.WriteByte((byte)(totalOut ? 0x01 : 0x00));
+				if (m_gameClient.Player == null)
+					pak.WriteByte(0);
+				else
+					pak.WriteByte(m_gameClient.Player.Level);
+				SendTCP(pak);
+			}
+		}
+		public virtual void SendPlayerTitles()
+		{
+			var titles = m_gameClient.Player.Titles;
+
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.DetailWindow)))
+			{
+
+				pak.WriteByte(1); // new in 1.75
+				pak.WriteByte(0); // new in 1.81
+				pak.WritePascalString("Player Statistics"); //window caption
+
+				byte line = 1;
+				foreach (string str in m_gameClient.Player.FormatStatistics())
+				{
+					pak.WriteByte(line++);
+					pak.WritePascalString(str);
+				}
+
+				pak.WriteByte(200);
+				long titlesCountPos = pak.Position;
+				pak.WriteByte((byte)titles.Count);
+				line = 0;
+
+				foreach (IPlayerTitle title in titles)
+				{
+					pak.WriteByte(line++);
+					pak.WritePascalString(title.GetDescription(m_gameClient.Player));
+				}
+
+				long titlesLen = (pak.Position - titlesCountPos - 1); // include titles count
+				if (titlesLen > byte.MaxValue)
+					log.WarnFormat("Titles block is too long! {0} (player: {1})", titlesLen, m_gameClient.Player);
+
+				//Trailing Zero!
+				pak.WriteByte(0);
+				SendTCP(pak);
+			}
+		}
+		public virtual void SendPlayerTitleUpdate(GamePlayer player)
+		{
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.VisualEffect)))
+			{
+				pak.WriteShort((ushort)player.ObjectID);
+				pak.WriteByte(0x0B); // subcode
+				IPlayerTitle title = player.CurrentTitle;
+				if (title == PlayerTitleMgr.ClearTitle)
+				{
+					pak.WriteByte(0); // flag
+					pak.WriteInt(0); // unk1 + str len
+				}
+				else
+				{
+					pak.WriteByte(1); // flag
+					string val = GameServer.ServerRules.GetPlayerTitle(m_gameClient.Player, player);
+					pak.WriteShort((ushort)val.Length);
+					pak.WriteShort(0); // unk1
+					pak.WriteStringBytes(val);
+				}
+				SendTCP(pak);
+			}
+		}
+		public virtual void SendQuestUpdate(AbstractQuest quest)
+		{
+			int questIndex = 1;
+			// add check for null due to LD
+			if (m_gameClient != null && m_gameClient.Player != null && m_gameClient.Player.QuestList != null)
+			{
+				lock (m_gameClient.Player.QuestList)
+				{
+					foreach (AbstractQuest q in m_gameClient.Player.QuestList)
+					{
+						if (q == quest)
+						{
+							SendQuestPacket(q, questIndex);
+							break;
+						}
+
+						if (q.Step != -1)
+							questIndex++;
+					}
+				}
+			}
+		}
+		public virtual void SendQuestListUpdate()
+		{
+			if (m_gameClient == null || m_gameClient.Player == null)
+			{
+				return;
+			}
+
+			SendTaskInfo();
+
+			int questIndex = 1;
+			lock (m_gameClient.Player.QuestList)
+			{
+				foreach (AbstractQuest quest in m_gameClient.Player.QuestList)
+				{
+					SendQuestPacket((quest.Step == 0 || quest == null) ? null : quest, questIndex++);
+				}
+			}
+		}
+
+		public virtual void SendQuestOfferWindow(GameNPC questNPC, GamePlayer player, DataQuest quest)
+		{
+			SendQuestWindow(questNPC, player, quest, true);
+		}
+
+		public virtual void SendQuestOfferWindow(GameNPC questNPC, GamePlayer player, RewardQuest quest)
+		{
+			SendQuestWindow(questNPC, player, quest, true);
+		}
+		public virtual void SendQuestRewardWindow(GameNPC questNPC, GamePlayer player, DataQuest quest)
+		{
+			SendQuestWindow(questNPC, player, quest, false);
+		}
+
+		public virtual void SendQuestRewardWindow(GameNPC questNPC, GamePlayer player, RewardQuest quest)
+		{
+			SendQuestWindow(questNPC, player, quest, false);
+		}
+
+		protected virtual void SendQuestWindow(GameNPC questNPC, GamePlayer player, DataQuest quest, bool offer)
+		{
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.Dialog)))
+			{
+				ushort QuestID = quest.ClientQuestID;
+				pak.WriteShort((offer) ? (byte)0x22 : (byte)0x21); // Dialog
+				pak.WriteShort(QuestID);
+				pak.WriteShort((ushort)questNPC.ObjectID);
+				pak.WriteByte(0x00); // unknown
+				pak.WriteByte(0x00); // unknown
+				pak.WriteByte(0x00); // unknown
+				pak.WriteByte(0x00); // unknown
+				pak.WriteByte((offer) ? (byte)0x02 : (byte)0x01); // Accept/Decline or Finish/Not Yet
+				pak.WriteByte(0x01); // Wrap
+				pak.WritePascalString(quest.Name);
+
+				String personalizedSummary = BehaviourUtils.GetPersonalizedMessage(quest.Description, player);
+				if (personalizedSummary.Length > 255)
+				{
+					pak.WritePascalString(personalizedSummary.Substring(0, 255)); // Summary is max 255 bytes or client will crash !
+				}
+				else
+				{
+					pak.WritePascalString(personalizedSummary);
+				}
+
+				if (offer)
+				{
+					String personalizedStory = BehaviourUtils.GetPersonalizedMessage(quest.Story, player);
+
+					if (personalizedStory.Length > MAX_STORY_LENGTH)
+					{
+						pak.WriteShort(MAX_STORY_LENGTH);
+						pak.WriteStringBytes(personalizedStory.Substring(0, MAX_STORY_LENGTH));
+					}
+					else
+					{
+						pak.WriteShort((ushort)personalizedStory.Length);
+						pak.WriteStringBytes(personalizedStory);
+					}
+				}
+				else
+				{
+					if (quest.FinishText.Length > MAX_STORY_LENGTH)
+					{
+						pak.WriteShort(MAX_STORY_LENGTH);
+						pak.WriteStringBytes(quest.FinishText.Substring(0, MAX_STORY_LENGTH));
+					}
+					else
+					{
+						pak.WriteShort((ushort)quest.FinishText.Length);
+						pak.WriteStringBytes(quest.FinishText);
+					}
+				}
+
+				pak.WriteShort(QuestID);
+				pak.WriteByte((byte)quest.StepTexts.Count); // #goals count
+				foreach (string text in quest.StepTexts)
+				{
+					string t = text;
+
+					// Need to protect for any text length > 255.  It does not crash client but corrupts RewardQuest display -Tolakram
+					if (text.Length > 253)
+					{
+						t = text.Substring(0, 253);
+					}
+
+					pak.WritePascalString(String.Format("{0}\r", t));
+				}
+				pak.WriteInt((uint)(quest.MoneyReward())); // patch 0016
+				pak.WriteByte((byte)quest.ExperiencePercent(player)); // patch 0016
+				pak.WriteByte((byte)quest.FinalRewards.Count);
+				foreach (ItemTemplate reward in quest.FinalRewards)
+				{
+					WriteItemData(pak, GameInventoryItem.Create(reward));
+				}
+				pak.WriteByte((byte)quest.NumOptionalRewardsChoice);
+				pak.WriteByte((byte)quest.OptionalRewards.Count);
+				foreach (ItemTemplate reward in quest.OptionalRewards)
+				{
+					WriteItemData(pak, GameInventoryItem.Create(reward));
+				}
+				SendTCP(pak);
+			}
+		}
+
+		protected virtual void SendQuestWindow(GameNPC questNPC, GamePlayer player, RewardQuest quest, bool offer)
+		{
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.Dialog)))
+			{
+				ushort QuestID = QuestMgr.GetIDForQuestType(quest.GetType());
+				pak.WriteShort((offer) ? (byte)0x22 : (byte)0x21); // Dialog
+				pak.WriteShort(QuestID);
+				pak.WriteShort((ushort)questNPC.ObjectID);
+				pak.WriteByte(0x00); // unknown
+				pak.WriteByte(0x00); // unknown
+				pak.WriteByte(0x00); // unknown
+				pak.WriteByte(0x00); // unknown
+				pak.WriteByte((offer) ? (byte)0x02 : (byte)0x01); // Accept/Decline or Finish/Not Yet
+				pak.WriteByte(0x01); // Wrap
+				pak.WritePascalString(quest.Name);
+
+				String personalizedSummary = BehaviourUtils.GetPersonalizedMessage(quest.Summary, player);
+				if (personalizedSummary.Length > 255)
+					pak.WritePascalString(personalizedSummary.Substring(0, 255)); // Summary is max 255 bytes !
+				else
+					pak.WritePascalString(personalizedSummary);
+
+				if (offer)
+				{
+					String personalizedStory = BehaviourUtils.GetPersonalizedMessage(quest.Story, player);
+
+					if (personalizedStory.Length > ServerProperties.Properties.MAX_REWARDQUEST_DESCRIPTION_LENGTH)
+					{
+						pak.WriteShort((ushort)ServerProperties.Properties.MAX_REWARDQUEST_DESCRIPTION_LENGTH);
+						pak.WriteStringBytes(personalizedStory.Substring(0, ServerProperties.Properties.MAX_REWARDQUEST_DESCRIPTION_LENGTH));
+					}
+					else
+					{
+						pak.WriteShort((ushort)personalizedStory.Length);
+						pak.WriteStringBytes(personalizedStory);
+					}
+				}
+				else
+				{
+					if (quest.Conclusion.Length > (ushort)ServerProperties.Properties.MAX_REWARDQUEST_DESCRIPTION_LENGTH)
+					{
+						pak.WriteShort((ushort)ServerProperties.Properties.MAX_REWARDQUEST_DESCRIPTION_LENGTH);
+						pak.WriteStringBytes(quest.Conclusion.Substring(0, (ushort)ServerProperties.Properties.MAX_REWARDQUEST_DESCRIPTION_LENGTH));
+					}
+					else
+					{
+						pak.WriteShort((ushort)quest.Conclusion.Length);
+						pak.WriteStringBytes(quest.Conclusion);
+					}
+				}
+
+				pak.WriteShort(QuestID);
+				pak.WriteByte((byte)quest.Goals.Count); // #goals count
+				foreach (RewardQuest.QuestGoal goal in quest.Goals)
+				{
+					pak.WritePascalString(String.Format("{0}\r", goal.Description));
+				}
+				pak.WriteInt((uint)(quest.Rewards.Money)); // unknown, new in 1.94
+				pak.WriteByte((byte)quest.Rewards.ExperiencePercent(player));
+				pak.WriteByte((byte)quest.Rewards.BasicItems.Count);
+				foreach (ItemTemplate reward in quest.Rewards.BasicItems)
+				{
+					WriteItemData(pak, GameInventoryItem.Create(reward));
+				}
+				pak.WriteByte((byte)quest.Rewards.ChoiceOf);
+				pak.WriteByte((byte)quest.Rewards.OptionalItems.Count);
+				foreach (ItemTemplate reward in quest.Rewards.OptionalItems)
+				{
+					WriteItemData(pak, GameInventoryItem.Create(reward));
+				}
+				SendTCP(pak);
+			}
+		}
+		protected virtual void SendQuestPacket(AbstractQuest q, int index)
+		{
+			if (q == null)
+			{
+				using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.QuestEntry)))
+				{
+					pak.WriteByte((byte)index);
+					pak.WriteByte(0);
+					pak.WriteByte(0);
+					pak.WriteByte(0);
+					pak.WriteByte(0);
+					pak.WriteByte(0);
+					SendTCP(pak);
+					return;
+				}
+			}
+			else if (q is RewardQuest)
+			{
+				RewardQuest quest = q as RewardQuest;
+				using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.QuestEntry)))
+				{
+					pak.WriteByte((byte)index);
+					pak.WriteByte((byte)quest.Name.Length);
+					pak.WriteShort(0x00); // unknown
+					pak.WriteByte((byte)quest.Goals.Count);
+					pak.WriteByte((byte)quest.Level);
+					pak.WriteStringBytes(quest.Name);
+					pak.WritePascalString(quest.Description);
+					int goalindex = 0;
+					foreach (RewardQuest.QuestGoal goal in quest.Goals)
+					{
+						goalindex++;
+						String goalDesc = String.Format("{0}\r", goal.Description);
+						pak.WriteShortLowEndian((ushort)goalDesc.Length);
+						pak.WriteStringBytes(goalDesc);
+						pak.WriteShortLowEndian((ushort)goal.ZoneID2);
+						pak.WriteShortLowEndian((ushort)goal.XOffset2);
+						pak.WriteShortLowEndian((ushort)goal.YOffset2);
+						pak.WriteShortLowEndian(0x00);  // unknown
+						pak.WriteShortLowEndian((ushort)goal.Type);
+						pak.WriteShortLowEndian(0x00);  // unknown
+						pak.WriteShortLowEndian((ushort)goal.ZoneID1);
+						pak.WriteShortLowEndian((ushort)goal.XOffset1);
+						pak.WriteShortLowEndian((ushort)goal.YOffset1);
+						pak.WriteByte((byte)((goal.IsAchieved) ? 0x01 : 0x00));
+						if (goal.QuestItem == null)
+						{
+							pak.WriteByte(0x00);
+						}
+						else
+						{
+							pak.WriteByte((byte)goalindex);
+							WriteTemplateData(pak, goal.QuestItem, 1);
+						}
+					}
+					SendTCP(pak);
+					return;
+				}
+			}
+			else
+			{
+				using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.QuestEntry)))
+				{
+					pak.WriteByte((byte)index);
+
+					string name = string.Format("{0} (Level {1})", q.Name, q.Level);
+					string desc = string.Format("[Step #{0}]: {1}", q.Step, q.Description);
+					if (name.Length > byte.MaxValue)
+					{
+						if (log.IsWarnEnabled)
+						{
+							log.Warn(q.GetType().ToString() + ": name is too long for 1.68+ clients (" + name.Length + ") '" + name + "'");
+						}
+						name = name.Substring(0, byte.MaxValue);
+					}
+					if (desc.Length > byte.MaxValue)
+					{
+						if (log.IsWarnEnabled)
+						{
+							log.Warn(q.GetType().ToString() + ": description is too long for 1.68+ clients (" + desc.Length + ") '" + desc + "'");
+						}
+						desc = desc.Substring(0, byte.MaxValue);
+					}
+					pak.WriteByte((byte)name.Length);
+					pak.WriteShortLowEndian((ushort)desc.Length);
+					pak.WriteByte(0); // Quest Zone ID ?
+					pak.WriteByte(0);
+					pak.WriteStringBytes(name); //Write Quest Name without trailing 0
+					pak.WriteStringBytes(desc); //Write Quest Description without trailing 0                   
+
+					SendTCP(pak);
+				}
+			}
+		}
+
+		public virtual void SendRealm(eRealm realm)
+		{
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.Realm)))
+			{
+				pak.WriteByte((byte)realm);
+				SendTCP(pak);
+			}
+		}
+		public virtual void SendRegions()
+		{
+			if (m_gameClient.Player != null)
+			{
+				if (!m_gameClient.Socket.Connected)
+					return;
+				Region region = WorldMgr.GetRegion(m_gameClient.Player.CurrentRegionID);
+				if (region == null)
+					return;
+				using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.ClientRegion)))
+				{
+					//				pak.WriteByte((byte)((region.Expansion + 1) << 4)); // Must be expansion
+					pak.WriteByte(0); // but this packet sended when client in old region. but this field must show expanstion for jump destanation region
+									  //Dinberg - trying to get instances to work.
+					pak.WriteByte((byte)region.Skin); // This was pak.WriteByte((byte)region.ID);
+					pak.Fill(0, 20);
+					pak.FillString(region.ServerPort.ToString(), 5);
+					pak.FillString(region.ServerPort.ToString(), 5);
+					string ip = region.ServerIP;
+					if (ip == "any" || ip == "0.0.0.0" || ip == "127.0.0.1" || ip.StartsWith("10.") || ip.StartsWith("192.168."))
+						ip = ((IPEndPoint)m_gameClient.Socket.LocalEndPoint).Address.ToString();
+					pak.FillString(ip, 20);
+					SendTCP(pak);
+				}
+			}
+			else
+			{
+				RegionEntry[] entries = WorldMgr.GetRegionList();
+
+				if (entries == null) return;
+				int index = 0;
+				int num = 0;
+				int count = entries.Length;
+				while (entries != null && count > index)
+				{
+					using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.ClientRegions)))
+					{
+						for (int i = 0; i < 4; i++)
+						{
+							while (index < count && (int)m_gameClient.ClientType <= entries[index].expansion)
+							{
+								index++;
+							}
+
+							if (index >= count)
+							{   //If we have no more entries
+								pak.Fill(0x0, 52);
+							}
+							else
+							{
+								pak.WriteByte((byte)(++num));
+								pak.WriteByte((byte)entries[index].id);
+								pak.FillString(entries[index].name, 20);
+								pak.FillString(entries[index].fromPort, 5);
+								pak.FillString(entries[index].toPort, 5);
+								//Try to fix the region ip so UDP is enabled!
+								string ip = entries[index].ip;
+								if (ip == "any" || ip == "0.0.0.0" || ip == "127.0.0.1" || ip.StartsWith("10.13.") || ip.StartsWith("192.168."))
+									ip = ((IPEndPoint)m_gameClient.Socket.LocalEndPoint).Address.ToString();
+								pak.FillString(ip, 20);
+
+								index++;
+							}
+						}
+						SendTCP(pak);
+					}
+				}
+			}
+		}
+		public virtual void SendRegionChanged()
+		{
+			if (m_gameClient.Player == null)
+				return;
+			SendRegions();
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.RegionChanged)))
+			{
+				//Dinberg - Changing to allow instances...
+				pak.WriteShort(m_gameClient.Player.CurrentRegion.Skin);
+				//Dinberg:Instances - also need to continue the bluff here, with zoneSkinID, for 
+				//clientside positions of objects.
+				pak.WriteShort(m_gameClient.Player.CurrentZone.ZoneSkinID); // Zone ID?
+				pak.WriteShort(0x00); // ?
+				pak.WriteShort(0x01); // cause region change ?
+				pak.WriteByte(0x0C); //Server ID
+				pak.WriteByte(0); // ?
+				pak.WriteShort(0xFFBF); // ?
+				SendTCP(pak);
+			}
+		}
+		public virtual void SendRegionColorScheme(byte color)
+		{
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.VisualEffect)))
+			{
+				pak.WriteShort(0); // not used
+				pak.WriteByte(0x05); // subcode
+				pak.WriteByte(color);
+				pak.WriteInt(0); // not used
+				SendTCP(pak);
+			}
+		}
+		public virtual void SendRvRGuildBanner(GamePlayer player, bool show)
+		{
+			if (player == null) return;
+
+			//cannot show banners for players that have no guild.
+			if (show && player.Guild == null)
+				return;
+			GSTCPPacketOut pak = new GSTCPPacketOut((byte)eServerPackets.VisualEffect);
+			pak.WriteShort((ushort)player.ObjectID);
+			pak.WriteByte(0xC); // show Banner
+			pak.WriteByte((byte)((show) ? 0 : 1)); // 0-enable, 1-disable
+			int newEmblemBitMask = ((player.Guild.Emblem & 0x010000) << 8) | (player.Guild.Emblem & 0xFFFF);
+			pak.WriteInt((uint)newEmblemBitMask);
+			SendTCP(pak);
+		}
+		public virtual void SendSessionID()
+		{
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.SessionID)))
+			{
+				pak.WriteShortLowEndian((ushort)m_gameClient.SessionID);
+				SendTCP(pak);
+			}
+		}
+		public virtual void SendSetControlledHorse(GamePlayer player)
+		{
+			if (player == null || player.ObjectState != GameObject.eObjectState.Active)
+				return;
+
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.ControlledHorse)))
+			{
+
+				if (player.HasHorse)
+				{
+					pak.WriteShort(0); // for set self horse OID must be zero
+					pak.WriteByte(player.ActiveHorse.ID);
+					if (player.ActiveHorse.BardingColor == 0 && player.ActiveHorse.Barding != 0 && player.Guild != null)
+					{
+						int newGuildBitMask = (player.Guild.Emblem & 0x010000) >> 9;
+						pak.WriteByte((byte)(player.ActiveHorse.Barding | newGuildBitMask));
+						pak.WriteShort((ushort)player.Guild.Emblem);
+					}
+					else
+					{
+						pak.WriteByte(player.ActiveHorse.Barding);
+						pak.WriteShort(player.ActiveHorse.BardingColor);
+					}
+					pak.WriteByte(player.ActiveHorse.Saddle);
+					pak.WriteByte(player.ActiveHorse.SaddleColor);
+					pak.WriteByte(player.ActiveHorse.Slots);
+					pak.WriteByte(player.ActiveHorse.Armor);
+					pak.WritePascalString(player.ActiveHorse.Name == null ? "" : player.ActiveHorse.Name);
+				}
+				else
+				{
+					pak.Fill(0x00, 8);
+				}
+				SendTCP(pak);
+			}
+		}
+		public virtual void SendSiegeWeaponCloseInterface()
+		{
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.SiegeWeaponInterface)))
+			{
+				pak.WriteShort(0);
+				pak.WriteShort(1);
+				pak.Fill(0, 13);
+				SendTCP(pak);
+			}
+		}
+
+		/// <summary>
+		/// new siege weapon animation 1.110 // patch 0021
+		/// </summary>
+		/// <param name="siegeWeapon"></param>
+		public virtual void SendSiegeWeaponAnimation(GameSiegeWeapon siegeWeapon)
+		{
+			if (siegeWeapon == null)
+				return;
+			byte[] siegeID = new byte[siegeWeapon.ObjectID]; // test
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.SiegeWeaponAnimation)))
+			{
+				pak.WriteInt((uint)siegeWeapon.ObjectID);
+				pak.WriteInt(
+					(uint)
+					(siegeWeapon.TargetObject == null
+					 ? (siegeWeapon.GroundTarget == null ? 0 : siegeWeapon.GroundTarget.X)
+					 : siegeWeapon.TargetObject.X));
+				pak.WriteInt(
+					(uint)
+					(siegeWeapon.TargetObject == null
+					 ? (siegeWeapon.GroundTarget == null ? 0 : siegeWeapon.GroundTarget.Y)
+					 : siegeWeapon.TargetObject.Y));
+				pak.WriteInt(
+					(uint)
+					(siegeWeapon.TargetObject == null
+					 ? (siegeWeapon.GroundTarget == null ? 0 : siegeWeapon.GroundTarget.Z)
+					 : siegeWeapon.TargetObject.Z));
+				pak.WriteInt((uint)(siegeWeapon.TargetObject == null ? 0 : siegeWeapon.TargetObject.ObjectID));
+				pak.WriteShort(siegeWeapon.Effect);
+				pak.WriteShort((ushort)(siegeWeapon.SiegeWeaponTimer.TimeUntilElapsed));
+				pak.WriteByte((byte)siegeWeapon.SiegeWeaponTimer.CurrentAction);
+				switch ((byte)siegeWeapon.SiegeWeaponTimer.CurrentAction)
+				{
+					case 0x01: //aiming
+						{
+							pak.WriteByte(siegeID[1]); // lowest value of siegeweapon.ObjectID
+							pak.WriteShort((ushort)(siegeWeapon.TargetObject == null ? 0x0000 : siegeWeapon.TargetObject.ObjectID));
+							break;
+						}
+					case 0x02: //arming
+						{
+							pak.WriteByte(0x5F);
+							pak.WriteShort(0xD000);
+							break;
+						}
+					case 0x03: // loading
+						{
+							pak.Fill(0, 3);
+							break;
+						}
+				}
+				//pak.WriteShort(0x5FD0);
+				//pak.WriteByte(0x00);
+				SendTCP(pak);
+
+			}
+		}
+
+		/// <summary>
+		/// new siege weapon fireanimation 1.110 // patch 0021
+		/// </summary>
+		/// <param name="siegeWeapon">The siege weapon</param>
+		/// <param name="timer">How long the animation lasts for</param>
+		public virtual void SendSiegeWeaponFireAnimation(GameSiegeWeapon siegeWeapon, int timer)
+		{
+			if (siegeWeapon == null)
+				return;
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.SiegeWeaponAnimation)))
+			{
+				pak.WriteInt((uint)siegeWeapon.ObjectID);
+				pak.WriteInt((uint)(siegeWeapon.TargetObject == null ? siegeWeapon.GroundTarget.X : siegeWeapon.TargetObject.X));
+				pak.WriteInt((uint)(siegeWeapon.TargetObject == null ? siegeWeapon.GroundTarget.Y : siegeWeapon.TargetObject.Y));
+				pak.WriteInt((uint)(siegeWeapon.TargetObject == null ? siegeWeapon.GroundTarget.Z + 50 : siegeWeapon.TargetObject.Z + 50));
+				pak.WriteInt((uint)(siegeWeapon.TargetObject == null ? 0 : siegeWeapon.TargetObject.ObjectID));
+				pak.WriteShort(siegeWeapon.Effect);
+				pak.WriteShort((ushort)(timer));
+				pak.WriteByte((byte)SiegeTimer.eAction.Fire);
+				pak.WriteShort(0xE134); // default ammo type, the only type currently supported on DOL
+				pak.WriteByte(0x08); // always this flag when firing
+				SendTCP(pak);
+			}
+		}
+		/// <summary>
+		/// new siege interface packet 1119
+		/// </summary>
+		/// <param name="siegeWeapon"></param>
+		/// <param name="time"></param>
+		public virtual void SendSiegeWeaponInterface(GameSiegeWeapon siegeWeapon, int time)
+		{
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.SiegeWeaponInterface)))
+			{
+				ushort flag = (ushort)((siegeWeapon.EnableToMove ? 1 : 0) | siegeWeapon.AmmoType << 8);
+				pak.WriteShort(flag); //byte Ammo,  byte SiegeMoving(1/0)
+				pak.WriteByte(0);
+				pak.WriteByte(0); // Close interface(1/0)
+				pak.WriteByte((byte)(time));//time x 100 eg 50 = 5000ms
+				pak.WriteByte((byte)siegeWeapon.Ammo.Count); // external ammo count
+				pak.WriteByte((byte)siegeWeapon.SiegeWeaponTimer.CurrentAction);
+				pak.WriteByte((byte)siegeWeapon.AmmoSlot);
+				pak.WriteShort(siegeWeapon.Effect);
+				pak.WriteShort(0); // SiegeHelperTimer ?
+				pak.WriteShort(0); // SiegeTimer ?
+				pak.WriteShort((ushort)siegeWeapon.ObjectID);
+
+				string name = siegeWeapon.Name;
+
+				LanguageDataObject translation = LanguageMgr.GetTranslation(m_gameClient, siegeWeapon);
+				if (translation != null)
+				{
+					if (!Util.IsEmpty(((DBLanguageNPC)translation).Name))
+						name = ((DBLanguageNPC)translation).Name;
+				}
+
+				//pak.WritePascalString(name + " (" + siegeWeapon.CurrentState.ToString() + ")");
+				foreach (InventoryItem item in siegeWeapon.Ammo)
+				{
+					if (item == null)
+					{
+						pak.Fill(0x00, 24);
+						continue;
+					}
+					pak.WriteByte((byte)siegeWeapon.Ammo.IndexOf(item));
+					pak.WriteShort(0); // unique objectID , can probably be 0
+					pak.WriteByte((byte)item.Level);
+					pak.WriteByte(0); // value1
+					pak.WriteByte(0); //value2
+					pak.WriteByte(0); // unknown
+					pak.WriteByte((byte)item.Object_Type);
+					pak.WriteByte(1); // unknown
+					pak.WriteByte(0);//
+					pak.WriteByte((byte)item.Count);
+					//pak.WriteByte((byte)(item.Hand * 64));
+					//pak.WriteByte((byte)((item.Type_Damage * 64) + item.Object_Type));
+					//pak.WriteShort((ushort)item.Weight);
+					pak.WriteByte(item.ConditionPercent); // % of con
+					pak.WriteByte(item.DurabilityPercent); // % of dur
+					pak.WriteByte((byte)item.Quality); // % of qua
+					pak.WriteByte((byte)item.Bonus); // % bonus
+					pak.WriteByte((byte)item.BonusLevel); // guessing
+					pak.WriteShort((ushort)item.Model);
+					pak.WriteByte((byte)item.Extension);
+					pak.WriteShort(0); // unknown
+					pak.WriteByte(4); // unknown flags?
+					pak.WriteShort(0); // unknown
+					if (item.Count > 1)
+						pak.WritePascalString(item.Count + " " + item.Name);
+					else
+						pak.WritePascalString(item.Name);
+				}
+				pak.WritePascalString(name + " (" + siegeWeapon.CurrentState.ToString() + ")");
+				SendTCP(pak);
+			}
+		}
+
+		public virtual void SendSpellEffectAnimation(GameObject spellCaster, GameObject spellTarget, ushort spellid, ushort boltTime, bool noSound, byte success)
+		{
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.SpellEffectAnimation)))
+			{
+				pak.WriteShort((ushort)spellCaster.ObjectID);
+				pak.WriteShort(spellid);
+				pak.WriteShort((ushort)(spellTarget == null ? 0 : spellTarget.ObjectID));
+				pak.WriteShort(boltTime);
+				pak.WriteByte((byte)(noSound ? 1 : 0));
+				pak.WriteByte(success);
+				SendTCP(pak);
+			}
+		}
+		public virtual void SendStatusUpdate(byte sittingFlag)
+		{
+			if (m_gameClient.Player == null)
+				return;
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.CharacterStatusUpdate)))
+			{
+				pak.WriteByte(m_gameClient.Player.HealthPercent);
+				pak.WriteByte(m_gameClient.Player.ManaPercent);
+				pak.WriteByte(sittingFlag);
+				pak.WriteByte(m_gameClient.Player.EndurancePercent);
+				pak.WriteByte(m_gameClient.Player.ConcentrationPercent);
+				//			pak.WriteShort((byte) (_gameClient.Player.IsAlive ? 0x00 : 0x0f)); // 0x0F if dead ??? where it now ?
+				pak.WriteByte(0);// unk
+				pak.WriteShort((ushort)m_gameClient.Player.MaxMana);
+				pak.WriteShort((ushort)m_gameClient.Player.MaxEndurance);
+				pak.WriteShort((ushort)m_gameClient.Player.MaxConcentration);
+				pak.WriteShort((ushort)m_gameClient.Player.MaxHealth);
+				pak.WriteShort((ushort)m_gameClient.Player.Health);
+				pak.WriteShort((ushort)m_gameClient.Player.Endurance);
+				pak.WriteShort((ushort)m_gameClient.Player.Mana);
+				pak.WriteShort((ushort)m_gameClient.Player.Concentration);
+				SendTCP(pak);
+			}
+		}
+		protected virtual void SendTaskInfo()
+		{
+			string name = BuildTaskString();
+
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.QuestEntry)))
+			{
+				pak.WriteByte(0); //index
+				pak.WriteShortLowEndian((ushort)name.Length);
+				pak.WriteByte((byte)0);
+				pak.WriteByte((byte)0);
+				pak.WriteByte((byte)0);
+				pak.WriteStringBytes(name); //Write Quest Name without trailing 0
+				pak.WriteStringBytes(""); //Write Quest Description without trailing 0
+				SendTCP(pak);
+			}
+		}
+		public virtual void SendTime()
+		{
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.Time)))
+			{
+				if (m_gameClient != null && m_gameClient.Player != null)
+				{
+					pak.WriteInt(WorldMgr.GetCurrentGameTime(m_gameClient.Player));
+					pak.WriteInt(WorldMgr.GetDayIncrement(m_gameClient.Player));
+				}
+				else
+				{
+					pak.WriteInt(WorldMgr.GetCurrentGameTime());
+					pak.WriteInt(WorldMgr.GetDayIncrement());
+				}
+				SendTCP(pak);
+			}
+		}
+		/// <summary>
+		/// send trade window packet
+		/// </summary>
+		public virtual void SendTradeWindow()
+		{
+			if (m_gameClient.Player == null)
+				return;
+			if (m_gameClient.Player.TradeWindow == null)
+				return;
+
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.TradeWindow)))
+			{
+				lock (m_gameClient.Player.TradeWindow.Sync)
+				{
+					foreach (InventoryItem item in m_gameClient.Player.TradeWindow.TradeItems)
+					{
+						pak.WriteByte((byte)item.SlotPosition);
+					}
+					pak.Fill(0x00, 10 - m_gameClient.Player.TradeWindow.TradeItems.Count);
+
+					pak.WriteShort(0x0000);
+					pak.WriteShort((ushort)Money.GetMithril(m_gameClient.Player.TradeWindow.TradeMoney));
+					pak.WriteShort((ushort)Money.GetPlatinum(m_gameClient.Player.TradeWindow.TradeMoney));
+					pak.WriteShort((ushort)Money.GetGold(m_gameClient.Player.TradeWindow.TradeMoney));
+					pak.WriteShort((ushort)Money.GetSilver(m_gameClient.Player.TradeWindow.TradeMoney));
+					pak.WriteShort((ushort)Money.GetCopper(m_gameClient.Player.TradeWindow.TradeMoney));
+
+					pak.WriteShort(0x0000);
+					pak.WriteShort((ushort)Money.GetMithril(m_gameClient.Player.TradeWindow.PartnerTradeMoney));
+					pak.WriteShort((ushort)Money.GetPlatinum(m_gameClient.Player.TradeWindow.PartnerTradeMoney));
+					pak.WriteShort((ushort)Money.GetGold(m_gameClient.Player.TradeWindow.PartnerTradeMoney));
+					pak.WriteShort((ushort)Money.GetSilver(m_gameClient.Player.TradeWindow.PartnerTradeMoney));
+					pak.WriteShort((ushort)Money.GetCopper(m_gameClient.Player.TradeWindow.PartnerTradeMoney));
+
+					pak.WriteShort(0x0000);
+					ArrayList items = m_gameClient.Player.TradeWindow.PartnerTradeItems;
+					if (items != null)
+					{
+						pak.WriteByte((byte)items.Count);
+						pak.WriteByte(0x01);
+					}
+					else
+					{
+						pak.WriteShort(0x0000);
+					}
+					pak.WriteByte((byte)(m_gameClient.Player.TradeWindow.Repairing ? 0x01 : 0x00));
+					pak.WriteByte((byte)(m_gameClient.Player.TradeWindow.Combine ? 0x01 : 0x00));
+					if (items != null)
+					{
+						foreach (InventoryItem item in items)
+						{
+							pak.WriteByte((byte)item.SlotPosition);
+							WriteItemData(pak, item);
+						}
+					}
+					if (m_gameClient.Player.TradeWindow.Partner != null)
+						pak.WritePascalString("Trading with " + m_gameClient.Player.GetName(m_gameClient.Player.TradeWindow.Partner)); // transaction with ...
+					else
+						pak.WritePascalString("Selfcrafting"); // transaction with ...
+					SendTCP(pak);
+				}
+			}
+		}
+
+		/// <summary>
+		/// SendTrainerWindow method
+		/// </summary>
+		public virtual void SendTrainerWindow()
+		{
+			if (m_gameClient == null || m_gameClient.Player == null)
+				return;
+
+			GamePlayer player = m_gameClient.Player;
+
+			List<Specialization> specs = m_gameClient.Player.GetSpecList().Where(it => it.Trainable).ToList();
+			IList<string> autotrains = player.CharacterClass.GetAutotrainableSkills();
+
+			// Send Trainer Window with Trainable Specs
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.TrainerWindow)))
+			{
+				pak.WriteByte((byte)specs.Count);
+				pak.WriteByte((byte)player.SkillSpecialtyPoints);
+				pak.WriteByte(0); // Spec code
+				pak.WriteByte(0);
+
+				int i = 0;
+				foreach (Specialization spec in specs)
+				{
+					pak.WriteByte((byte)i++);
+					pak.WriteByte((byte)Math.Min(player.MaxLevel, spec.Level));
+					pak.WriteByte((byte)(Math.Min(player.MaxLevel, spec.Level) + 1));
+					pak.WritePascalString(spec.Name);
+				}
+				SendTCP(pak);
+			}
+
+			// send RA usable by this class
+			var raList = SkillBase.GetClassRealmAbilities(m_gameClient.Player.CharacterClass.ID).Where(ra => !(ra is RR5RealmAbility));
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.TrainerWindow)))
+			{
+				pak.WriteByte((byte)raList.Count());
+				pak.WriteByte((byte)player.RealmSpecialtyPoints);
+				pak.WriteByte(1); // RA Code
+				pak.WriteByte(0);
+
+				int i = 0;
+				foreach (RealmAbility ra in raList)
+				{
+					int level = player.GetAbilityLevel(ra.KeyName);
+					pak.WriteByte((byte)i++);
+					pak.WriteByte((byte)level);
+					pak.WriteByte((byte)ra.CostForUpgrade(level));
+					bool canBeUsed = ra.CheckRequirement(player);
+					pak.WritePascalString(canBeUsed ? ra.Name : string.Format("[{0}]", ra.Name));
+				}
+				SendTCP(pak);
+			}
+
+			// Send Name Index for each spec.
+			// Get ALL skills for player, ordered by spec key.
+			List<Tuple<Specialization, List<Tuple<int, int, Skill>>>> skillDictCache = null;
+
+			// get from cache
+			if (m_gameClient.TrainerSkillCache == null)
+			{
+				skillDictCache = new List<Tuple<Specialization, List<Tuple<int, int, Skill>>>>();
+
+				foreach (Specialization spec in specs)
+				{
+					var toAdd = new List<Tuple<int, int, Skill>>();
+
+					foreach (Ability ab in spec.PretendAbilitiesForLiving(player, player.MaxLevel))
+					{
+						toAdd.Add(new Tuple<int, int, Skill>(5, ab.InternalID, ab));
+					}
+
+					foreach (KeyValuePair<SpellLine, List<Skill>> ls in spec.PretendLinesSpellsForLiving(player, player.MaxLevel).Where(k => !k.Key.IsBaseLine))
+					{
+						foreach (Skill sk in ls.Value)
+						{
+							toAdd.Add(new Tuple<int, int, Skill>((int)sk.SkillType, sk.InternalID, sk));
+						}
+					}
+
+					foreach (Style st in spec.PretendStylesForLiving(player, player.MaxLevel))
+					{
+						toAdd.Add(new Tuple<int, int, Skill>((int)st.SkillType, st.InternalID, st));
+					}
+
+					skillDictCache.Add(new Tuple<Specialization, List<Tuple<int, int, Skill>>>(spec, toAdd.OrderBy(e => (e.Item3 is Ability) ? ((Ability)e.Item3).SpecLevelRequirement : (((e.Item3 is Style) ? ((Style)e.Item3).SpecLevelRequirement : e.Item3.Level))).ToList()));
+				}
+
+
+
+				// save to cache
+				m_gameClient.TrainerSkillCache = skillDictCache;
+			}
+
+			skillDictCache = m_gameClient.TrainerSkillCache;
+
+			// Send Names first
+			int index = 0;
+			for (int skindex = 0; skindex < skillDictCache.Count; skindex++)
+			{
+				using (GSTCPPacketOut pakindex = new GSTCPPacketOut(GetPacketCode(eServerPackets.TrainerWindow)))
+				{
+					pakindex.WriteByte((byte)skillDictCache[skindex].Item2.Count); //size
+					pakindex.WriteByte((byte)player.SkillSpecialtyPoints);
+					pakindex.WriteByte(4); // name index code
+					pakindex.WriteByte(0);
+					pakindex.WriteByte((byte)index); // start index
+
+					foreach (Skill sk in skillDictCache[skindex].Item2.Select(e => e.Item3))
+					{
+						// send name
+						pakindex.WritePascalString(sk.Name);
+						index++;
+					}
+
+					SendTCP(pakindex);
+				}
+			}
+
+			// Send Skill Secondly
+			using (GSTCPPacketOut pakskill = new GSTCPPacketOut(GetPacketCode(eServerPackets.TrainerWindow)))
+			{
+
+				pakskill.WriteByte((byte)skillDictCache.Count); //size we send for all specs
+				pakskill.WriteByte((byte)player.SkillSpecialtyPoints);
+				pakskill.WriteByte(3); // Skill description code
+				pakskill.WriteByte(0);
+				pakskill.WriteByte((byte)0); // unk ?
+
+				// Fill out an array that tells the client how many spec points are available at each of
+				// this characters levels.  This seems to only be used for the 'Minimum Level' display on
+				// the new trainer window.  I've changed the calls below to use AdjustedSpecPointsMultiplier
+				// to enable servers that allow levels > 50 to train properly by modifying points available per level. - Tolakram
+
+				// There is a bug here that is calculating too few spec points and causing level 50 players to 
+				// be unable to train RA.  Setting this to max for now to disable 'Minimum Level' feature on train window.
+				// I think bug is that auto train points must be added to this calculation.
+				// -Tolakram
+
+				for (byte i = 2; i <= 50; i++)
+				{
+					//int specpoints = 0;
+
+					//if (i <= 5)
+					//    specpoints = i;
+
+					//if (i > 5)
+					//    specpoints = i * _gameClient.Player.CharacterClass.AdjustedSpecPointsMultiplier / 10;
+
+					//if (i > 40 && i != 50)
+					//    specpoints += i * _gameClient.Player.CharacterClass.AdjustedSpecPointsMultiplier / 20;
+
+					//paksub.WriteByte((byte)specpoints);
+					pakskill.WriteByte((byte)255);
+				}
+
+				for (int skindex = 0; skindex < skillDictCache.Count; skindex++)
+				{
+
+					byte autotrain = 0;
+					if (autotrains.Contains(specs[skindex].KeyName))
+					{
+						autotrain = (byte)Math.Floor((double)m_gameClient.Player.BaseLevel / 4);
+					}
+
+					if (pakskill.Length >= 2045)
+						break;
+
+					// Skill Index Header
+					pakskill.WriteByte((byte)skindex); // skill index
+					pakskill.WriteByte((byte)skillDictCache[skindex].Item2.Count); // Count
+					pakskill.WriteByte(autotrain); // autotrain byte
+
+					foreach (Tuple<int, int, Skill> sk in skillDictCache[skindex].Item2)
+					{
+						if (pakskill.Length >= 2040)
+							break;
+
+						if (sk.Item3 is Ability)
+						{
+							Ability ab = (Ability)sk.Item3;
+							// skill description
+							pakskill.WriteByte((byte)ab.SpecLevelRequirement); // level
+																			   // tooltip
+							pakskill.WriteShort((ushort)ab.Icon); // icon
+							pakskill.WriteByte((byte)sk.Item1); // skill page
+							pakskill.WriteByte((byte)0); // 
+							pakskill.WriteByte((byte)0xFD); // line
+							pakskill.WriteShort((ushort)sk.Item2); // ID
+						}
+						else if (sk.Item3 is Spell)
+						{
+							Spell sp = (Spell)sk.Item3;
+							// skill description
+							pakskill.WriteByte((byte)sp.Level); // level
+																// tooltip
+							pakskill.WriteShort(sp.InternalIconID > 0 ? sp.InternalIconID : sp.Icon); // icon
+							pakskill.WriteByte((byte)sk.Item1); // skill page
+							pakskill.WriteByte((byte)0); // 
+							pakskill.WriteByte((byte)(sp.SkillType == eSkillPage.Songs ? 0xFF : 0xFE)); // line
+							pakskill.WriteShort((ushort)sk.Item2); // ID
+						}
+						else if (sk.Item3 is Style)
+						{
+							Style st = (Style)sk.Item3;
+							pakskill.WriteByte((byte)Math.Min(player.MaxLevel, st.SpecLevelRequirement));
+							// tooltip
+							pakskill.WriteShort((ushort)st.Icon);
+							pakskill.WriteByte((byte)sk.Item1);
+							pakskill.WriteByte((byte)st.OpeningRequirementType);
+							pakskill.WriteByte((byte)st.OpeningRequirementValue);
+							pakskill.WriteShort((ushort)sk.Item2);
+						}
+						else
+						{
+							// ??
+							pakskill.WriteByte((byte)sk.Item3.Level);
+							// tooltip
+							pakskill.WriteShort((ushort)sk.Item3.Icon);
+							pakskill.WriteByte((byte)sk.Item1);
+							pakskill.WriteByte((byte)0);
+							pakskill.WriteByte((byte)0);
+							pakskill.WriteShort((ushort)sk.Item2);
+						}
+					}
+				}
+
+				SendTCP(pakskill);
+			}
+
+			// type 5 (realm abilities)
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.TrainerWindow)))
+			{
+				pak.WriteByte((byte)raList.Count());
+				pak.WriteByte((byte)player.RealmSpecialtyPoints);
+				pak.WriteByte(5);
+				pak.WriteByte(0);
+
+				foreach (RealmAbility ra in raList)
+				{
+					pak.WriteByte((byte)player.GetAbilityLevel(ra.KeyName));
+
+					pak.WriteByte(0);
+					pak.WriteByte((byte)ra.MaxLevel);
+
+					for (int i = 0; i < ra.MaxLevel; i++)
+						pak.WriteByte((byte)ra.CostForUpgrade(i));
+
+					if (ra.CheckRequirement(m_gameClient.Player))
+						pak.WritePascalString(ra.KeyName);
+					else
+						pak.WritePascalString(string.Format("[{0}]", ra.Name));
+				}
+				SendTCP(pak);
+			}
+			// Send tooltips
+			if (ForceTooltipUpdate && m_gameClient.TrainerSkillCache != null)
+				SendForceTooltipUpdate(m_gameClient.TrainerSkillCache.SelectMany(e => e.Item2).Select(e => e.Item3));
+		}
+
+		/// <summary>
+		/// Send Delve for Provided Collection of Skills that need forced Tooltip Update.
+		/// </summary>
+		/// <param name="skills"></param>
+		protected virtual void SendForceTooltipUpdate(IEnumerable<Skill> skills)
+		{
+			foreach (Skill t in skills)
+			{
+				if (t is Specialization)
+					continue;
+
+				if (t is RealmAbility)
+				{
+					if (m_gameClient.CanSendTooltip(27, t.InternalID))
+						SendDelveInfo(DOL.GS.PacketHandler.Client.v168.DetailDisplayHandler.DelveRealmAbility(m_gameClient, t.InternalID));
+				}
+				else if (t is Ability)
+				{
+					if (m_gameClient.CanSendTooltip(28, t.InternalID))
+						SendDelveInfo(DOL.GS.PacketHandler.Client.v168.DetailDisplayHandler.DelveAbility(m_gameClient, t.InternalID));
+				}
+				else if (t is Style)
+				{
+					if (m_gameClient.CanSendTooltip(25, t.InternalID))
+						SendDelveInfo(DOL.GS.PacketHandler.Client.v168.DetailDisplayHandler.DelveStyle(m_gameClient, t.InternalID));
+				}
+				else if (t is Spell)
+				{
+					if (t is Song || (t is Spell && ((Spell)t).NeedInstrument))
+					{
+						if (m_gameClient.CanSendTooltip(26, ((Spell)t).InternalID))
+							SendDelveInfo(DOL.GS.PacketHandler.Client.v168.DetailDisplayHandler.DelveSong(m_gameClient, ((Spell)t).InternalID));
+					}
+
+					if (m_gameClient.CanSendTooltip(24, ((Spell)t).InternalID))
+						SendDelveInfo(DOL.GS.PacketHandler.Client.v168.DetailDisplayHandler.DelveSpell(m_gameClient, ((Spell)t).InternalID));
+				}
+			}
+		}
+
+		public virtual void SendUpdateIcons(IList changedEffects, ref int lastUpdateEffectsCount)
+		{
+			if (m_gameClient.Player == null)
+			{
+				return;
+			}
+
+			IList<int> tooltipids = new List<int>();
+
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.UpdateIcons)))
+			{
+				long initPos = pak.Position;
+
+				int fxcount = 0;
+				int entriesCount = 0;
+
+				pak.WriteByte(0); // effects count set in the end
+				pak.WriteByte(0); // unknown
+				pak.WriteByte(Icons); // unknown
+				pak.WriteByte(0); // unknown
+
+				foreach (IGameEffect effect in m_gameClient.Player.EffectList)
+				{
+					if (effect.Icon != 0)
+					{
+						fxcount++;
+						if (changedEffects != null && !changedEffects.Contains(effect))
+						{
+							continue;
+						}
+
+						// store tooltip update for gamespelleffect.
+						if (ForceTooltipUpdate && (effect is GameSpellEffect))
+						{
+							Spell spell = ((GameSpellEffect)effect).Spell;
+							tooltipids.Add(spell.InternalID);
+						}
+
+						//						log.DebugFormat("adding [{0}] '{1}'", fxcount-1, effect.Name);
+						pak.WriteByte((byte)(fxcount - 1)); // icon index
+						pak.WriteByte((effect is GameSpellEffect || effect.Icon > 5000) ? (byte)(fxcount - 1) : (byte)0xff);
+
+						byte ImmunByte = 0;
+						var gsp = effect as GameSpellEffect;
+						if (gsp != null && gsp.IsDisabled)
+							ImmunByte = 1;
+						pak.WriteByte(ImmunByte); // new in 1.73; if non zero says "protected by" on right click
+
+						// bit 0x08 adds "more..." to right click info
+						pak.WriteShort(effect.Icon);
+						//pak.WriteShort(effect.IsFading ? (ushort)1 : (ushort)(effect.RemainingTime / 1000));
+						pak.WriteShort((ushort)(effect.RemainingTime / 1000));
+						if (effect is GameSpellEffect)
+							pak.WriteShort((ushort)((GameSpellEffect)effect).Spell.InternalID); //v1.110+ send the spell ID for delve info in active icon
+						else
+							pak.WriteShort(0);//don't override existing tooltip ids
+
+						byte flagNegativeEffect = 0;
+						if (effect is StaticEffect)
+						{
+							if (((StaticEffect)effect).HasNegativeEffect)
+							{
+								flagNegativeEffect = 1;
+							}
+						}
+						else if (effect is GameSpellEffect)
+						{
+							if (!((GameSpellEffect)effect).SpellHandler.HasPositiveEffect)
+							{
+								flagNegativeEffect = 1;
+							}
+						}
+						pak.WriteByte(flagNegativeEffect);
+
+						pak.WritePascalString(effect.Name);
+						entriesCount++;
+					}
+				}
+
+				int oldCount = lastUpdateEffectsCount;
+				lastUpdateEffectsCount = fxcount;
+
+				while (oldCount > fxcount)
+				{
+					pak.WriteByte((byte)(fxcount++));
+					pak.Fill(0, 10);
+					entriesCount++;
+					//					log.DebugFormat("adding [{0}] (empty)", fxcount-1);
+				}
+
+				if (changedEffects != null)
+				{
+					changedEffects.Clear();
+				}
+
+				if (entriesCount == 0)
+				{
+					return; // nothing changed - no update is needed
+				}
+
+				pak.Position = initPos;
+				pak.WriteByte((byte)entriesCount);
+				pak.Seek(0, SeekOrigin.End);
+
+				SendTCP(pak);
+			}
+
+			// force tooltips update
+			foreach (int entry in tooltipids)
+			{
+				if (m_gameClient.CanSendTooltip(24, entry))
+					SendDelveInfo(DOL.GS.PacketHandler.Client.v168.DetailDisplayHandler.DelveSpell(m_gameClient, entry));
+			}
+		}
+
+		public virtual void SendUpdatePoints()
+		{
+			if (m_gameClient.Player == null)
+				return;
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.CharacterPointsUpdate)))
+			{
+				pak.WriteInt((uint)m_gameClient.Player.RealmPoints);
+				pak.WriteShort(m_gameClient.Player.LevelPermill);
+				pak.WriteShort((ushort)m_gameClient.Player.SkillSpecialtyPoints);
+				pak.WriteInt((uint)m_gameClient.Player.BountyPoints);
+				pak.WriteShort((ushort)m_gameClient.Player.RealmSpecialtyPoints);
+				pak.WriteShort(m_gameClient.Player.ChampionLevelPermill);
+				pak.WriteLongLowEndian((ulong)m_gameClient.Player.Experience);
+				pak.WriteLongLowEndian((ulong)m_gameClient.Player.ExperienceForNextLevel);
+				pak.WriteLongLowEndian(0);//champExp
+				pak.WriteLongLowEndian(0);//champExpNextLevel
+				SendTCP(pak);
+			}
+		}
+		public virtual void SendUpdatePlayer()
+		{
+			GamePlayer player = m_gameClient.Player;
+			if (player == null)
+				return;
+
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.VariousUpdate)))
+			{
+				pak.WriteByte(0x03); //subcode
+				pak.WriteByte(0x0f); //number of entry
+				pak.WriteByte(0x00); //subtype
+				pak.WriteByte(0x00); //unk
+									 //entry :
+
+				pak.WriteByte(player.GetDisplayLevel(m_gameClient.Player)); //level
+				pak.WritePascalString(player.Name); // player name
+				pak.WriteByte((byte)(player.MaxHealth >> 8)); // maxhealth high byte ?
+				pak.WritePascalString(player.CharacterClass.Name); // class name
+				pak.WriteByte((byte)(player.MaxHealth & 0xFF)); // maxhealth low byte ?
+				pak.WritePascalString( /*"The "+*/player.CharacterClass.Profession); // Profession
+				pak.WriteByte(0x00); //unk
+				pak.WritePascalString(player.CharacterClass.GetTitle(player, player.Level)); // player level
+																							 //todo make function to calcule realm rank
+																							 //client.Player.RealmPoints
+																							 //todo i think it s realmpoint percent not realrank
+				pak.WriteByte((byte)player.RealmLevel); //urealm rank
+				pak.WritePascalString(player.RealmRankTitle(player.Client.Account.Language)); // Realm title
+				pak.WriteByte((byte)player.RealmSpecialtyPoints); // realm skill points
+				pak.WritePascalString(player.CharacterClass.BaseName); // base class
+				pak.WriteByte((byte)(HouseMgr.GetHouseNumberByPlayer(player) >> 8)); // personal house high byte
+				pak.WritePascalString(player.GuildName); // Guild name
+				pak.WriteByte((byte)(HouseMgr.GetHouseNumberByPlayer(player) & 0xFF)); // personal house low byte
+				pak.WritePascalString(player.LastName); // Last name
+				pak.WriteByte((byte)(player.MLLevel + 1)); // ML Level (+1)
+				pak.WritePascalString(player.RaceName); // Race name
+				pak.WriteByte(0x0);
+
+				if (player.GuildRank != null)
+					pak.WritePascalString(player.GuildRank.Title); // Guild title
+				else
+					pak.WritePascalString("");
+				pak.WriteByte(0x0);
+
+				AbstractCraftingSkill skill = CraftingMgr.getSkillbyEnum(player.CraftingPrimarySkill);
+				if (skill != null)
+					pak.WritePascalString(skill.Name); //crafter guilde: alchemist
+				else
+					pak.WritePascalString("None"); //no craft skill at start
+
+				pak.WriteByte(0x0);
+				pak.WritePascalString(player.CraftTitle.GetValue(player, player)); //crafter title: legendary alchemist
+				pak.WriteByte(0x0);
+				pak.WritePascalString(player.MLTitle.GetValue(player, player)); //ML title
+
+				// new in 1.75
+				pak.WriteByte(0x0);
+				if (player.CurrentTitle != PlayerTitleMgr.ClearTitle)
+					pak.WritePascalString(player.CurrentTitle.GetValue(player, player)); // new in 1.74 - Custom title
+				else
+					pak.WritePascalString("None");
+
+				// new in 1.79
+				if (player.Champion)
+					pak.WriteByte((byte)(player.ChampionLevel + 1)); // Champion Level (+1)
+				else
+					pak.WriteByte(0x0);
+				pak.WritePascalString(player.CLTitle.GetValue(player, player)); // Champion Title
+				SendTCP(pak);
+			}
+		}
+		public virtual void SendUpdatePlayerSkills()
+		{
+			if (m_gameClient.Player == null)
+				return;
+
+			// Get Skills as "Usable Skills" which are in network order ! (with forced update)
+			List<Tuple<Skill, Skill>> usableSkills = m_gameClient.Player.GetAllUsableSkills(true);
+
+			bool sent = false; // set to true once we can't send packet anymore !
+			int index = 0; // index of our position in the list !
+			int total = usableSkills.Count; // cache List count.
+			int packetCount = 0; // Number of packet sent for the entire list
+			while (!sent)
+			{
+				int packetEntry = 0; // needed to tell client how much skill we send
+									 // using pak
+				using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.VariousUpdate)))
+				{
+					// Write header
+					pak.WriteByte(0x01); //subcode for skill
+					pak.WriteByte((byte)0); //packet entries, can't know it for now...
+					pak.WriteByte((byte)0x03); //subtype for following pages
+					pak.WriteByte((byte)index); // packet first entry
+
+					// getting pak filled
+					while (index < total)
+					{
+						// this item will break the limit, send the packet before, keep index as is to continue !
+						if ((index >= byte.MaxValue) || ((pak.Length + 8 + usableSkills[index].Item1.Name.Length) > 1400))
+						{
+							break;
+						}
+
+						// Enter Packet Values !! Format Level - Type - SpecialField - Bonus - Icon - Name
+						Skill skill = usableSkills[index].Item1;
+						Skill skillrelated = usableSkills[index].Item2;
+
+						if (skill is Specialization)
+						{
+							Specialization spec = (Specialization)skill;
+							pak.WriteByte((byte)spec.Level);
+							pak.WriteShort((ushort)spec.InternalID); //new 1.112
+							pak.WriteByte((byte)spec.SkillType);
+							pak.WriteShort(0);
+							pak.WriteByte((byte)(m_gameClient.Player.GetModifiedSpecLevel(spec.KeyName) - spec.Level)); // bonus
+							pak.WriteShort((ushort)spec.Icon);
+							pak.WritePascalString(spec.Name);
+						}
+						else if (skill is Ability)
+						{
+							Ability ab = (Ability)skill;
+							pak.WriteByte((byte)ab.Level);
+							pak.WriteShort((ushort)ab.InternalID); //new 1.112
+							pak.WriteByte((byte)ab.SkillType);
+							pak.WriteShort(0);
+							pak.WriteByte((byte)0);
+							pak.WriteShort((ushort)ab.Icon);
+							pak.WritePascalString(ab.Name);
+
+						}
+						else if (skill is Spell)
+						{
+							Spell spell = (Spell)skill;
+							pak.WriteByte((byte)spell.Level);
+							pak.WriteShort((ushort)spell.InternalID); //new 1.112
+							pak.WriteByte((byte)spell.SkillType);
+
+							// spec index for this Spell - Special for Song and Unknown Indexes...
+							int spin = 0;
+							if (spell.SkillType == eSkillPage.Songs)
+							{
+								spin = 0xFF;
+							}
+							else
+							{
+								// find this line Specialization index !
+								if (skillrelated is SpellLine && !Util.IsEmpty(((SpellLine)skillrelated).Spec))
+								{
+									spin = usableSkills.FindIndex(sk => (sk.Item1 is Specialization) && ((Specialization)sk.Item1).KeyName == ((SpellLine)skillrelated).Spec);
+
+									if (spin == -1)
+										spin = 0xFE;
+								}
+								else
+								{
+									spin = 0xFE;
+								}
+							}
+
+							pak.WriteShort((ushort)spin); // special index for spellline
+							pak.WriteByte(0); // bonus
+							pak.WriteShort(spell.InternalIconID > 0 ? spell.InternalIconID : spell.Icon); // icon
+							pak.WritePascalString(spell.Name);
+						}
+						else if (skill is Style)
+						{
+							Style style = (Style)skill;
+							pak.WriteByte((byte)style.SpecLevelRequirement);
+							pak.WriteShort((ushort)style.InternalID); //new 1.112
+							pak.WriteByte((byte)style.SkillType);
+
+							// Special pre-requisite (First byte is Pre-requisite Icon / second Byte is prerequisite code...)
+							int pre = 0;
+
+							switch (style.OpeningRequirementType)
+							{
+								case Style.eOpening.Offensive:
+									pre = (int)style.AttackResultRequirement; // last result of our attack against enemy hit, miss, target blocked, target parried, ...
+									if (style.AttackResultRequirement == Style.eAttackResultRequirement.Style)
+									{
+										// get style requirement value... find prerequisite style index from specs beginning...
+										int styleindex = Math.Max(0, usableSkills.FindIndex(it => (it.Item1 is Style) && it.Item1.ID == style.OpeningRequirementValue));
+										int speccount = Math.Max(0, usableSkills.FindIndex(it => (it.Item1 is Specialization) == false));
+										pre |= ((byte)(100 + styleindex - speccount)) << 8;
+									}
+									break;
+								case Style.eOpening.Defensive:
+									pre = 100 + (int)style.AttackResultRequirement; // last result of enemies attack against us hit, miss, you block, you parry, ...
+									break;
+								case Style.eOpening.Positional:
+									pre = 200 + style.OpeningRequirementValue;
+									break;
+							}
+
+							// style required?
+							if (pre == 0)
+								pre = 0x100;
+
+							pak.WriteShort((ushort)pre);
+							pak.WriteByte(GlobalConstants.GetSpecToInternalIndex(style.Spec)); // index specialization in bonus...
+							pak.WriteShort((ushort)style.Icon);
+							pak.WritePascalString(style.Name);
+						}
+
+						packetEntry++;
+						index++;
+					}
+
+					// test if we finished sending packets
+					if (index >= total || index >= byte.MaxValue)
+						sent = true;
+
+					// rewrite header for count.
+					pak.Position = 4;
+					pak.WriteByte((byte)packetEntry);
+
+					if (!sent)
+						pak.WriteByte((byte)99);
+
+					SendTCP(pak);
+
+				}
+
+				packetCount++;
+			}
+
+			// Send List Cast Spells...
+			SendNonHybridSpellLines();
+			// clear trainer cache
+			m_gameClient.TrainerSkillCache = null;
+
+			if (ForceTooltipUpdate)
+				SendForceTooltipUpdate(usableSkills.Select(t => t.Item1));
+		}
+		public virtual void SendUDPInitReply()
+		{
+			using (var pak = new GSUDPPacketOut(GetPacketCode(eServerPackets.UDPInitReply)))
+			{
+				Region playerRegion = null;
+				if (!m_gameClient.Socket.Connected) // || !_gameClient.UsingRC4) // not using RC4, wont accept UDP packets anyway.)
+				{
+					return;
+				}
+				if (m_gameClient.Player != null && m_gameClient.Player.CurrentRegion != null)
+				{
+					playerRegion = m_gameClient.Player.CurrentRegion;
+				}
+				if (playerRegion == null)
+				{
+					pak.Fill(0x0, 0x18);
+				}
+				else
+				{
+					//Try to fix the region ip so UDP is enabled!
+					string ip = playerRegion.ServerIP;
+					if (ip == "any" || ip == "0.0.0.0" || ip == "127.0.0.1" || ip.StartsWith("10.13.") || ip.StartsWith("192.168."))
+					{
+						ip = ((IPEndPoint)m_gameClient.Socket.LocalEndPoint).Address.ToString();
+					}
+					pak.FillString(ip, 22);
+					pak.WriteShort(playerRegion.ServerPort);
+				}
+				SendUDP(pak, true);
+			}
+		}
+		public virtual void SendVampireEffect(GameLiving living, bool show)
+		{
+			if (m_gameClient.Player == null || living == null)
+				return;
+
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.VisualEffect)))
+			{
+
+				pak.WriteShort((ushort)living.ObjectID);
+				pak.WriteByte(0x4); // Vampire (can fly)
+				pak.WriteByte((byte)(show ? 0 : 1)); // 0-enable, 1-disable
+				pak.WriteInt(0);
+
+				SendTCP(pak);
+			}
+		}
+		/// <summary>
+		/// Reply on Server Opening to Client Encryption Request
+		/// Actually forces Encryption Off to work with Portal.
+		/// </summary>
+		public virtual void SendVersionAndCryptKey()
+		{
+			//Construct the new packet
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.CryptKey)))
+			{
+				pak.WriteByte((byte)m_gameClient.ClientType);
+
+				//Disable encryption (1110+ always encrypt)
+				pak.WriteByte(0x00);
+
+				// Reply with current version
+				pak.WriteString((((int)m_gameClient.Version) / 1000) + "." + (((int)m_gameClient.Version) - 1000), 5);
+
+				// revision, last seen (c) 0x63
+				pak.WriteByte((byte)m_gameClient.MinorRev[0]);
+
+				// Build number
+				pak.WriteByte(m_gameClient.MajorBuild); // last seen : 0x44 0x05
+				pak.WriteByte(m_gameClient.MinorBuild);
+				SendTCP(pak);
+			}
+		}
+		public virtual void SendWarlockChamberEffect(GamePlayer player)
+		{
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.VisualEffect)))
+			{
+
+				pak.WriteShort((ushort)player.ObjectID);
+				pak.WriteByte((byte)3);
+
+				SortedList sortList = new SortedList();
+				sortList.Add(1, null);
+				sortList.Add(2, null);
+				sortList.Add(3, null);
+				sortList.Add(4, null);
+				sortList.Add(5, null);
+				lock (player.EffectList)
+				{
+					foreach (IGameEffect fx in player.EffectList)
+					{
+						if (fx is GameSpellEffect)
+						{
+							GameSpellEffect effect = (GameSpellEffect)fx;
+							if (effect.SpellHandler.Spell != null && (effect.SpellHandler.Spell.SpellType == "Chamber"))
+							{
+								ChamberSpellHandler chamber = (ChamberSpellHandler)effect.SpellHandler;
+								sortList[chamber.EffectSlot] = effect;
+							}
+						}
+					}
+					foreach (GameSpellEffect effect in sortList.Values)
+					{
+						if (effect == null)
+						{
+							pak.WriteByte((byte)0);
+						}
+						else
+						{
+							ChamberSpellHandler chamber = (ChamberSpellHandler)effect.SpellHandler;
+							if (chamber.PrimarySpell != null && chamber.SecondarySpell == null)
+							{
+								pak.WriteByte((byte)3);
+							}
+							else if (chamber.PrimarySpell != null && chamber.SecondarySpell != null)
+							{
+								if (chamber.SecondarySpell.SpellType == "Lifedrain")
+									pak.WriteByte(0x11);
+								else if (chamber.SecondarySpell.SpellType.IndexOf("SpeedDecrease") != -1)
+									pak.WriteByte(0x33);
+								else if (chamber.SecondarySpell.SpellType == "PowerRegenBuff")
+									pak.WriteByte(0x77);
+								else if (chamber.SecondarySpell.SpellType == "DirectDamage")
+									pak.WriteByte(0x66);
+								else if (chamber.SecondarySpell.SpellType == "SpreadHeal")
+									pak.WriteByte(0x55);
+								else if (chamber.SecondarySpell.SpellType == "Nearsight")
+									pak.WriteByte(0x44);
+								else if (chamber.SecondarySpell.SpellType == "DamageOverTime")
+									pak.WriteByte(0x22);
+							}
+						}
+					}
+				}
+				//pak.WriteByte(0x11);
+				//pak.WriteByte(0x22);
+				//pak.WriteByte(0x33);
+				//pak.WriteByte(0x44);
+				//pak.WriteByte(0x55);
+				pak.WriteInt(0);
+
+				foreach (GamePlayer plr in player.GetPlayersInRadius(WorldMgr.VISIBILITY_DISTANCE))
+				{
+					if (player != plr)
+						plr.Client.PacketProcessor.SendTCP(pak);
+				}
+
+				SendTCP(pak);
+			}
+		}
+		public virtual void SendWarmapBonuses()
+		{
+			if (m_gameClient.Player == null) return;
+			int AlbTowers = 0;
+			int MidTowers = 0;
+			int HibTowers = 0;
+			int AlbKeeps = 0;
+			int MidKeeps = 0;
+			int HibKeeps = 0;
+			int OwnerDFTowers = 0;
+			eRealm OwnerDF = eRealm.None;
+			foreach (AbstractGameKeep keep in GameServer.KeepManager.GetFrontierKeeps())
+			{
+
+				switch ((eRealm)keep.Realm)
+				{
+					case eRealm.Albion:
+						if (keep is GameKeep)
+							AlbKeeps++;
+						else
+							AlbTowers++;
+						break;
+					case eRealm.Midgard:
+						if (keep is GameKeep)
+							MidKeeps++;
+						else
+							MidTowers++;
+						break;
+					case eRealm.Hibernia:
+						if (keep is GameKeep)
+							HibKeeps++;
+						else
+							HibTowers++;
+						break;
+					default:
+						break;
+				}
+			}
+			if (AlbTowers > MidTowers && AlbTowers > HibTowers)
+			{
+				OwnerDF = eRealm.Albion;
+				OwnerDFTowers = AlbTowers;
+			}
+			else if (MidTowers > AlbTowers && MidTowers > HibTowers)
+			{
+				OwnerDF = eRealm.Midgard;
+				OwnerDFTowers = MidTowers;
+			}
+			else if (HibTowers > AlbTowers && HibTowers > MidTowers)
+			{
+				OwnerDF = eRealm.Hibernia;
+				OwnerDFTowers = HibTowers;
+			}
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.WarmapBonuses)))
+			{
+				int RealmKeeps = 0;
+				int RealmTowers = 0;
+				switch ((eRealm)m_gameClient.Player.Realm)
+				{
+					case eRealm.Albion:
+						RealmKeeps = AlbKeeps;
+						RealmTowers = AlbTowers;
+						break;
+					case eRealm.Midgard:
+						RealmKeeps = MidKeeps;
+						RealmTowers = MidTowers;
+						break;
+					case eRealm.Hibernia:
+						RealmKeeps = HibKeeps;
+						RealmTowers = HibTowers;
+						break;
+					default:
+						break;
+				}
+				pak.WriteByte((byte)RealmKeeps);
+				pak.WriteByte((byte)(((byte)RelicMgr.GetRelicCount(m_gameClient.Player.Realm, eRelicType.Magic)) << 4 | (byte)RelicMgr.GetRelicCount(m_gameClient.Player.Realm, eRelicType.Strength)));
+				pak.WriteByte((byte)OwnerDF);
+				pak.WriteByte((byte)RealmTowers);
+				pak.WriteByte((byte)OwnerDFTowers);
+				SendTCP(pak);
+			}
+		}
+		public virtual void SendWarmapUpdate(ICollection<IGameKeep> list)
+		{
+			if (m_gameClient.Player == null) return;
+
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.WarMapClaimedKeeps)))
+			{
+				int KeepCount = 0;
+				int TowerCount = 0;
+				foreach (AbstractGameKeep keep in list)
+				{
+					// New Agramon tower are counted as keep
+					if (keep is GameKeep || (keep.KeepID & 0xFF) > 150)
+						KeepCount++;
+					else
+						TowerCount++;
+				}
+				pak.WriteShort(0x0F00);
+				pak.WriteByte((byte)KeepCount);
+				pak.WriteByte((byte)TowerCount);
+				byte albStr = 0;
+				byte hibStr = 0;
+				byte midStr = 0;
+				byte albMagic = 0;
+				byte hibMagic = 0;
+				byte midMagic = 0;
+				foreach (GameRelic relic in RelicMgr.getNFRelics())
+				{
+					switch (relic.OriginalRealm)
+					{
+						case eRealm.Albion:
+							if (relic.RelicType == eRelicType.Strength)
+							{
+								albStr = (byte)relic.Realm;
+							}
+							if (relic.RelicType == eRelicType.Magic)
+							{
+								albMagic = (byte)relic.Realm;
+							}
+							break;
+						case eRealm.Hibernia:
+							if (relic.RelicType == eRelicType.Strength)
+							{
+								hibStr = (byte)relic.Realm;
+							}
+							if (relic.RelicType == eRelicType.Magic)
+							{
+								hibMagic = (byte)relic.Realm;
+							}
+							break;
+						case eRealm.Midgard:
+							if (relic.RelicType == eRelicType.Strength)
+							{
+								midStr = (byte)relic.Realm;
+							}
+							if (relic.RelicType == eRelicType.Magic)
+							{
+								midMagic = (byte)relic.Realm;
+							}
+							break;
+					}
+				}
+				pak.WriteByte(albStr);
+				pak.WriteByte(midStr);
+				pak.WriteByte(hibStr);
+				pak.WriteByte(albMagic);
+				pak.WriteByte(midMagic);
+				pak.WriteByte(hibMagic);
+				foreach (AbstractGameKeep keep in list)
+				{
+					int keepId = keep.KeepID;
+
+					/*if (ServerProperties.Properties.USE_NEW_KEEPS == 1 || ServerProperties.Properties.USE_NEW_KEEPS == 2)
+	                {
+	                    keepId -= 12;
+	                    if ((keep.KeepID > 74 && keep.KeepID < 114) || (keep.KeepID > 330 && keep.KeepID < 370) || (keep.KeepID > 586 && keep.KeepID < 626) 
+	                        || (keep.KeepID > 842 && keep.KeepID < 882) || (keep.KeepID > 1098 && keep.KeepID < 1138)) 
+	                        keepId += 5;
+	                }*/
+
+					int id = keepId & 0xFF;
+					int tower = keep.KeepID >> 8;
+					int map = (id / 25) - 1;
+
+					int index = id - (map * 25 + 25);
+
+					// Special Agramon zone
+					if ((keep.KeepID & 0xFF) > 150)
+						index = keep.KeepID - 151;
+
+					int flag = (byte)keep.Realm; // 3 bits
+					Guild guild = keep.Guild;
+					string name = "";
+					// map is now 0 indexed
+					pak.WriteByte((byte)(((map - 1) << 6) | (index << 3) | tower));
+					if (guild != null)
+					{
+						flag |= (byte)eRealmWarmapKeepFlags.Claimed;
+						name = guild.Name;
+					}
+
+					//Teleport
+					if (m_gameClient.Account.PrivLevel > (int)ePrivLevel.Player)
+					{
+						flag |= (byte)eRealmWarmapKeepFlags.Teleportable;
+					}
+					else
+					{
+						if (GameServer.KeepManager.FrontierRegionsList.Contains(m_gameClient.Player.CurrentRegionID) && m_gameClient.Player.Realm == keep.Realm)
+						{
+							GameKeep theKeep = keep as GameKeep;
+							if (theKeep != null)
+							{
+								if (theKeep.OwnsAllTowers && !theKeep.InCombat)
+								{
+									flag |= (byte)eRealmWarmapKeepFlags.Teleportable;
+								}
+							}
+						}
+					}
+
+					if (keep.InCombat)
+					{
+						flag |= (byte)eRealmWarmapKeepFlags.UnderSiege;
+					}
+
+					pak.WriteByte((byte)flag);
+					pak.WritePascalString(name);
+				}
+				SendTCP(pak);
+			}
+		}
+
+		public virtual void SendWarmapDetailUpdate(List<List<byte>> fights, List<List<byte>> groups)
+		{
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.WarMapDetailUpdate)))
+			{
+				pak.WriteByte((byte)fights.Count);// count - Fights (Byte)
+				pak.WriteByte((byte)groups.Count);// count - Groups (Byte)
+												  // order first fights after than groups
+
+				// zoneid  - byte // zoneid from zones.xml
+				//			- A7 - Mid	- left			-	10100111		Map: Midgard
+				//			- A8 - Mid	- middle		-	10101000			| X	|
+				//			- A9 - Mid	- right			-	10101001		|x	  x		x	|
+				//			- AA - Mid	- middle  - top	-	10101010
+				//
+				//			- AB - Hib	- top			-	10101011	171		Map: Hibernia
+				//			- AC - Hib	- middle		-	10101100				|X		|
+				//			- AD - Hib	- middle -left	-	10101101			|x	 x		|
+				//			- AE - Hib	- bottom		-	10101110				|x		|
+
+				//			- AF - Alb	- bottom		-	10101111			Map: Albion
+				//			- B0 - Alb	- middle -right	-	10110000			|X	|
+				//			- B1 - Alb	- middle -left	-	10110001			|x	 x	|
+				//			- B2 - Alb	- top			-	10110010	178		|X	|
+
+				// position   x/y offset  x<<4,y
+
+				foreach (List<byte> obj in fights)
+				{
+					pak.WriteByte(obj[0]);// zoneid
+					pak.WriteByte((byte)((obj[1] << 4) | (obj[2] & 0x0f))); // position
+					pak.WriteByte(obj[3]);// color - ( Fights:  0x00 - Grey , 0x01 - RedBlue , 0x02 - RedGreen , 0x03 - GreenBlue )
+					pak.WriteByte(obj[4]);// type  - ( Fights:  Size 0x00 - small  0x01 - medium  0x02 - big 0x03 - huge )
+				}
+
+				foreach (List<byte> obj in groups)
+				{
+					pak.WriteByte(obj[0]);// zoneid
+					pak.WriteByte((byte)(obj[1] << 4 | obj[2])); // position
+					byte realm = obj[3];
+
+					pak.WriteByte((byte)((realm == 3) ? 0x04 : (realm == 2) ? 0x02 : 0x01));//	color   ( Groups:  0x01 - Alb  , 0x02 - Mid , 0x04 - Hib
+					switch ((eRealm)obj[3])
+					{
+						//	type    ( Groups:	Alb:	type	   0x03,0x02,0x01	& 0x03
+						//						Mid:	type << 2  0x0C,0x08,0x04 	& 0x03
+						//						Hib:	type << 4  0x30,0x20,0x10	& 0x03  )
+						case eRealm.Albion:
+						default:
+							pak.WriteByte(obj[4]);
+							break;
+						case eRealm.Midgard:
+							pak.WriteByte((byte)(obj[4] << 2));
+							break;
+						case eRealm.Hibernia:
+							pak.WriteByte((byte)(obj[4] << 4));
+							break;
+					}
+				}
+
+				SendTCP(pak);
+			}
+		}
+		protected void WriteCustomTextWindowData(GSTCPPacketOut pak, IList<string> text)
+		{
+			byte line = 0;
+			bool needBreak = false;
+
+			foreach (var listStr in text)
+			{
+				string str = listStr;
+
+				if (str != null)
+				{
+					if (pak.Position + 4 > MaxPacketLength) // line + pascalstringline(1) + trailingZero
+						return;
+
+					pak.WriteByte(++line);
+
+					while (str.Length > byte.MaxValue)
+					{
+						string s = str.Substring(0, byte.MaxValue);
+
+						if (pak.Position + s.Length + 2 > MaxPacketLength)
+						{
+							needBreak = true;
+							break;
+						}
+
+						pak.WritePascalString(s);
+						str = str.Substring(byte.MaxValue, str.Length - byte.MaxValue);
+						if (line >= 200 || pak.Position + Math.Min(byte.MaxValue, str.Length) + 2 >= MaxPacketLength)
+							// line + pascalstringline(1) + trailingZero
+							return;
+
+						pak.WriteByte(++line);
+					}
+
+					if (pak.Position + str.Length + 2 > MaxPacketLength) // str.Length + trailing zero
+					{
+						str = str.Substring(0, (int)Math.Max(Math.Min(1, str.Length), MaxPacketLength - pak.Position - 2));
+						needBreak = true;
+					}
+
+					pak.WritePascalString(str);
+
+					if (needBreak || line >= 200) // Check max packet length or max stings in window (0 - 199)
+						break;
+				}
+			}
+		}
+		protected virtual void WriteGroupMemberUpdate(GSTCPPacketOut pak, bool updateIcons, GameLiving living)
+		{
+			pak.WriteByte((byte)(living.GroupIndex + 1)); // From 1 to 8
+			bool sameRegion = living.CurrentRegion == m_gameClient.Player.CurrentRegion;
+			GamePlayer player = null;
+
+			if (sameRegion)
+			{
+
+				player = living as GamePlayer;
+
+				if (player != null)
+					pak.WriteByte(player.CharacterClass.HealthPercentGroupWindow);
+				else
+					pak.WriteByte(living.HealthPercent);
+
+				pak.WriteByte(living.ManaPercent);
+				pak.WriteByte(living.EndurancePercent); // new in 1.69
+
+				byte playerStatus = 0;
+				if (!living.IsAlive)
+					playerStatus |= 0x01;
+				if (living.IsMezzed)
+					playerStatus |= 0x02;
+				if (living.IsDiseased)
+					playerStatus |= 0x04;
+				if (SpellHelper.FindEffectOnTarget(living, "DamageOverTime") != null)
+					playerStatus |= 0x08;
+				if (living is GamePlayer)
+				{
+					if ((living as GamePlayer).Client.ClientState == GameClient.eClientState.Linkdead)
+						playerStatus |= 0x10;
+				}
+				if (!sameRegion)
+					playerStatus |= 0x20;
+				if (living.DebuffCategory[(int)eProperty.SpellRange] != 0 || living.DebuffCategory[(int)eProperty.ArcheryRange] != 0)
+					playerStatus |= 0x40;
+
+				pak.WriteByte(playerStatus);
+				// 0x00 = Normal , 0x01 = Dead , 0x02 = Mezzed , 0x04 = Diseased ,
+				// 0x08 = Poisoned , 0x10 = Link Dead , 0x20 = In Another Region, 0x40 - NS
+
+				if (updateIcons)
+				{
+					pak.WriteByte((byte)(0x80 | living.GroupIndex));
+					lock (living.EffectList)
+					{
+						byte i = 0;
+						foreach (IGameEffect effect in living.EffectList)
+							if (effect is GameSpellEffect)
+								i++;
+						pak.WriteByte(i);
+						foreach (IGameEffect effect in living.EffectList)
+							if (effect is GameSpellEffect)
+							{
+								pak.WriteByte(0);
+								pak.WriteShort(effect.Icon);
+							}
+					}
+				}
+				WriteGroupMemberMapUpdate(pak, living);
+			}
+			else
+			{
+				pak.WriteInt(0x20);
+				if (updateIcons)
+				{
+					pak.WriteByte((byte)(0x80 | living.GroupIndex));
+					pak.WriteByte(0);
+				}
+			}
+		}
+		protected virtual void WriteGroupMemberMapUpdate(GSTCPPacketOut pak, GameLiving living)
+		{
+			bool sameRegion = living.CurrentRegion == m_gameClient.Player.CurrentRegion;
+			if (sameRegion && living.CurrentSpeed != 0)//todo : find a better way to detect when player change coord
+			{
+				Zone zone = living.CurrentZone;
+				if (zone == null)
+					return;
+				pak.WriteByte((byte)(0x40 | living.GroupIndex));
+				//Dinberg - ZoneSkinID for group members aswell.
+				pak.WriteShort(zone.ZoneSkinID);
+				pak.WriteShort((ushort)(living.X - zone.XOffset));
+				pak.WriteShort((ushort)(living.Y - zone.YOffset));
+			}
+		}
+		protected virtual void WriteHouseFurniture(GSTCPPacketOut pak, IndoorItem item, int index)
+		{
+			pak.WriteByte((byte)index);
+			byte type = 0;
+			if (item.Emblem > 0)
+				item.Color = item.Emblem;
+			if (item.Color > 0)
+			{
+				if (item.Color <= 0xFF)
+					type |= 1; // colored
+				else if (item.Color <= 0xFFFF)
+					type |= 2; // old emblem
+				else
+					type |= 6; // new emblem
+			}
+			if (item.Size != 0)
+				type |= 8; // have size
+			pak.WriteByte(type);
+			pak.WriteShort((ushort)item.Model);
+			if ((type & 1) == 1)
+				pak.WriteByte((byte)item.Color);
+			else if ((type & 6) == 2)
+				pak.WriteShort((ushort)item.Color);
+			else if ((type & 6) == 6)
+				pak.WriteShort((ushort)(item.Color & 0xFFFF));
+			pak.WriteShort((ushort)item.X);
+			pak.WriteShort((ushort)item.Y);
+			pak.WriteShort((ushort)item.Rotation);
+			if ((type & 8) == 8)
+				pak.WriteByte((byte)item.Size);
+			pak.WriteByte((byte)item.Position);
+			pak.WriteByte((byte)(item.PlacementMode - 2));
+		}
+		/// <summary>
+		/// New item data packet for 1.119
 		/// </summary>		
-		public override void SendPlayerForgedPosition(GamePlayer player)
-        {
-            using (GSUDPPacketOut pak = new GSUDPPacketOut(GetPacketCode(eServerPackets.PlayerPosition)))
-            {                
-                int heading = 4096 + player.Heading;
-                pak.WriteFloatLowEndian(player.X);
-                pak.WriteFloatLowEndian(player.Y);
-                pak.WriteFloatLowEndian(player.Z);
-                pak.WriteFloatLowEndian(player.CurrentSpeed);
-                pak.WriteInt(0); // needs to be Zaxis speed
-                pak.WriteShort((ushort)player.Client.SessionID);
-                pak.WriteShort(player.CurrentZone.ZoneSkinID);
-                // Write Speed
-                if (player.Steed != null && player.Steed.ObjectState == GameObject.eObjectState.Active)
-                {
-                    player.Heading = player.Steed.Heading;
-                    pak.WriteShort(0x1800);
-                }
-                else
-                {
-                    short rSpeed = player.CurrentSpeed;
+		protected virtual void WriteItemData(GSTCPPacketOut pak, InventoryItem item)
+		{
+			if (item == null)
+			{
+				pak.Fill(0x00, 24); // +1 item.Effect changed to short
+				return;
+			}
+			pak.WriteShort((ushort)0); // item uniqueID
+			pak.WriteByte((byte)item.Level);
 
-                    if (player.IsIncapacitated)
-                    {
-                        rSpeed = 0;
-                    }
+			int value1; // some object types use this field to display count
+			int value2; // some object types use this field to display count
+			switch (item.Object_Type)
+			{
+				case (int)eObjectType.GenericItem:
+					value1 = item.Count & 0xFF;
+					value2 = (item.Count >> 8) & 0xFF;
+					break;
+				case (int)eObjectType.Arrow:
+				case (int)eObjectType.Bolt:
+				case (int)eObjectType.Poison:
+					value1 = item.Count;
+					value2 = item.SPD_ABS;
+					break;
+				case (int)eObjectType.Thrown:
+					value1 = item.DPS_AF;
+					value2 = item.Count;
+					break;
+				case (int)eObjectType.Instrument:
+					value1 = (item.DPS_AF == 2 ? 0 : item.DPS_AF);
+					value2 = 0;
+					break; // unused
+				case (int)eObjectType.Shield:
+					value1 = item.Type_Damage;
+					value2 = item.DPS_AF;
+					break;
+				case (int)eObjectType.AlchemyTincture:
+				case (int)eObjectType.SpellcraftGem:
+					value1 = 0;
+					value2 = 0;
+					/*
+					must contain the quality of gem for spell craft and think same for tincture
+					*/
+					break;
+				case (int)eObjectType.HouseWallObject:
+				case (int)eObjectType.HouseFloorObject:
+				case (int)eObjectType.GardenObject:
+					value1 = 0;
+					value2 = item.SPD_ABS;
+					/*
+					Value2 byte sets the width, only lower 4 bits 'seem' to be used (so 1-15 only)
 
-                    ushort content;
+					The byte used for "Hand" (IE: Mini-delve showing a weapon as Left-Hand
+					usabe/TwoHanded), the lower 4 bits store the height (1-15 only)
+					*/
+					break;
 
-                    if (rSpeed < 0)
-                    {
-                        content = (ushort)((Math.Abs(rSpeed) > 511 ? 511 : Math.Abs(rSpeed)) + 0x200);
-                    }
-                    else
-                    {
-                        content = (ushort)(rSpeed > 511 ? 511 : rSpeed);
-                    }
+				default:
+					value1 = item.DPS_AF;
+					value2 = item.SPD_ABS;
+					break;
+			}
+			pak.WriteByte((byte)value1);
+			pak.WriteByte((byte)value2);
 
-                    if (!player.IsAlive)
-                    {
-                        content += 5 << 10;
-                    }
-                    else
-                    {
-                        ushort state = 0;
+			if (item.Object_Type == (int)eObjectType.GardenObject)
+				pak.WriteByte((byte)(item.DPS_AF));
+			else
+				pak.WriteByte((byte)(item.Hand << 6));
 
-                        if (player.IsSwimming)
-                        {
-                            state = 1;
-                        }
-                        if (player.IsClimbing)
-                        {
-                            state = 7;
-                        }
-                        if (player.IsSitting)
-                        {
-                            state = 4;
-                        }
-                        content += (ushort)(state << 10);
-                    }
+			pak.WriteByte((byte)((item.Type_Damage > 3 ? 0 : item.Type_Damage << 6) | item.Object_Type));
+			pak.WriteByte(0x00); //unk 1.112
+			pak.WriteShort((ushort)item.Weight);
+			pak.WriteByte(item.ConditionPercent); // % of con
+			pak.WriteByte(item.DurabilityPercent); // % of dur
+			pak.WriteByte((byte)item.Quality); // % of qua
+			pak.WriteByte((byte)item.Bonus); // % bonus
+			pak.WriteByte((byte)item.BonusLevel); // 1.109
+			pak.WriteShort((ushort)item.Model);
+			pak.WriteByte((byte)item.Extension);
+			int flag = 0;
+			int emblem = item.Emblem;
+			int color = item.Color;
+			if (emblem != 0)
+			{
+				pak.WriteShort((ushort)emblem);
+				flag |= (emblem & 0x010000) >> 16; // = 1 for newGuildEmblem
+			}
+			else
+			{
+				pak.WriteShort((ushort)color);
+			}
+			//flag |= 0x01; // newGuildEmblem
+			flag |= 0x02; // enable salvage button
+			AbstractCraftingSkill skill = CraftingMgr.getSkillbyEnum(m_gameClient.Player.CraftingPrimarySkill);
+			if (skill != null && skill is AdvancedCraftingSkill/* && ((AdvancedCraftingSkill)skill).IsAllowedToCombine(_gameClient.Player, item)*/)
+				flag |= 0x04; // enable craft button
+			ushort icon1 = 0;
+			ushort icon2 = 0;
+			string spell_name1 = "";
+			string spell_name2 = "";
+			if (item.Object_Type != (int)eObjectType.AlchemyTincture)
+			{
+				if (item.SpellID > 0/* && item.Charges > 0*/)
+				{
+					SpellLine chargeEffectsLine = SkillBase.GetSpellLine(GlobalSpellsLines.Item_Effects);
+					if (chargeEffectsLine != null)
+					{
+						List<Spell> spells = SkillBase.GetSpellList(chargeEffectsLine.KeyName);
+						foreach (Spell spl in spells)
+						{
+							if (spl.ID == item.SpellID)
+							{
+								flag |= 0x08;
+								icon1 = spl.Icon;
+								spell_name1 = spl.Name; // or best spl.Name ?
+								break;
+							}
+						}
+					}
+				}
+				if (item.SpellID1 > 0/* && item.Charges > 0*/)
+				{
+					SpellLine chargeEffectsLine = SkillBase.GetSpellLine(GlobalSpellsLines.Item_Effects);
+					if (chargeEffectsLine != null)
+					{
+						List<Spell> spells = SkillBase.GetSpellList(chargeEffectsLine.KeyName);
+						foreach (Spell spl in spells)
+						{
+							if (spl.ID == item.SpellID1)
+							{
+								flag |= 0x10;
+								icon2 = spl.Icon;
+								spell_name2 = spl.Name; // or best spl.Name ?
+								break;
+							}
+						}
+					}
+				}
+			}
+			pak.WriteByte((byte)flag);
+			if ((flag & 0x08) == 0x08)
+			{
+				pak.WriteShort((ushort)icon1);
+				pak.WritePascalString(spell_name1);
+			}
+			if ((flag & 0x10) == 0x10)
+			{
+				pak.WriteShort((ushort)icon2);
+				pak.WritePascalString(spell_name2);
+			}
+			pak.WriteShort((ushort)item.Effect); // item effect changed to short
+			string name = item.Name;
+			if (item.Count > 1)
+				name = item.Count + " " + name;
+			if (item.SellPrice > 0)
+			{
+				if (ServerProperties.Properties.CONSIGNMENT_USE_BP)
+					name += "[" + item.SellPrice.ToString() + " BP]";
+				else
+					name += "[" + Money.GetString(item.SellPrice) + "]";
+			}
+			if (name == null) name = "";
+			if (name.Length > 55)
+				name = name.Substring(0, 55);
+			pak.WritePascalString(name);
+		}
 
-                    content += (ushort)(player.IsStrafing ? 1 << 13 : 0 << 13);
+		/// <summary>
+		/// patch 0020
+		/// </summary>       
+		protected virtual void WriteItemData(GSTCPPacketOut pak, InventoryItem item, int questID)
+		{
+			if (item == null)
+			{
+				pak.Fill(0x00, 24); //item.Effect changed to short 1.119
+				return;
+			}
 
-                    pak.WriteShort(content);
-                }
-                
-                pak.WriteByte(0);
-                pak.WriteByte(0);
-                pak.WriteShort((ushort)heading);
-                // Write Flags
-                byte flagcontent = 0;
+			pak.WriteShort((ushort)questID); // need to send an objectID for reward quest delve to work 1.115+
+			pak.WriteByte((byte)item.Level);
 
-                if (player.IsDiving)
-                {
-                    flagcontent += 0x04;
-                }
+			int value1; // some object types use this field to display count
+			int value2; // some object types use this field to display count
+			switch (item.Object_Type)
+			{
+				case (int)eObjectType.GenericItem:
+					value1 = item.Count & 0xFF;
+					value2 = (item.Count >> 8) & 0xFF;
+					break;
+				case (int)eObjectType.Arrow:
+				case (int)eObjectType.Bolt:
+				case (int)eObjectType.Poison:
+					value1 = item.Count;
+					value2 = item.SPD_ABS;
+					break;
+				case (int)eObjectType.Thrown:
+					value1 = item.DPS_AF;
+					value2 = item.Count;
+					break;
+				case (int)eObjectType.Instrument:
+					value1 = (item.DPS_AF == 2 ? 0 : item.DPS_AF);
+					value2 = 0;
+					break; // unused
+				case (int)eObjectType.Shield:
+					value1 = item.Type_Damage;
+					value2 = item.DPS_AF;
+					break;
+				case (int)eObjectType.AlchemyTincture:
+				case (int)eObjectType.SpellcraftGem:
+					value1 = 0;
+					value2 = 0;
+					/*
+					must contain the quality of gem for spell craft and think same for tincture
+					*/
+					break;
+				case (int)eObjectType.HouseWallObject:
+				case (int)eObjectType.HouseFloorObject:
+				case (int)eObjectType.GardenObject:
+					value1 = 0;
+					value2 = item.SPD_ABS;
+					/*
+					Value2 byte sets the width, only lower 4 bits 'seem' to be used (so 1-15 only)
 
-                if (player.IsWireframe)
-                {
-                    flagcontent += 0x01;
-                }
+					The byte used for "Hand" (IE: Mini-delve showing a weapon as Left-Hand
+					usabe/TwoHanded), the lower 4 bits store the height (1-15 only)
+					*/
+					break;
 
-                if (player.IsStealthed)
-                {
-                    flagcontent += 0x02;
-                }
+				default:
+					value1 = item.DPS_AF;
+					value2 = item.SPD_ABS;
+					break;
+			}
+			pak.WriteByte((byte)value1);
+			pak.WriteByte((byte)value2);
 
-                if (player.IsTorchLighted)
-                {
-                    flagcontent += 0x80;
-                }
+			if (item.Object_Type == (int)eObjectType.GardenObject)
+				pak.WriteByte((byte)(item.DPS_AF));
+			else
+				pak.WriteByte((byte)(item.Hand << 6));
 
-                pak.WriteByte(flagcontent);
-                pak.WriteByte((byte)(player.RPFlag ? 1 : 0));
-                pak.WriteByte(0);
-                pak.WriteByte(player.HealthPercent);
-                pak.WriteByte(player.ManaPercent);
-                pak.WriteByte(player.EndurancePercent);
-                SendUDP(pak);
-            }
+			pak.WriteByte((byte)((item.Type_Damage > 3 ? 0 : item.Type_Damage << 6) | item.Object_Type));
+			pak.WriteByte(0x00); //unk 1.112
+			pak.WriteShort((ushort)item.Weight);
+			pak.WriteByte(item.ConditionPercent); // % of con
+			pak.WriteByte(item.DurabilityPercent); // % of dur
+			pak.WriteByte((byte)item.Quality); // % of qua
+			pak.WriteByte((byte)item.Bonus); // % bonus
+			pak.WriteByte((byte)item.BonusLevel); // 1.109
+			pak.WriteShort((ushort)item.Model);
+			pak.WriteByte((byte)item.Extension);
+			int flag = 0;
+			int emblem = item.Emblem;
+			int color = item.Color;
+			if (emblem != 0)
+			{
+				pak.WriteShort((ushort)emblem);
+				flag |= (emblem & 0x010000) >> 16; // = 1 for newGuildEmblem
+			}
+			else
+			{
+				pak.WriteShort((ushort)color);
+			}
+			//flag |= 0x01; // newGuildEmblem
+			flag |= 0x02; // enable salvage button
+			AbstractCraftingSkill skill = CraftingMgr.getSkillbyEnum(m_gameClient.Player.CraftingPrimarySkill);
+			if (skill != null && skill is AdvancedCraftingSkill/* && ((AdvancedCraftingSkill)skill).IsAllowedToCombine(_gameClient.Player, item)*/)
+				flag |= 0x04; // enable craft button
+			ushort icon1 = 0;
+			ushort icon2 = 0;
+			string spell_name1 = "";
+			string spell_name2 = "";
+			if (item.Object_Type != (int)eObjectType.AlchemyTincture)
+			{
+				if (item.SpellID > 0/* && item.Charges > 0*/)
+				{
+					SpellLine chargeEffectsLine = SkillBase.GetSpellLine(GlobalSpellsLines.Item_Effects);
+					if (chargeEffectsLine != null)
+					{
+						List<Spell> spells = SkillBase.GetSpellList(chargeEffectsLine.KeyName);
+						foreach (Spell spl in spells)
+						{
+							if (spl.ID == item.SpellID)
+							{
+								flag |= 0x08;
+								icon1 = spl.Icon;
+								spell_name1 = spl.Name; // or best spl.Name ?
+								break;
+							}
+						}
+					}
+				}
+				if (item.SpellID1 > 0/* && item.Charges > 0*/)
+				{
+					SpellLine chargeEffectsLine = SkillBase.GetSpellLine(GlobalSpellsLines.Item_Effects);
+					if (chargeEffectsLine != null)
+					{
+						List<Spell> spells = SkillBase.GetSpellList(chargeEffectsLine.KeyName);
+						foreach (Spell spl in spells)
+						{
+							if (spl.ID == item.SpellID1)
+							{
+								flag |= 0x10;
+								icon2 = spl.Icon;
+								spell_name2 = spl.Name; // or best spl.Name ?
+								break;
+							}
+						}
+					}
+				}
+			}
+			pak.WriteByte((byte)flag);
+			if ((flag & 0x08) == 0x08)
+			{
+				pak.WriteShort((ushort)icon1);
+				pak.WritePascalString(spell_name1);
+			}
+			if ((flag & 0x10) == 0x10)
+			{
+				pak.WriteShort((ushort)icon2);
+				pak.WritePascalString(spell_name2);
+			}
+			pak.WriteShort((ushort)item.Effect); // changed to short 1.119
+			string name = item.Name;
+			if (item.Count > 1)
+				name = item.Count + " " + name;
+			if (item.SellPrice > 0)
+			{
+				if (ServerProperties.Properties.CONSIGNMENT_USE_BP)
+					name += "[" + item.SellPrice.ToString() + " BP]";
+				else
+					name += "[" + Money.GetString(item.SellPrice) + "]";
+			}
+			if (name == null) name = "";
+			if (name.Length > 55)
+				name = name.Substring(0, 55);
+			pak.WritePascalString(name);
+		}
 
-            // Update Cache
-            m_gameClient.GameObjectUpdateArray[new Tuple<ushort, ushort>(player.CurrentRegionID, (ushort)player.ObjectID)] = GameTimer.GetTickCount();
-        }
+		protected virtual void WriteTemplateData(GSTCPPacketOut pak, ItemTemplate template, int count)
+		{
+			if (template == null)
+			{
+				pak.Fill(0x00, 24); // 1.109 +1 byte
+				return;
+			}
+			pak.WriteShort(0); // objectID
+			pak.WriteByte((byte)template.Level);
 
-        public override void SendPlayerPositionAndObjectID()
-        {
-            if (m_gameClient.Player == null)
+			int value1;
+			int value2;
+
+			switch (template.Object_Type)
+			{
+				case (int)eObjectType.Arrow:
+				case (int)eObjectType.Bolt:
+				case (int)eObjectType.Poison:
+				case (int)eObjectType.GenericItem:
+					value1 = count; // Count
+					value2 = template.SPD_ABS;
+					break;
+				case (int)eObjectType.Thrown:
+					value1 = template.DPS_AF;
+					value2 = count; // Count
+					break;
+				case (int)eObjectType.Instrument:
+					value1 = (template.DPS_AF == 2 ? 0 : template.DPS_AF);
+					value2 = 0;
+					break;
+				case (int)eObjectType.Shield:
+					value1 = template.Type_Damage;
+					value2 = template.DPS_AF;
+					break;
+				case (int)eObjectType.AlchemyTincture:
+				case (int)eObjectType.SpellcraftGem:
+					value1 = 0;
+					value2 = 0;
+					/*
+					must contain the quality of gem for spell craft and think same for tincture
+					*/
+					break;
+				case (int)eObjectType.GardenObject:
+					value1 = 0;
+					value2 = template.SPD_ABS;
+					/*
+					Value2 byte sets the width, only lower 4 bits 'seem' to be used (so 1-15 only)
+
+					The byte used for "Hand" (IE: Mini-delve showing a weapon as Left-Hand
+					usabe/TwoHanded), the lower 4 bits store the height (1-15 only)
+					*/
+					break;
+
+				default:
+					value1 = template.DPS_AF;
+					value2 = template.SPD_ABS;
+					break;
+			}
+			pak.WriteByte((byte)value1);
+			pak.WriteByte((byte)value2);
+
+			if (template.Object_Type == (int)eObjectType.GardenObject)
+				pak.WriteByte((byte)(template.DPS_AF));
+			else
+				pak.WriteByte((byte)(template.Hand << 6));
+			pak.WriteByte((byte)((template.Type_Damage > 3
+				? 0
+				: template.Type_Damage << 6) | template.Object_Type));
+			pak.Fill(0x00, 1); // 1.109, +1 byte, no clue what this is  - Tolakram
+			pak.WriteShort((ushort)template.Weight);
+			pak.WriteByte(template.BaseConditionPercent);
+			pak.WriteByte(template.BaseDurabilityPercent);
+			pak.WriteByte((byte)template.Quality);
+			pak.WriteByte((byte)template.Bonus);
+			pak.WriteByte((byte)template.BonusLevel); // 1.109
+			pak.WriteShort((ushort)template.Model);
+			pak.WriteByte((byte)template.Extension);
+			if (template.Emblem != 0)
+				pak.WriteShort((ushort)template.Emblem);
+			else
+				pak.WriteShort((ushort)template.Color);
+			pak.WriteByte((byte)template.Flags);
+			pak.WriteShort((ushort)template.Effect);
+			if (count > 1)
+				pak.WritePascalString(String.Format("{0} {1}", count, template.Name));
+			else
+				pak.WritePascalString(template.Name);
+		}
+
+		public virtual void SendXFireInfo(byte flag)
+		{
+			if (m_gameClient == null || m_gameClient.Player == null)
+				return;
+			using (GSTCPPacketOut pak = new GSTCPPacketOut((byte)eServerPackets.XFire))
+			{
+				pak.WriteShort((ushort)m_gameClient.Player.ObjectID);
+				pak.WriteByte(flag);
+				pak.WriteByte(0x00);
+				SendTCP(pak);
+			}
+		}
+
+		/*
+		 * public override void SendPlayerBanner(GamePlayer player, int GuildEmblem)
+		{
+			if (player == null) return;
+			GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.VisualEffect));
+			pak.WriteShort((ushort) player.ObjectID);
+			pak.WriteByte(12);
+			if (GuildEmblem == 0)
+			{
+				pak.WriteByte(1);
+			}
+			else
+			{
+				pak.WriteByte(0);
+			}
+			int newEmblemBitMask = ((GuildEmblem & 0x010000) << 8) | (GuildEmblem & 0xFFFF);
+			pak.WriteInt((uint)newEmblemBitMask);
+			SendTCP(pak);
+		}
+
+		 */
+		public virtual void SendDebugMode(bool on)
+		{
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.DebugMode)))
+			{
+				if (m_gameClient.Account.PrivLevel == 1)
+				{
+					pak.WriteByte((0x00));
+				}
+				else
+				{
+					pak.WriteByte((byte)(on ? 0x01 : 0x00));
+				}
+				pak.WriteByte(0x00);
+				SendTCP(pak);
+			}
+		}
+
+		public void SendModelChange(GameObject obj, ushort newModel)
+		{
+			if (obj is GameNPC)
+				SendModelAndSizeChange(obj, newModel, (obj as GameNPC).Size);
+			else
+				SendModelAndSizeChange(obj, newModel, 0);
+		}
+
+		public void SendModelAndSizeChange(GameObject obj, ushort newModel, byte newSize)
+		{
+			SendModelAndSizeChange((ushort)obj.ObjectID, newModel, newSize);
+		}
+
+		public virtual void SendModelAndSizeChange(ushort objectId, ushort newModel, byte newSize)
+		{
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.ModelChange)))
+			{
+				pak.WriteShort(objectId);
+				pak.WriteShort(newModel);
+				pak.WriteIntLowEndian(newSize);
+				SendTCP(pak);
+			}
+		}
+
+		public virtual void SendEmoteAnimation(GameObject obj, eEmote emote)
+		{
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.EmoteAnimation)))
+			{
+				pak.WriteShort((ushort)obj.ObjectID);
+				pak.WriteByte((byte)emote);
+				pak.WriteByte(0x00);
+				SendTCP(pak);
+			}
+		}
+
+		public virtual void SendUpdateMoney()
+		{
+			if (m_gameClient.Player == null)
+				return;
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.MoneyUpdate)))
+			{
+				pak.WriteByte((byte)m_gameClient.Player.Copper);
+				pak.WriteByte((byte)m_gameClient.Player.Silver);
+				pak.WriteShort((ushort)m_gameClient.Player.Gold);
+				pak.WriteShort((ushort)m_gameClient.Player.Mithril);
+				pak.WriteShort((ushort)m_gameClient.Player.Platinum);
+				SendTCP(pak);
+			}
+		}
+
+		public virtual void SendUpdateMaxSpeed()
+		{
+			//Speed is in % not a fixed value!
+			if (m_gameClient.Player == null)
+				return;
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.MaxSpeed)))
+			{
+				// _gameClient.Player.LastMaxSpeed = _gameClient.Player.MaxSpeed; // patch 0024 experimental hackdetect
+				pak.WriteShort((ushort)(m_gameClient.Player.MaxSpeed * 100 / GamePlayer.PLAYER_BASE_SPEED));
+				pak.WriteByte((byte)(m_gameClient.Player.IsTurningDisabled ? 0x01 : 0x00));
+				// water speed in % of land speed if its over 0 i think
+				pak.WriteByte(
+					(byte)
+					Math.Min(byte.MaxValue,
+							 ((m_gameClient.Player.MaxSpeed * 100 / GamePlayer.PLAYER_BASE_SPEED) *
+							  (m_gameClient.Player.GetModified(eProperty.WaterSpeed) * .01))));
+				SendTCP(pak);
+			}
+		}
+
+
+		public virtual void SendStatusUpdate()
+		{
+			if (m_gameClient.Player == null)
+				return;
+			SendStatusUpdate((byte)(m_gameClient.Player.IsSitting ? 0x02 : 0x00));
+		}
+
+
+
+		public virtual void SendSpellCastAnimation(GameLiving spellCaster, ushort spellID, ushort castingTime)
+		{
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.SpellCastAnimation)))
+			{
+				pak.WriteShort((ushort)spellCaster.ObjectID);
+				pak.WriteShort(spellID);
+				pak.WriteShort(castingTime);
+				pak.WriteShort(0x00);
+				SendTCP(pak);
+			}
+		}
+
+		public virtual void SendRiding(GameObject rider, GameObject steed, bool dismount)
+		{
+			int slot = 0;
+			if (steed is GameNPC npc && rider is GamePlayer playerRider && dismount == false)
+				slot = npc.RiderSlot(playerRider);
+			if (slot == -1)
+				log.Error($"SendRiding error, slot is -1 with rider {rider.Name} steed {steed.Name}");
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.Riding)))
+			{
+				pak.WriteShort((ushort)rider.ObjectID);
+				pak.WriteShort((ushort)steed.ObjectID);
+				pak.WriteByte((byte)(dismount ? 0x00 : 0x01));
+				pak.WriteByte((byte)slot);
+				pak.WriteShort(0x00);
+				SendTCP(pak);
+			}
+		}
+
+		public virtual void SendGroupInviteCommand(GamePlayer invitingPlayer, string inviteMessage)
+		{
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.Dialog)))
+			{
+				pak.WriteByte(0x00);
+				pak.WriteByte(0x05);
+				pak.WriteShort((ushort)invitingPlayer.Client.SessionID); //data1
+				pak.Fill(0x00, 6); //data2&data3
+				pak.WriteByte(0x01);
+				pak.WriteByte(0x00);
+				if (inviteMessage.Length > 0)
+					pak.WriteString(inviteMessage, inviteMessage.Length);
+				pak.WriteByte(0x00);
+				SendTCP(pak);
+			}
+		}
+
+		public virtual void SendGuildInviteCommand(GamePlayer invitingPlayer, string inviteMessage)
+		{
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.Dialog)))
+			{
+				pak.WriteByte(0x00);
+				pak.WriteByte(0x03);
+				pak.WriteShort((ushort)invitingPlayer.ObjectID); //data1
+				pak.Fill(0x00, 6); //data2&data3
+				pak.WriteByte(0x01);
+				pak.WriteByte(0x00);
+				if (inviteMessage.Length > 0)
+					pak.WriteString(inviteMessage, inviteMessage.Length);
+				pak.WriteByte(0x00);
+				SendTCP(pak);
+			}
+		}
+
+		public virtual void SendGuildLeaveCommand(GamePlayer invitingPlayer, string inviteMessage)
+		{
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.Dialog)))
+			{
+				pak.WriteByte(0x00);
+				pak.WriteByte(0x08);
+				pak.WriteShort((ushort)invitingPlayer.ObjectID); //data1
+				pak.Fill(0x00, 6); //data2&data3
+				pak.WriteByte(0x01);
+				pak.WriteByte(0x00);
+				if (inviteMessage.Length > 0)
+					pak.WriteString(inviteMessage, inviteMessage.Length);
+				pak.WriteByte(0x00);
+				SendTCP(pak);
+			}
+		}
+
+
+
+
+
+
+		// i'm reusing the questsubscribe command for quest abort since its 99% the same, only different event dets fired
+		// data 3 defines wether it's subscribe or abort
+		public virtual void SendQuestSubscribeCommand(GameNPC invitingNPC, ushort questid, string inviteMessage)
+		{
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.Dialog)))
+			{
+				pak.WriteByte(0x00);
+				pak.WriteByte(0x64);
+				pak.WriteShort(questid); //questid, data1
+				pak.WriteShort((ushort)invitingNPC.ObjectID); //data2
+				pak.WriteShort(0x00); // 0x00 means subscribe data3
+				pak.WriteShort(0x00);
+				pak.WriteByte(0x01); // yes/no response
+				pak.WriteByte(0x01); // autowrap message
+				if (inviteMessage.Length > 0)
+					pak.WriteString(inviteMessage, inviteMessage.Length);
+				pak.WriteByte(0x00);
+				SendTCP(pak);
+			}
+		}
+
+		// i'm reusing the questsubscribe command for quest abort since its 99% the same, only different event dets fired
+		// data 3 defines wether it's subscribe or abort
+		public virtual void SendQuestAbortCommand(GameNPC abortingNPC, ushort questid, string abortMessage)
+		{
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.Dialog)))
+			{
+				pak.WriteByte(0x00);
+				pak.WriteByte(0x64);
+				pak.WriteShort(questid); //questid, data1
+				pak.WriteShort((ushort)abortingNPC.ObjectID); //data2
+				pak.WriteShort(0x01); // 0x01 means abort data3
+				pak.WriteShort(0x00);
+				pak.WriteByte(0x01); // yes/no response
+				pak.WriteByte(0x01); // autowrap message
+				if (abortMessage.Length > 0)
+					pak.WriteString(abortMessage, abortMessage.Length);
+				pak.WriteByte(0x00);
+				SendTCP(pak);
+			}
+		}
+
+		public virtual void SendDialogBox(eDialogCode code, ushort data1, ushort data2, ushort data3, ushort data4,
+										  eDialogType type, bool autoWrapText, string message)
+		{
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.Dialog)))
+			{
+				pak.WriteByte(0x00);
+				pak.WriteByte((byte)code);
+				pak.WriteShort(data1); //data1
+				pak.WriteShort(data2); //data2
+				pak.WriteShort(data3); //data3
+				pak.WriteShort(data4); //data4
+				pak.WriteByte((byte)type);
+				pak.WriteByte((byte)(autoWrapText ? 0x01 : 0x00));
+				if (message.Length > 0)
+					pak.WriteString(message, message.Length);
+				pak.WriteByte(0x00);
+				SendTCP(pak);
+			}
+		}
+
+		public virtual void SendCustomDialog(string msg, CustomDialogResponse callback)
+		{
+			if (m_gameClient.Player == null)
+				return;
+
+			lock (m_gameClient.Player)
+			{
+				if (m_gameClient.Player.CustomDialogCallback != null)
+					m_gameClient.Player.CustomDialogCallback(m_gameClient.Player, 0x00);
+				m_gameClient.Player.CustomDialogCallback = callback;
+			}
+
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.Dialog)))
+			{
+				pak.WriteByte(0x00);
+				pak.WriteByte((byte)eDialogCode.CustomDialog);
+				pak.WriteShort((ushort)m_gameClient.SessionID); //data1
+				pak.WriteShort(0x01); //custom dialog!	  //data2
+				pak.WriteShort(0x00); //data3
+				pak.WriteShort(0x00);
+				pak.WriteByte((byte)(callback == null ? 0x00 : 0x01)); //ok or yes/no response
+				pak.WriteByte(0x01); // autowrap text
+				if (msg.Length > 0)
+					pak.WriteString(msg, msg.Length);
+				pak.WriteByte(0x00);
+				SendTCP(pak);
+			}
+		}
+		// patch 0017
+		public virtual void SendCustomDialog(string msg, CustomDialogResponse callback, bool customFormat)
+		{
+			if (m_gameClient.Player == null)
+				return;
+
+			lock (m_gameClient.Player)
+			{
+				if (m_gameClient.Player.CustomDialogCallback != null)
+					m_gameClient.Player.CustomDialogCallback(m_gameClient.Player, 0x00);
+				m_gameClient.Player.CustomDialogCallback = callback;
+			}
+
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.Dialog)))
+			{
+				pak.WriteByte(0x00);
+				pak.WriteByte((byte)eDialogCode.CustomDialog);
+				pak.WriteShort((ushort)m_gameClient.SessionID); //data1
+				pak.WriteShort(0x01); //custom dialog!	  //data2
+				pak.WriteShort(0x00); //data3
+				pak.WriteShort(0x00);
+				pak.WriteByte((byte)(callback == null ? 0x00 : 0x01)); //ok or yes/no response
+				pak.WriteByte((byte)(customFormat ? 0x00 : 0x01)); // autowrap text? false if customFormatted == true. Allows use of \n etc in string
+				if (msg.Length > 0)
+					pak.WriteString(msg, msg.Length);
+				pak.WriteByte(0x00);
+				SendTCP(pak);
+			}
+		}
+
+		[Obsolete("Shouldn't be used in favor of new LoS Check Manager")]
+		public virtual void SendCheckLOS(GameObject Checker, GameObject Target, CheckLOSResponse callback)
+		{
+			if (m_gameClient.Player == null)
+				return;
+			int TargetOID = (Target != null ? Target.ObjectID : 0);
+			string key = string.Format("LOS C:0x{0} T:0x{1}", Checker.ObjectID, TargetOID);
+			CheckLOSResponse old_callback = null;
+			lock (m_gameClient.Player.TempProperties)
+			{
+				old_callback = (CheckLOSResponse)m_gameClient.Player.TempProperties.getProperty<object>(key, null);
+				m_gameClient.Player.TempProperties.setProperty(key, callback);
+			}
+			if (old_callback != null)
+				old_callback(m_gameClient.Player, 0, 0); // not sure for this,  i want targetOID there
+
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.CheckLOSRequest)))
+			{
+				pak.WriteShort((ushort)Checker.ObjectID);
+				pak.WriteShort((ushort)TargetOID);
+				pak.WriteShort(0x00); // ?
+				pak.WriteShort(0x00); // ?
+				SendTCP(pak);
+			}
+		}
+
+		public virtual void SendCheckLOS(GameObject source, GameObject target, CheckLOSMgrResponse callback)
+		{
+			if (m_gameClient.Player == null)
+				return;
+
+			int TargetOID = (target != null ? target.ObjectID : 0);
+			int SourceOID = (source != null ? source.ObjectID : 0);
+
+			string key = string.Format("LOSMGR C:0x{0} T:0x{1}", SourceOID, TargetOID);
+
+			CheckLOSMgrResponse old_callback = null;
+			lock (m_gameClient.Player.TempProperties)
+			{
+				old_callback = (CheckLOSMgrResponse)m_gameClient.Player.TempProperties.getProperty<object>(key, null);
+				m_gameClient.Player.TempProperties.setProperty(key, callback);
+			}
+			if (old_callback != null)
+				old_callback(m_gameClient.Player, 0, 0, 0);
+
+			using (var pak = new GSTCPPacketOut(0xD0))
+			{
+				pak.WriteShort((ushort)SourceOID);
+				pak.WriteShort((ushort)TargetOID);
+				pak.WriteShort(0x00); // ?
+				pak.WriteShort(0x00); // ?
+				SendTCP(pak);
+			}
+		}
+
+		public void SendGroupMemberUpdate(bool updateIcons, GameLiving living)
+		{
+			if (m_gameClient.Player == null)
+				return;
+			Group group = m_gameClient.Player.Group;
+			if (group == null)
+				return;
+
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.GroupMemberUpdate)))
+			{
+				lock (group)
+				{
+					// make sure group is not modified before update is sent else player index could change _before_ update
+					if (living.Group != group)
+						return;
+					WriteGroupMemberUpdate(pak, updateIcons, living);
+					pak.WriteByte(0x00);
+					SendTCP(pak);
+				}
+			}
+		}
+
+		public void SendGroupMembersUpdate(bool updateIcons)
+		{
+			if (m_gameClient.Player == null)
+				return;
+
+			Group group = m_gameClient.Player.Group;
+			if (group == null)
+				return;
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.GroupMemberUpdate)))
+			{
+				foreach (GameLiving living in group.GetMembersInTheGroup())
+					WriteGroupMemberUpdate(pak, updateIcons, living);
+				pak.WriteByte(0x00);
+				SendTCP(pak);
+			}
+		}
+
+		public virtual void SendInventorySlotsUpdate(ICollection<int> slots)
+		{
+			// slots contain ints
+
+			if (m_gameClient.Player == null)
+				return;
+
+			// clients crash if too long packet is sent
+			// so we send big updates in parts
+			if (slots == null || slots.Count <= ServerProperties.Properties.MAX_ITEMS_PER_PACKET)
+			{
+				SendInventorySlotsUpdateRange(slots, 0);
+			}
+			else
+			{
+				var updateSlots = new List<int>(ServerProperties.Properties.MAX_ITEMS_PER_PACKET);
+				foreach (int slot in slots)
+				{
+					updateSlots.Add(slot);
+					if (updateSlots.Count >= ServerProperties.Properties.MAX_ITEMS_PER_PACKET)
+					{
+						SendInventorySlotsUpdateRange(updateSlots, 0);
+						updateSlots.Clear();
+					}
+				}
+				if (updateSlots.Count > 0)
+					SendInventorySlotsUpdateRange(updateSlots, 0);
+			}
+		}
+
+
+
+
+
+		public virtual void SendInventoryItemsUpdate(ICollection<InventoryItem> itemsToUpdate)
+		{
+			SendInventoryItemsUpdate(eInventoryWindowType.Update, itemsToUpdate);
+		}
+
+		public virtual void SendInventoryItemsUpdate(eInventoryWindowType windowType, ICollection<InventoryItem> itemsToUpdate)
+		{
+			if (m_gameClient.Player == null)
+				return;
+			if (itemsToUpdate == null)
+			{
+				SendInventorySlotsUpdateRange(null, windowType);
+				return;
+			}
+
+			// clients crash if too long packet is sent
+			// so we send big updates in parts
+			var slotsToUpdate = new List<int>(Math.Min(ServerProperties.Properties.MAX_ITEMS_PER_PACKET, itemsToUpdate.Count));
+			foreach (InventoryItem item in itemsToUpdate)
+			{
+				if (item == null)
+					continue;
+
+				slotsToUpdate.Add(item.SlotPosition);
+				if (slotsToUpdate.Count >= ServerProperties.Properties.MAX_ITEMS_PER_PACKET)
+				{
+					SendInventorySlotsUpdateRange(slotsToUpdate, windowType);
+					slotsToUpdate.Clear();
+					windowType = eInventoryWindowType.Update;
+				}
+			}
+			if (slotsToUpdate.Count > 0)
+			{
+				SendInventorySlotsUpdateRange(slotsToUpdate, windowType);
+			}
+		}
+
+		public virtual void SendDoorState(Region region, IDoor door)
+		{
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.DoorState)))
+			{
+				ushort zone = (ushort)(door.DoorID / 1000000);
+				int doorType = door.DoorID / 100000000;
+				uint flag = door.Flag;
+
+				// by default give all unflagged above ground non keep doors a default sound (excluding TrialsOfAtlantis zones)
+				if (flag == 0 && doorType != 7 && region != null && !region.IsDungeon && region.Expansion != (int)eClientExpansion.TrialsOfAtlantis)
+				{
+					flag = 1;
+				}
+
+				pak.WriteInt((uint)door.DoorID);
+				pak.WriteByte((byte)(door.State == eDoorState.Open ? 0x01 : 0x00));
+				pak.WriteByte((byte)flag);
+				pak.WriteByte(0xFF);
+				pak.WriteByte(0x0);
+				SendTCP(pak);
+			}
+		}
+
+		public virtual void SendMerchantWindow(MerchantTradeItems tradeItemsList, eMerchantWindowType windowType)
+		{
+
+			if (tradeItemsList != null)
+			{
+				for (byte page = 0; page < MerchantTradeItems.MAX_PAGES_IN_TRADEWINDOWS; page++)
+				{
+					IDictionary itemsInPage = tradeItemsList.GetItemsInPage((int)page);
+					if (itemsInPage == null || itemsInPage.Count == 0)
+						continue;
+
+					using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.MerchantWindow)))
+					{
+						pak.WriteByte((byte)itemsInPage.Count); //Item count on this page
+						pak.WriteByte((byte)windowType);
+						pak.WriteByte((byte)page); //Page number
+						pak.WriteByte(0x00); //Unused
+
+						for (ushort i = 0; i < MerchantTradeItems.MAX_ITEM_IN_TRADEWINDOWS; i++)
+						{
+							if (!itemsInPage.Contains((int)i))
+								continue;
+
+							var item = (ItemTemplate)itemsInPage[(int)i];
+							if (item != null)
+							{
+								pak.WriteByte((byte)i); //Item index on page
+								pak.WriteByte((byte)item.Level);
+								// some objects use this for count
+								int value1;
+								int value2;
+								switch (item.Object_Type)
+								{
+									case (int)eObjectType.Arrow:
+									case (int)eObjectType.Bolt:
+									case (int)eObjectType.Poison:
+									case (int)eObjectType.GenericItem:
+										{
+											value1 = item.PackSize;
+											value2 = value1 * item.Weight;
+											break;
+										}
+									case (int)eObjectType.Thrown:
+										{
+											value1 = item.DPS_AF;
+											value2 = item.PackSize;
+											break;
+										}
+									case (int)eObjectType.Shield:
+										{
+											value1 = item.Type_Damage;
+											value2 = item.Weight;
+											break;
+										}
+									case (int)eObjectType.GardenObject:
+										{
+											value1 = 0;
+											value2 = item.Weight;
+											break;
+										}
+									default:
+										{
+											value1 = item.DPS_AF;
+											value2 = item.Weight;
+											break;
+										}
+								}
+								pak.WriteByte((byte)value1);
+								pak.WriteByte((byte)item.SPD_ABS);
+								if (item.Object_Type == (int)eObjectType.GardenObject)
+									pak.WriteByte((byte)(item.DPS_AF));
+								else
+									pak.WriteByte((byte)(item.Hand << 6));
+								pak.WriteByte((byte)((item.Type_Damage << 6) | item.Object_Type));
+								//1 if item cannot be used by your class (greyed out)
+								if (m_gameClient.Player != null && m_gameClient.Player.HasAbilityToUseItem(item))
+									pak.WriteByte(0x00);
+								else
+									pak.WriteByte(0x01);
+								pak.WriteShort((ushort)value2);
+								//Item Price
+								pak.WriteInt((uint)item.Price);
+								pak.WriteShort((ushort)item.Model);
+								pak.WritePascalString(item.Name);
+							}
+							else
+							{
+								if (log.IsErrorEnabled)
+									log.Error("Merchant item template '" +
+											  ((MerchantItem)itemsInPage[page * MerchantTradeItems.MAX_ITEM_IN_TRADEWINDOWS + i]).ItemTemplateID +
+											  "' not found, abort!!!");
+								return;
+							}
+						}
+						SendTCP(pak);
+					}
+				}
+			}
+			else
+			{
+				using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.MerchantWindow)))
+				{
+					pak.WriteByte(0); //Item count on this page
+					pak.WriteByte((byte)windowType); //Unknown 0x00
+					pak.WriteByte(0); //Page number
+					pak.WriteByte(0x00); //Unused
+					SendTCP(pak);
+				}
+			}
+		}
+
+
+
+		public virtual void SendCloseTradeWindow()
+		{
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.TradeWindow)))
+			{
+				pak.Fill(0x00, 40);
+				SendTCP(pak);
+			}
+		}
+
+		public virtual void SendPlayerDied(GamePlayer killedPlayer, GameObject killer)
+		{
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.PlayerDeath)))
+			{
+				pak.WriteShort((ushort)killedPlayer.ObjectID);
+				if (killer != null)
+					pak.WriteShort((ushort)killer.ObjectID);
+				else
+					pak.WriteShort(0x00);
+				pak.Fill(0x0, 4);
+				SendTCP(pak);
+			}
+		}
+
+		public virtual void SendPlayerRevive(GamePlayer revivedPlayer)
+		{
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.PlayerRevive)))
+			{
+				pak.WriteShort((ushort)revivedPlayer.ObjectID);
+				pak.WriteShort(0x00);
+				SendTCP(pak);
+			}
+		}
+
+		public virtual void SendUpdateCraftingSkills()
+		{
+			if (m_gameClient.Player == null)
+				return;
+
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.VariousUpdate)))
+			{
+				pak.WriteByte(0x08); //subcode
+				pak.WriteByte((byte)m_gameClient.Player.CraftingSkills.Count); //count
+				pak.WriteByte(0x03); //subtype
+				pak.WriteByte(0x00); //unk
+
+				foreach (KeyValuePair<eCraftingSkill, int> de in m_gameClient.Player.CraftingSkills)
+				{
+					AbstractCraftingSkill curentCraftingSkill = CraftingMgr.getSkillbyEnum((eCraftingSkill)de.Key);
+					pak.WriteShort(Convert.ToUInt16(de.Value)); //points
+					pak.WriteByte(curentCraftingSkill.Icon); //icon
+					pak.WriteInt(1);
+					pak.WritePascalString(curentCraftingSkill.Name); //name
+				}
+				SendTCP(pak);
+			}
+		}
+
+		public virtual void SendUpdateWeaponAndArmorStats()
+		{
+			if (m_gameClient.Player == null)
+				return;
+
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.VariousUpdate)))
+			{
+				pak.WriteByte(0x05); //subcode
+				pak.WriteByte(6); //number of entries
+				pak.WriteByte(0x00); //subtype
+				pak.WriteByte(0x00); //unk
+
+				// weapondamage
+				var wd = (int)(m_gameClient.Player.WeaponDamage(m_gameClient.Player.AttackWeapon) * 100.0);
+				pak.WriteByte((byte)(wd / 100));
+				pak.WritePascalString(" ");
+				pak.WriteByte((byte)(wd % 100));
+				pak.WritePascalString(" ");
+				// weaponskill
+				int ws = m_gameClient.Player.DisplayedWeaponSkill;
+				pak.WriteByte((byte)(ws >> 8));
+				pak.WritePascalString(" ");
+				pak.WriteByte((byte)(ws & 0xff));
+				pak.WritePascalString(" ");
+				// overall EAF
+				int eaf = m_gameClient.Player.EffectiveOverallAF;
+				pak.WriteByte((byte)(eaf >> 8));
+				pak.WritePascalString(" ");
+				pak.WriteByte((byte)(eaf & 0xff));
+				pak.WritePascalString(" ");
+
+				SendTCP(pak);
+			}
+		}
+
+		public virtual void SendEncumberance()
+		{
+			if (m_gameClient.Player == null)
+				return;
+
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.Encumberance)))
+			{
+				pak.WriteShort((ushort)m_gameClient.Player.MaxEncumberance); // encumb total
+				pak.WriteShort((ushort)m_gameClient.Player.Encumberance); // encumb used
+				SendTCP(pak);
+			}
+		}
+
+
+		public virtual void SendAddFriends(string[] friendNames)
+		{
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.AddFriend)))
+			{
+				foreach (string friend in friendNames)
+					pak.WritePascalString(friend);
+				pak.WriteByte(0x00);
+				SendTCP(pak);
+			}
+		}
+
+		public virtual void SendRemoveFriends(string[] friendNames)
+		{
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.RemoveFriend)))
+			{
+				foreach (string friend in friendNames)
+					pak.WritePascalString(friend);
+				pak.WriteByte(0x00);
+				SendTCP(pak);
+			}
+		}
+
+		public virtual void SendTimerWindow(string title, int seconds)
+		{
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.TimerWindow)))
+			{
+				pak.WriteShort((ushort)seconds);
+				pak.WriteByte((byte)title.Length);
+				pak.WriteByte(1);
+				pak.WriteString((title.Length > byte.MaxValue ? title.Substring(0, byte.MaxValue) : title));
+				SendTCP(pak);
+			}
+		}
+
+		public virtual void SendCloseTimerWindow()
+		{
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.TimerWindow)))
+			{
+				pak.WriteShort(0);
+				pak.WriteByte(0);
+				pak.WriteByte(0);
+				SendTCP(pak);
+			}
+		}
+
+		public virtual void SendCustomTrainerWindow(int type, List<Tuple<Specialization, List<Tuple<Skill, byte>>>> tree)
+		{
+			if (m_gameClient.Player == null)
+				return;
+
+			GamePlayer player = m_gameClient.Player;
+
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.TrainerWindow)))
+			{
+				if (tree != null && tree.Count > 0)
+				{
+					pak.WriteByte((byte)type); // index for Champion Line ID (returned for training request)
+					pak.WriteByte((byte)0); // Spec points available for this player.
+					pak.WriteByte(2); // Champion Window Type
+					pak.WriteByte(0);
+					pak.WriteByte((byte)tree.Count); // Count of sublines
+
+					for (int skillIndex = 0; skillIndex < tree.Count; skillIndex++)
+					{
+						pak.WriteByte((byte)(skillIndex + 1));
+						pak.WriteByte((byte)tree[skillIndex].Item2.Where(t => t.Item1 != null).Count()); // Count of item for this line
+
+						for (int itemIndex = 0; itemIndex < tree[skillIndex].Item2.Count; itemIndex++)
+						{
+							Skill sk = tree[skillIndex].Item2[itemIndex].Item1;
+
+							if (sk != null)
+							{
+								pak.WriteByte((byte)(itemIndex + 1));
+
+								if (sk is Style)
+								{
+									pak.WriteByte(2);
+								}
+								else if (sk is Spell)
+								{
+									pak.WriteByte(3);
+								}
+								else
+								{
+									pak.WriteByte(4);
+								}
+
+								pak.WriteShortLowEndian(sk.Icon); // Icon should be style icon + 3352 ???
+								pak.WritePascalString(sk.Name);
+
+								// Skill Status
+								pak.WriteByte(1); // 0 = disable, 1 = trained, 2 = can train
+
+								// Attached Skill
+								if (tree[skillIndex].Item2[itemIndex].Item2 == 2)
+								{
+									pak.WriteByte(2); // count of attached skills
+									pak.WriteByte((byte)(skillIndex << 8 + itemIndex));
+									pak.WriteByte((byte)((skillIndex + 2) << 8 + itemIndex));
+								}
+								else if (tree[skillIndex].Item2[itemIndex].Item2 == 3)
+								{
+									pak.WriteByte(3); // count of attached skills
+									pak.WriteByte((byte)(skillIndex << 8 + itemIndex));
+									pak.WriteByte((byte)((skillIndex + 1) << 8 + itemIndex));
+									pak.WriteByte((byte)((skillIndex + 2) << 8 + itemIndex));
+								}
+								else
+								{
+									// doesn't support other count
+									pak.WriteByte(0);
+								}
+							}
+						}
+					}
+
+					SendTCP(pak);
+				}
+			}
+		}
+
+
+		public virtual void SendChampionTrainerWindow(int type)
+		{
+			if (m_gameClient.Player == null)
+				return;
+
+			GamePlayer player = m_gameClient.Player;
+
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.TrainerWindow)))
+			{
+				// Get Player CL Spec
+				var clspec = player.GetSpecList().Where(sp => sp is LiveChampionsSpecialization).Cast<LiveChampionsSpecialization>().FirstOrDefault();
+
+				// check if the tree can be used
+				List<Tuple<MiniLineSpecialization, List<Tuple<Skill, byte>>>> tree = null;
+				if (clspec != null)
+				{
+					tree = clspec.GetTrainerTreeDisplay(player, clspec.RetrieveTypeForIndex(type));
+				}
+
+				if (tree != null && tree.Count > 0)
+				{
+					pak.WriteByte((byte)type); // index for Champion Line ID (returned for training request)
+					pak.WriteByte((byte)player.ChampionSpecialtyPoints); // Spec points available for this player.
+					pak.WriteByte(2); // Champion Window Type
+					pak.WriteByte(0);
+					pak.WriteByte((byte)tree.Count); // Count of sublines
+
+					for (int skillIndex = 0; skillIndex < tree.Count; skillIndex++)
+					{
+						pak.WriteByte((byte)(skillIndex + 1));
+						pak.WriteByte((byte)tree[skillIndex].Item2.Where(t => t.Item1 != null).Count()); // Count of item for this line
+
+						for (int itemIndex = 0; itemIndex < tree[skillIndex].Item2.Count; itemIndex++)
+						{
+							Skill sk = tree[skillIndex].Item2[itemIndex].Item1;
+
+							if (sk != null)
+							{
+								pak.WriteByte((byte)(itemIndex + 1));
+
+								if (sk is Style)
+								{
+									pak.WriteByte(2);
+								}
+								else if (sk is Spell)
+								{
+									pak.WriteByte(3);
+								}
+								else
+								{
+									pak.WriteByte(1);
+								}
+
+								pak.WriteShortLowEndian(sk.Icon); // Icon should be style icon + 3352 ???
+								pak.WritePascalString(sk.Name);
+
+								// Skill Status
+								pak.WriteByte(clspec.GetSkillStatus(tree, skillIndex, itemIndex).Item1); // 0 = disable, 1 = trained, 2 = can train
+
+								// Attached Skill
+								if (tree[skillIndex].Item2[itemIndex].Item2 == 2)
+								{
+									pak.WriteByte(2); // count of attached skills
+									pak.WriteByte((byte)(skillIndex << 8 + itemIndex));
+									pak.WriteByte((byte)((skillIndex + 2) << 8 + itemIndex));
+								}
+								else if (tree[skillIndex].Item2[itemIndex].Item2 == 3)
+								{
+									pak.WriteByte(3); // count of attached skills
+									pak.WriteByte((byte)(skillIndex << 8 + itemIndex));
+									pak.WriteByte((byte)((skillIndex + 1) << 8 + itemIndex));
+									pak.WriteByte((byte)((skillIndex + 2) << 8 + itemIndex));
+								}
+								else
+								{
+									// doesn't support other count
+									pak.WriteByte(0);
+								}
+							}
+						}
+					}
+
+					SendTCP(pak);
+				}
+			}
+		}
+
+
+
+		public virtual void SendInterruptAnimation(GameLiving living)
+		{
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.InterruptSpellCast)))
+			{
+				pak.WriteShort((ushort)living.ObjectID);
+				pak.WriteShort(1);
+				SendTCP(pak);
+			}
+		}
+
+		public virtual void SendDisableSkill(ICollection<Tuple<Skill, int>> skills)
+		{
+			if (m_gameClient.Player == null)
+				return;
+
+			var disabledSpells = new List<Tuple<byte, byte, ushort>>();
+			var disabledSkills = new List<Tuple<ushort, ushort>>();
+
+			var listspells = m_gameClient.Player.GetAllUsableListSpells();
+			var listskills = m_gameClient.Player.GetAllUsableSkills();
+			int specCount = listskills.Where(sk => sk.Item1 is Specialization).Count();
+
+			// Get through all disabled skills
+			foreach (Tuple<Skill, int> disabled in skills)
+			{
+
+				// Check if spell
+				byte lsIndex = 0;
+				foreach (var ls in listspells)
+				{
+					int index = ls.Item2.FindIndex(sk => sk.SkillType == disabled.Item1.SkillType && sk.ID == disabled.Item1.ID);
+
+					if (index > -1)
+					{
+						disabledSpells.Add(new Tuple<byte, byte, ushort>(lsIndex, (byte)index, (ushort)(disabled.Item2 > 0 ? disabled.Item2 / 1000 + 1 : 0)));
+						break;
+					}
+
+					lsIndex++;
+				}
+
+				int skIndex = listskills.FindIndex(skt => disabled.Item1.SkillType == skt.Item1.SkillType && disabled.Item1.ID == skt.Item1.ID) - specCount;
+
+				if (skIndex > -1)
+					disabledSkills.Add(new Tuple<ushort, ushort>((ushort)skIndex, (ushort)(disabled.Item2 > 0 ? disabled.Item2 / 1000 + 1 : 0)));
+			}
+
+			if (disabledSkills.Count > 0)
+			{
+				// Send matching hybrid spell match
+				using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.DisableSkills)))
+				{
+					byte countskill = (byte)Math.Min(disabledSkills.Count, 255);
+					if (countskill > 0)
+					{
+						pak.WriteShort(0); // duration unused
+						pak.WriteByte(countskill); // count...
+						pak.WriteByte(1); // code for hybrid skill
+
+						for (int i = 0; i < countskill; i++)
+						{
+							pak.WriteShort(disabledSkills[i].Item1); // index
+							pak.WriteShort(disabledSkills[i].Item2); // duration
+						}
+
+						SendTCP(pak);
+					}
+				}
+			}
+
+			if (disabledSpells.Count > 0)
+			{
+				var groupedDuration = disabledSpells.GroupBy(sp => sp.Item3);
+				foreach (var groups in groupedDuration)
+				{
+					// Send matching list spell match
+					using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.DisableSkills)))
+					{
+						byte total = (byte)Math.Min(groups.Count(), 255);
+						if (total > 0)
+						{
+							pak.WriteShort(groups.Key); // duration
+							pak.WriteByte(total); // count...
+							pak.WriteByte(2); // code for list spells
+
+							for (int i = 0; i < total; i++)
+							{
+								pak.WriteByte(groups.ElementAt(i).Item1); // line index
+								pak.WriteByte(groups.ElementAt(i).Item2); // spell index
+							}
+
+							SendTCP(pak);
+						}
+					}
+				}
+			}
+		}
+
+
+
+		public virtual void SendLevelUpSound()
+		{
+			// not sure what package this is, but it triggers the mob color update
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.RegionSound)))
+			{
+				pak.WriteShort((ushort)m_gameClient.Player.ObjectID);
+				pak.WriteByte(1); //level up sounds
+				pak.WriteByte((byte)m_gameClient.Player.Realm);
+				SendTCP(pak);
+			}
+		}
+
+		public virtual void SendRegionEnterSound(byte soundId)
+		{
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.RegionSound)))
+			{
+				pak.WriteShort((ushort)m_gameClient.Player.ObjectID);
+				pak.WriteByte(2); //region enter sounds
+				pak.WriteByte(soundId);
+				SendTCP(pak);
+			}
+		}
+
+		public virtual void SendDebugMessage(string format, params object[] parameters)
+		{
+			if (m_gameClient.Account.PrivLevel > (int)ePrivLevel.Player || ServerProperties.Properties.ENABLE_DEBUG)
+				SendMessage(String.Format("[DEBUG] " + format, parameters), eChatType.CT_System, eChatLoc.CL_SystemWindow);
+		}
+
+		public virtual void SendDebugPopupMessage(string format, params object[] parameters)
+		{
+			if (m_gameClient.Account.PrivLevel > (int)ePrivLevel.Player || ServerProperties.Properties.ENABLE_DEBUG)
+				SendMessage(String.Format("[DEBUG] " + format, parameters), eChatType.CT_System, eChatLoc.CL_PopupWindow);
+		}
+
+		public virtual void SendEmblemDialogue()
+		{
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.EmblemDialogue)))
+			{
+				pak.Fill(0x00, 4);
+				SendTCP(pak);
+			}
+		}
+
+		//FOR GM to test param and see min and max of each param
+		public virtual void SendWeather(uint x, uint width, ushort speed, ushort fogdiffusion, ushort intensity)
+		{
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.Weather)))
+			{
+				pak.WriteInt(x);
+				pak.WriteInt(width);
+				pak.WriteShort(fogdiffusion);
+				pak.WriteShort(speed);
+				pak.WriteShort(intensity);
+				pak.WriteShort(0); // 0x0508, 0xEB51, 0xFFBF
+				SendTCP(pak);
+			}
+		}
+
+		public virtual void SendPlayerModelTypeChange(GamePlayer player, byte modelType)
+		{
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.PlayerModelTypeChange)))
+			{
+				pak.WriteShort((ushort)player.ObjectID);
+				pak.WriteByte(modelType);
+				pak.WriteByte((byte)(modelType == 3 ? 0x08 : 0x00)); //unused?
+				SendTCP(pak);
+			}
+		}
+
+		public virtual void SendObjectDelete(GameObject obj)
+		{
+			// Remove from Cache
+			if (m_gameClient.GameObjectUpdateArray.ContainsKey(new Tuple<ushort, ushort>(obj.CurrentRegionID, (ushort)obj.ObjectID)))
+			{
+				long dummy;
+				m_gameClient.GameObjectUpdateArray.TryRemove(new Tuple<ushort, ushort>(obj.CurrentRegionID, (ushort)obj.ObjectID), out dummy);
+			}
+
+			SendObjectDelete((ushort)obj.ObjectID);
+		}
+
+		public void SendObjectDelete(ushort oid)
+		{
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.ObjectDelete)))
+			{
+				pak.WriteShort(oid);
+				pak.WriteShort(1); //TODO: unknown
+				SendTCP(pak);
+			}
+		}
+
+		public void SendChangeTarget(GameObject newTarget)
+		{
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.ChangeTarget)))
+			{
+				pak.WriteShort((ushort)(newTarget == null ? 0 : newTarget.ObjectID));
+				pak.WriteShort(0); // unknown
+				SendTCP(pak);
+			}
+		}
+
+		public void SendChangeGroundTarget(Point3D newTarget)
+		{
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.ChangeGroundTarget)))
+			{
+				pak.WriteInt((uint)(newTarget == null ? 0 : newTarget.X));
+				pak.WriteInt((uint)(newTarget == null ? 0 : newTarget.Y));
+				pak.WriteInt((uint)(newTarget == null ? 0 : newTarget.Z));
+				SendTCP(pak);
+			}
+		}
+
+
+
+		public virtual void SendRemoveHouse(House house)
+		{
+			// Remove from cache
+			if (m_gameClient.HouseUpdateArray.ContainsKey(new Tuple<ushort, ushort>(house.RegionID, (ushort)house.HouseNumber)))
+			{
+				long dummy;
+				m_gameClient.HouseUpdateArray.TryRemove(new Tuple<ushort, ushort>(house.RegionID, (ushort)house.HouseNumber), out dummy);
+			}
+
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.HouseCreate)))
+			{
+				pak.WriteShort((ushort)house.HouseNumber);
+				pak.WriteShort((ushort)house.Z);
+				pak.WriteInt((uint)house.X);
+				pak.WriteInt((uint)house.Y);
+				pak.Fill(0x00, 15);
+				pak.WriteByte(0x03);
+				pak.WritePascalString("");
+
+				SendTCP(pak);
+			}
+		}
+
+		public virtual void SendHousePayRentDialog(string title)
+		{
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.Dialog)))
+			{
+				pak.WriteByte(0x00);
+				pak.WriteByte((byte)eDialogCode.HousePayRent);
+				pak.Fill(0x00, 8); // empty
+				pak.WriteByte(0x02); // type
+				pak.WriteByte(0x01); // wrap
+				if (title.Length > 0)
+					pak.WriteString(title); // title ??
+				pak.WriteByte(0x00);
+				SendTCP(pak);
+			}
+		}
+
+
+
+
+		public virtual void SendExitHouse(House house, ushort unknown = 0)
+		{
+			// do not send anything if client is leaving house due to linkdeath
+			if (m_gameClient != null && m_gameClient.Player != null && m_gameClient.ClientState != GameClient.eClientState.Linkdead)
+			{
+				using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.HouseExit)))
+				{
+					pak.WriteShort((ushort)house.HouseNumber);
+					pak.WriteShort(unknown);
+					SendTCP(pak);
+				}
+			}
+		}
+
+		public virtual void SendToggleHousePoints(House house)
+		{
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.HouseTogglePoints)))
+			{
+				pak.WriteShort((ushort)house.HouseNumber);
+				pak.WriteByte(0x04);
+				pak.WriteByte(0x00);
+
+				SendTCP(pak);
+			}
+		}
+
+		public virtual void SendHouseUsersPermissions(House house)
+		{
+			if (house == null)
+				return;
+
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.HouseUserPermissions)))
+			{
+				pak.WriteByte((byte)house.HousePermissions.Count()); // number of permissions
+				pak.WriteByte(0x00); // ?
+				pak.WriteShort((ushort)house.HouseNumber); // house number
+
+				foreach (var entry in house.HousePermissions)
+				{
+					// grab permission
+					var perm = entry.Value;
+
+					pak.WriteByte((byte)entry.Key); // Slot
+					pak.WriteByte(0x00); // ?
+					pak.WriteByte(0x00); // ?
+					pak.WriteByte((byte)perm.PermissionType); // Type (Guild, Class, Race ...)
+					pak.WriteByte((byte)perm.PermissionLevel); // Level (Friend, Visitor ...)
+					pak.WritePascalString(perm.DisplayName);
+				}
+
+				SendTCP(pak);
+			}
+		}
+
+		public virtual void SendFurniture(House house)
+		{
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.HousingItem)))
+			{
+				pak.WriteShort((ushort)house.HouseNumber);
+				pak.WriteByte((byte)house.IndoorItems.Count);
+				pak.WriteByte(0x80); //0x00 = update, 0x80 = complete package
+
+				foreach (var entry in house.IndoorItems.OrderBy(entry => entry.Key))
+				{
+					var item = entry.Value;
+					WriteHouseFurniture(pak, item, entry.Key);
+				}
+
+				SendTCP(pak);
+			}
+		}
+
+		public virtual void SendFurniture(House house, int i)
+		{
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.HousingItem)))
+			{
+				pak.WriteShort((ushort)house.HouseNumber);
+				pak.WriteByte(0x01); //cnt
+				pak.WriteByte(0x00); //upd
+				var item = (IndoorItem)house.IndoorItems[i];
+				WriteHouseFurniture(pak, item, i);
+				SendTCP(pak);
+			}
+		}
+
+		public virtual void SendRentReminder(House house)
+		{
+			//0:00:58.047 S=>C 0xF7 show help window (topicIndex:106 houseLot?:4281)
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.HelpWindow)))
+			{
+				pak.WriteShort(106); //short index
+				pak.WriteShort((ushort)house.HouseNumber); //short lot
+				SendTCP(pak);
+			}
+		}
+
+		public virtual void SendStarterHelp()
+		{
+			//* 0:00:57.984 S=>C 0xF7 show help window (topicIndex:1 houseLot?:0)
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.HelpWindow)))
+			{
+				pak.WriteShort(1); //short index
+				pak.WriteShort(0); //short lot
+				SendTCP(pak);
+			}
+		}
+
+		public virtual void SendPlaySound(eSoundType soundType, ushort soundID)
+		{
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.PlaySound)))
+			{
+				pak.WriteShort((ushort)soundType);
+				pak.WriteShort(soundID);
+				pak.Fill(0x00, 8);
+				SendTCP(pak);
+			}
+		}
+
+		public virtual void SendMovingObjectCreate(GameMovingObject obj)
+		{
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.MovingObjectCreate)))
+			{
+				pak.WriteShort((ushort)obj.ObjectID);
+				pak.WriteShort(0);
+				pak.WriteShort(obj.Heading);
+				pak.WriteShort((ushort)obj.Z);
+				pak.WriteInt((uint)obj.X);
+				pak.WriteInt((uint)obj.Y);
+				pak.WriteShort(obj.Model);
+				int flag = (obj.Type() | ((byte)obj.Realm == 3 ? 0x40 : (byte)obj.Realm << 4) | obj.GetDisplayLevel(m_gameClient.Player) << 9);
+				pak.WriteShort((ushort)flag); //(0x0002-for Ship,0x7D42-for catapult,0x9602,0x9612,0x9622-for ballista)
+				pak.WriteShort(obj.Emblem); //emblem
+				pak.WriteShort(0);
+				pak.WriteInt(0);
+
+				string name = obj.Name;
+
+				LanguageDataObject translation = LanguageMgr.GetTranslation(m_gameClient, obj);
+				if (translation != null)
+				{
+					if (!Util.IsEmpty(((DBLanguageNPC)translation).Name))
+						name = ((DBLanguageNPC)translation).Name;
+				}
+
+				pak.WritePascalString(name);/*pak.WritePascalString(obj.Name);*/
+				pak.WriteByte(0); // trailing ?
+				SendTCP(pak);
+			}
+
+			// Update Cache
+			m_gameClient.GameObjectUpdateArray[new Tuple<ushort, ushort>(obj.CurrentRegionID, (ushort)obj.ObjectID)] = GameTimer.GetTickCount();
+
+		}
+
+
+
+		public virtual void SendSoundEffect(ushort soundId, ushort zoneId, ushort x, ushort y, ushort z, ushort radius)
+		{
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.SoundEffect)))
+			{
+				pak.WriteShort(soundId);
+				pak.WriteShort(zoneId);
+				pak.WriteShort(x);
+				pak.WriteShort(y);
+				pak.WriteShort(z);
+				pak.WriteShort(radius);
+				SendTCP(pak);
+			}
+		}
+
+		public virtual void SendRegionColorScheme()
+		{
+			SendRegionColorScheme(GameServer.ServerRules.GetColorHandling(m_gameClient));
+		}
+
+		public virtual void SendNPCCreate(GameNPC npc, bool updateCache)
+		{
+			if (m_gameClient.Player == null || npc.IsVisibleTo(m_gameClient.Player) == false)
+				return;
+
+			//Added by Suncheck - Mines are not shown to enemy players
+			/* if (npc is GameMine) patch 0048
             {
-                return;
-            }
-
-            using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.PositionAndObjectID)))
-            {
-                pak.WriteFloatLowEndian(m_gameClient.Player.X);
-                pak.WriteFloatLowEndian(m_gameClient.Player.Y);
-                pak.WriteFloatLowEndian(m_gameClient.Player.Z);
-                pak.WriteShort((ushort)m_gameClient.Player.ObjectID); //This is the player's objectid not Sessionid!!!
-                pak.WriteShort(m_gameClient.Player.Heading);
-
-                int flags = 0;
-                Zone zone = m_gameClient.Player.CurrentZone;
-                if (zone == null)
+                if (GameServer.ServerRules.IsAllowedToAttack((npc as GameMine).Owner, _gameClient.Player, true))
                 {
                     return;
                 }
-                if (m_gameClient.Player.CurrentZone.IsDivingEnabled)
-                {
-                    flags = 0x80 | (m_gameClient.Player.IsUnderwater ? 0x01 : 0x00);
-                }
-                if (zone.IsDungeon)
-                {
-                    pak.WriteShort((ushort)(zone.XOffset / 0x2000));
-                    pak.WriteShort((ushort)(zone.YOffset / 0x2000));
-                }
-                else
-                {
-                    pak.WriteShort(0);
-                    pak.WriteShort(0);
-                }
-                //Dinberg - Changing to allow instances...
-                pak.WriteShort(m_gameClient.Player.CurrentRegion.Skin);
-                pak.WriteByte((byte)(flags));
-                if (m_gameClient.Player.CurrentRegion.IsHousing)
-                {
-                    pak.WriteByte((byte)GameServer.Instance.Configuration.ServerType); // guess?
-                    pak.WritePascalString(GameServer.Instance.Configuration.ServerName);
-                }
-                else pak.WriteByte(0);
-                pak.WriteByte(0); // the rest is unknown for now, but seems inconsequential if sent as 0. Needs more research
-                pak.WriteByte(0); // flag?
-                pak.WriteByte(0); // flag? these seemingly randomly have a value, most common is last 2 bytes are 34 08 . Cannot replicate it 100%
-                pak.WriteByte(0); // flag?
-                SendTCP(pak);
-            }
-        }
-        
-        public override void SendPlayerCreate(GamePlayer playerToCreate)
-        {
-            if (playerToCreate == null)
-            {
-                if (log.IsErrorEnabled)
-                {
-                    log.Error("SendPlayerCreate: playerToCreate == null");
-                }
-                return;
-            }
+            }*/
 
-            if (m_gameClient.Player == null)
-            {
-                if (log.IsErrorEnabled)
-                {
-                    log.Error("SendPlayerCreate: m_gameClient.Player == null");
-                }
-                return;
-            }
+			if (npc is GameMovingObject)
+			{
+				SendMovingObjectCreate(npc as GameMovingObject);
+				return;
+			}
 
-            Region playerRegion = playerToCreate.CurrentRegion;
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.NPCCreate)))
+			{
+				int speed = 0;
+				ushort speedZ = 0;
+				if (npc == null)
+					return;
+				if (!npc.IsAtTargetPosition)
+				{
+					speed = npc.CurrentSpeed;
+					speedZ = (ushort)npc.TickSpeedZ;
+				}
+				pak.WriteShort((ushort)npc.ObjectID);
+				pak.WriteShort((ushort)(speed));
+				pak.WriteShort(npc.Heading);
+				pak.WriteShort((ushort)npc.Z);
+				pak.WriteInt((uint)npc.X);
+				pak.WriteInt((uint)npc.Y);
+				pak.WriteShort(speedZ);
+				pak.WriteShort(npc.Model);
+				pak.WriteByte(npc.Size);
+				byte level = npc.GetDisplayLevel(m_gameClient.Player);
+				if ((npc.Flags & GameNPC.eFlags.STATUE) != 0)
+				{
+					level |= 0x80;
+				}
+				pak.WriteByte(level);
 
-            if (playerRegion == null)
-            {
-                if (log.IsWarnEnabled)
-                {
-                    log.Warn("SendPlayerCreate: playerRegion == null");
-                }
-                return;
-            }
+				byte flags = (byte)(GameServer.ServerRules.GetLivingRealm(m_gameClient.Player, npc) << 6);
+				if ((npc.Flags & GameNPC.eFlags.GHOST) != 0) flags |= 0x01;
+				if (npc.Inventory != null) flags |= 0x02; //If mob has equipment, then only show it after the client gets the 0xBD packet
+				if ((npc.Flags & GameNPC.eFlags.PEACE) != 0) flags |= 0x10;
+				if ((npc.Flags & GameNPC.eFlags.FLYING) != 0) flags |= 0x20;
+				if ((npc.Flags & GameNPC.eFlags.TORCH) != 0) flags |= 0x04;
 
-            Zone playerZone = playerToCreate.CurrentZone;
+				pak.WriteByte(flags);
+				pak.WriteByte(0x20); //TODO this is the default maxstick distance
 
-            if (playerZone == null)
-            {
-                if (log.IsWarnEnabled)
-                {
-                    log.Warn("SendPlayerCreate: playerZone == null");
-                }
-                return;
-            }
+				string add = "";
+				byte flags2 = 0x00;
+				IControlledBrain brain = npc.Brain as IControlledBrain;
+				//patch 0042
+				if (brain != null)
+				{
+					flags2 |= 0x80; // have Owner
+				}
 
-            if (playerToCreate.IsVisibleTo(m_gameClient.Player) == false)
-            {
-                return;
-            }
+				if ((npc.Flags & GameNPC.eFlags.CANTTARGET) != 0)
+					if (m_gameClient.Account.PrivLevel > 1) add += "-DOR"; // indicates DOR flag for GMs
+					else flags2 |= 0x01;
+				if ((npc.Flags & GameNPC.eFlags.DONTSHOWNAME) != 0)
+					if (m_gameClient.Account.PrivLevel > 1) add += "-NON"; // indicates NON flag for GMs
+					else flags2 |= 0x02;
 
-            using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.PlayerCreate172)))
-            {
-                pak.WriteFloatLowEndian(playerToCreate.X);
-                pak.WriteFloatLowEndian(playerToCreate.Y);
-                pak.WriteFloatLowEndian(playerToCreate.Z);
-                pak.WriteShort((ushort)playerToCreate.Client.SessionID);
-                pak.WriteShort((ushort)playerToCreate.ObjectID);
-                pak.WriteShort(playerToCreate.Heading);
-                pak.WriteShort(playerToCreate.Model);
-                pak.WriteByte(playerToCreate.GetDisplayLevel(m_gameClient.Player));
+				if ((npc.Flags & GameNPC.eFlags.STEALTH) > 0)
+					flags2 |= 0x04;
 
-                int flags = (GameServer.ServerRules.GetLivingRealm(m_gameClient.Player, playerToCreate) & 0x03) << 2;
-                if (playerToCreate.IsAlive == false)
-                {
-                    flags |= 0x01;
-                }
-                if (playerToCreate.IsUnderwater)
-                {
-                    flags |= 0x02; //swimming
-                }
-                if (playerToCreate.IsStealthed)
-                {
-                    flags |= 0x10;
-                }
-                if (playerToCreate.IsWireframe)
-                {
-                    flags |= 0x20;
-                }
-                if (playerToCreate.CharacterClass.ID == (int)eCharacterClass.Vampiir)
-                {
-                    flags |= 0x40; //Vamp fly
-                }
+				eQuestIndicator questIndicator = npc.GetQuestIndicator(m_gameClient.Player);
 
-                pak.WriteByte((byte)flags);
+				if (questIndicator == eQuestIndicator.Available)
+					flags2 |= 0x08;//hex 8 - quest available
+				if (questIndicator == eQuestIndicator.Finish)
+					flags2 |= 0x10;//hex 16 - quest finish
+								   //flags2 |= 0x20;//hex 32 - water mob?
+								   //flags2 |= 0x40;//hex 64 - unknown
+								   //flags2 |= 0x80;//hex 128 - has owner
 
-                pak.WriteByte(playerToCreate.GetFaceAttribute(eCharFacePart.EyeSize)); //1-4 = Eye Size / 5-8 = Nose Size
-                pak.WriteByte(playerToCreate.GetFaceAttribute(eCharFacePart.LipSize)); //1-4 = Ear size / 5-8 = Kin size
-                pak.WriteByte(playerToCreate.GetFaceAttribute(eCharFacePart.MoodType)); //1-4 = Ear size / 5-8 = Kin size
-                pak.WriteByte(playerToCreate.GetFaceAttribute(eCharFacePart.EyeColor)); //1-4 = Skin Color / 5-8 = Eye Color                
-                pak.WriteByte(playerToCreate.GetFaceAttribute(eCharFacePart.HairColor)); //Hair: 1-4 = Color / 5-8 = unknown
-                pak.WriteByte(playerToCreate.GetFaceAttribute(eCharFacePart.FaceType)); //1-4 = Unknown / 5-8 = Face type
-                pak.WriteByte(playerToCreate.GetFaceAttribute(eCharFacePart.HairStyle)); //1-4 = Unknown / 5-8 = Hair Style
-                               
-                pak.WriteByte(0x00); // new in 1.74
-                pak.WriteByte(0x00); //unknown
-                pak.WriteByte(0x00); //unknown
-                pak.WritePascalString(GameServer.ServerRules.GetPlayerName(m_gameClient.Player, playerToCreate));
-                pak.WritePascalString(GameServer.ServerRules.GetPlayerGuildName(m_gameClient.Player, playerToCreate));
-                pak.WritePascalString(GameServer.ServerRules.GetPlayerLastName(m_gameClient.Player, playerToCreate));
-                //RR 12 / 13
-                pak.WritePascalString(GameServer.ServerRules.GetPlayerPrefixName(m_gameClient.Player, playerToCreate));
-                pak.WritePascalString(GameServer.ServerRules.GetPlayerTitle(m_gameClient.Player, playerToCreate)); // new in 1.74, NewTitle
-                if (playerToCreate.IsOnHorse)
-                {
-                    pak.WriteByte(playerToCreate.ActiveHorse.ID);
 
-                    if (playerToCreate.ActiveHorse.BardingColor == 0 && playerToCreate.ActiveHorse.Barding != 0 && playerToCreate.Guild != null)
-                    {
-                        int newGuildBitMask = (playerToCreate.Guild.Emblem & 0x010000) >> 9;
-                        pak.WriteByte((byte)(playerToCreate.ActiveHorse.Barding | newGuildBitMask));
-                        pak.WriteShortLowEndian((ushort)playerToCreate.Guild.Emblem);
-                    }
-                    else
-                    {
-                        pak.WriteByte(playerToCreate.ActiveHorse.Barding);
-                        pak.WriteShort(playerToCreate.ActiveHorse.BardingColor);
-                    }
+				pak.WriteByte(flags2); // flags 2
 
-                    pak.WriteByte(playerToCreate.ActiveHorse.Saddle);
-                    pak.WriteByte(playerToCreate.ActiveHorse.SaddleColor);
-                }
-                else
-                {
-                    pak.WriteByte(0); // trailing zero
-                }
+				byte flags3 = 0x00;
+				if (questIndicator == eQuestIndicator.Lesson)
+					flags3 |= 0x01;
+				if (questIndicator == eQuestIndicator.Lore)
+					flags3 |= 0x02;
+				if (questIndicator == eQuestIndicator.Pending) // new? patch 0031
+					flags3 |= 0x20;
+				pak.WriteByte(flags3); // new in 1.71 (region instance ID from StoC_0x20) OR flags 3?
+				pak.WriteShort(0x00); // new in 1.71 unknown
 
-                SendTCP(pak);
-            }
+				string name = npc.Name;
+				string guildName = npc.GuildName;
 
-            // Update Cache
-            m_gameClient.GameObjectUpdateArray[new Tuple<ushort, ushort>(playerToCreate.CurrentRegionID, (ushort)playerToCreate.ObjectID)] = GameTimer.GetTickCount();
+				LanguageDataObject translation = LanguageMgr.GetTranslation(m_gameClient, npc);
+				if (translation != null)
+				{
+					if (!Util.IsEmpty(((DBLanguageNPC)translation).Name))
+						name = ((DBLanguageNPC)translation).Name;
 
-            SendObjectGuildID(playerToCreate, playerToCreate.Guild); //used for nearest friendly/enemy object buttons and name colors on PvP server
+					if (!Util.IsEmpty(((DBLanguageNPC)translation).GuildName))
+						guildName = ((DBLanguageNPC)translation).GuildName;
+				}
 
-            if (playerToCreate.GuildBanner != null)
-            {
-                SendRvRGuildBanner(playerToCreate, true);
-            }
-        }        
-    }
+				if (name.Length + add.Length + 2 > 47) // clients crash with too long names
+					name = name.Substring(0, 47 - add.Length - 2);
+				if (add.Length > 0)
+					name = string.Format("[{0}]{1}", name, add);
+
+				pak.WritePascalString(name);
+
+				if (guildName.Length > 47)
+					pak.WritePascalString(guildName.Substring(0, 47));
+				else pak.WritePascalString(guildName);
+
+				pak.WriteByte(0x00);
+				SendTCP(pak);
+			}
+		}
+	}
 }

--- a/GameServer/packets/Server/PacketLib1125.cs
+++ b/GameServer/packets/Server/PacketLib1125.cs
@@ -1,28 +1,37 @@
 ﻿/*
  * DAWN OF LIGHT - The first free open source DAoC server emulator
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; either version 2
  * of the License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  *
  */
+using DOL.Database;
+using log4net;
 using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 
 namespace DOL.GS.PacketHandler
 {
 	[PacketLib(1125, GameClient.eClientVersion.Version1125)]
 	public class PacketLib1125 : PacketLib1124
 	{
+
+		private static readonly ILog log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+
 		/// <summary>
 		/// Constructs a new PacketLib for Client Version 1.125
 		/// </summary>
@@ -30,6 +39,615 @@ namespace DOL.GS.PacketHandler
 		public PacketLib1125(GameClient client)
 			: base(client)
 		{
+		}
+
+		/// <summary>
+		/// 1125 cryptkey
+		/// </summary>
+		public override void SendVersionAndCryptKey()
+		{
+			//Construct the new packet
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.CryptKey)))
+			{
+				pak.WritePascalStringIntLE((((int)m_gameClient.Version) / 1000) + "." + (((int)m_gameClient.Version) - 1000) + m_gameClient.MinorRev);
+				//// Same as the trailing two bytes sent in first client to server packet
+				pak.WriteByte(m_gameClient.MajorBuild); // last seen : 0x2A 0x07
+				pak.WriteByte(m_gameClient.MinorBuild);
+				SendTCP(pak);
+			}
+		}
+
+		/// <summary>
+		/// 1125 login granted		
+		/// </summary>        
+		public override void SendLoginGranted(byte color)
+		{
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.LoginGranted)))
+			{
+				pak.WritePascalString(m_gameClient.Account.Name);
+				pak.WritePascalString(GameServer.Instance.Configuration.ServerNameShort); //server name
+				pak.WriteByte(0x05); //Server ID, seems irrelevant
+				pak.WriteByte(color); // 00 normal type?, 01 mordred type, 03 gaheris type, 07 ywain type
+				pak.WriteByte(0x01); // always sent as 0x01 , unsure of significance
+				SendTCP(pak);
+			}
+		}
+
+		/// <summary>
+		/// 1125 sendrealm
+		/// </summary>        
+		public override void SendRealm(eRealm realm)
+		{
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.Realm)))
+			{
+				pak.WriteByte((byte)realm);
+				pak.Fill(0, 12);
+				SendTCP(pak);
+			}
+		}
+
+		/// <summary>
+		/// 1125 char overview
+		/// </summary>        
+		public override void SendCharacterOverview(eRealm realm)
+		{
+			if (realm < eRealm._FirstPlayerRealm || realm > eRealm._LastPlayerRealm)
+			{
+				throw new Exception("CharacterOverview requested for unknown realm " + realm);
+			}
+
+			int firstSlot = (byte)realm * 100;
+
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.CharacterOverview)))
+			{
+				//pak.Fillstring(GameClient.Account.Name, 24);
+				pak.Fill(0, 8);
+				if (m_gameClient.Account.Characters == null)
+				{
+					pak.Fill(0x0, 10);
+				}
+				else
+				{
+					Dictionary<int, DOLCharacters> charsBySlot = new Dictionary<int, DOLCharacters>();
+					foreach (DOLCharacters c in m_gameClient.Account.Characters)
+					{
+						try
+						{
+							charsBySlot.Add(c.AccountSlot, c);
+						}
+						catch (Exception ex)
+						{
+							log.Error("SendCharacterOverview - Duplicate char in slot? Slot: " + c.AccountSlot + ", Account: " + c.AccountName, ex);
+						}
+					}
+					var itemsByOwnerID = new Dictionary<string, Dictionary<eInventorySlot, InventoryItem>>();
+
+					if (charsBySlot.Any())
+					{
+						var allItems = GameServer.Database.SelectObjects<InventoryItem>("`OwnerID` = @OwnerID AND `SlotPosition` >= @MinEquipable AND `SlotPosition` <= @MaxEquipable",
+																						charsBySlot.Select(kv => new[] { new QueryParameter("@OwnerID", kv.Value.ObjectId), new QueryParameter("@MinEquipable", (int)eInventorySlot.MinEquipable), new QueryParameter("@MaxEquipable", (int)eInventorySlot.MaxEquipable) }))
+							.SelectMany(objs => objs);
+
+						foreach (InventoryItem item in allItems)
+						{
+							try
+							{
+								if (!itemsByOwnerID.ContainsKey(item.OwnerID))
+								{
+									itemsByOwnerID.Add(item.OwnerID, new Dictionary<eInventorySlot, InventoryItem>());
+								}
+
+								itemsByOwnerID[item.OwnerID].Add((eInventorySlot)item.SlotPosition, item);
+							}
+							catch (Exception ex)
+							{
+								log.Error("SendCharacterOverview - Duplicate item on character? OwnerID: " + item.OwnerID + ", SlotPosition: " + item.SlotPosition + ", Account: " + m_gameClient.Account.Name, ex);
+							}
+						}
+					}
+
+					for (int i = firstSlot; i < (firstSlot + 10); i++)
+					{
+						if (!charsBySlot.TryGetValue(i, out DOLCharacters c))
+						{
+							pak.WriteByte(0);
+						}
+						else
+						{
+
+							if (!itemsByOwnerID.TryGetValue(c.ObjectId, out Dictionary<eInventorySlot, InventoryItem> charItems))
+							{
+								charItems = new Dictionary<eInventorySlot, InventoryItem>();
+							}
+
+							byte extensionTorso = 0;
+							byte extensionGloves = 0;
+							byte extensionBoots = 0;
+
+
+							if (charItems.TryGetValue(eInventorySlot.TorsoArmor, out InventoryItem item))
+							{
+								extensionTorso = item.Extension;
+							}
+
+							if (charItems.TryGetValue(eInventorySlot.HandsArmor, out item))
+							{
+								extensionGloves = item.Extension;
+							}
+
+							if (charItems.TryGetValue(eInventorySlot.FeetArmor, out item))
+							{
+								extensionBoots = item.Extension;
+							}
+
+							pak.WriteByte((byte)c.Level); // moved
+							pak.WritePascalStringIntLE(c.Name);
+							pak.WriteByte(0x18); // no idea
+							pak.WriteInt(1); // no idea
+							pak.WriteByte((byte)c.EyeSize);
+							pak.WriteByte((byte)c.LipSize);
+							pak.WriteByte((byte)c.EyeColor);
+							pak.WriteByte((byte)c.HairColor);
+							pak.WriteByte((byte)c.FaceType);
+							pak.WriteByte((byte)c.HairStyle);
+							pak.WriteByte((byte)((extensionBoots << 4) | extensionGloves));
+							pak.WriteByte((byte)((extensionTorso << 4) | (c.IsCloakHoodUp ? 0x1 : 0x0)));
+							pak.WriteByte((byte)c.CustomisationStep); //1 = auto generate config, 2= config ended by player, 3= enable config to player
+							pak.WriteByte((byte)c.MoodType);
+							pak.Fill(0x0, 13); //0 string
+
+							string locationDescription = string.Empty;
+							Region region = WorldMgr.GetRegion((ushort)c.Region);
+							if (region != null)
+							{
+								locationDescription = region.GetTranslatedSpotDescription(m_gameClient, c.Xpos, c.Ypos, c.Zpos);
+							}
+							if (locationDescription.Length > 23) // location name over 23 chars has to be truncated eg. "The Great Pyramid of Stygia"
+							{
+								locationDescription = (locationDescription.Substring(0, 20)) + "...";
+							}
+							pak.WritePascalStringIntLE(locationDescription);
+
+							string classname = "";
+							if (c.Class != 0)
+							{
+								classname = ((eCharacterClass)c.Class).ToString();
+							}
+							pak.WritePascalStringIntLE(classname);
+
+							string racename = m_gameClient.RaceToTranslatedName(c.Race, c.Gender);
+
+							pak.WritePascalStringIntLE(racename);
+							pak.WriteShortLowEndian((ushort)c.CurrentModel); // moved
+																			 // something here
+							pak.WriteByte((byte)c.Region);
+
+							if (region == null || (int)m_gameClient.ClientType > region.Expansion)
+							{
+								pak.WriteByte(0x00);
+							}
+							else
+							{
+								pak.WriteByte((byte)(region.Expansion + 1)); //0x04-Cata zone, 0x05 - DR zone
+							}
+
+							charItems.TryGetValue(eInventorySlot.RightHandWeapon, out InventoryItem rightHandWeapon);
+							charItems.TryGetValue(eInventorySlot.LeftHandWeapon, out InventoryItem leftHandWeapon);
+							charItems.TryGetValue(eInventorySlot.TwoHandWeapon, out InventoryItem twoHandWeapon);
+							charItems.TryGetValue(eInventorySlot.DistanceWeapon, out InventoryItem distanceWeapon);
+							charItems.TryGetValue(eInventorySlot.HeadArmor, out InventoryItem helmet);
+							charItems.TryGetValue(eInventorySlot.HandsArmor, out InventoryItem gloves);
+							charItems.TryGetValue(eInventorySlot.FeetArmor, out InventoryItem boots);
+							charItems.TryGetValue(eInventorySlot.TorsoArmor, out InventoryItem torso);
+							charItems.TryGetValue(eInventorySlot.Cloak, out InventoryItem cloak);
+							charItems.TryGetValue(eInventorySlot.LegsArmor, out InventoryItem legs);
+							charItems.TryGetValue(eInventorySlot.ArmsArmor, out InventoryItem arms);
+
+							pak.WriteShortLowEndian((ushort)(helmet != null ? helmet.Model : 0));
+							pak.WriteShortLowEndian((ushort)(gloves != null ? gloves.Model : 0));
+							pak.WriteShortLowEndian((ushort)(boots != null ? boots.Model : 0));
+
+							ushort rightHandColor = 0;
+							if (rightHandWeapon != null)
+							{
+								rightHandColor = (ushort)(rightHandWeapon.Emblem != 0 ? rightHandWeapon.Emblem : rightHandWeapon.Color);
+							}
+							pak.WriteShortLowEndian(rightHandColor);
+
+							pak.WriteShortLowEndian((ushort)(torso != null ? torso.Model : 0));
+							pak.WriteShortLowEndian((ushort)(cloak != null ? cloak.Model : 0));
+							pak.WriteShortLowEndian((ushort)(legs != null ? legs.Model : 0));
+							pak.WriteShortLowEndian((ushort)(arms != null ? arms.Model : 0));
+
+							ushort helmetColor = 0;
+							if (helmet != null)
+							{
+								helmetColor = (ushort)(helmet.Emblem != 0 ? helmet.Emblem : helmet.Color);
+							}
+							pak.WriteShortLowEndian(helmetColor);
+
+							ushort glovesColor = 0;
+							if (gloves != null)
+							{
+								glovesColor = (ushort)(gloves.Emblem != 0 ? gloves.Emblem : gloves.Color);
+							}
+							pak.WriteShortLowEndian(glovesColor);
+
+							ushort bootsColor = 0;
+							if (boots != null)
+							{
+								bootsColor = (ushort)(boots.Emblem != 0 ? boots.Emblem : boots.Color);
+							}
+							pak.WriteShortLowEndian(bootsColor);
+
+							ushort leftHandWeaponColor = 0;
+							if (leftHandWeapon != null)
+							{
+								leftHandWeaponColor = (ushort)(leftHandWeapon.Emblem != 0 ? leftHandWeapon.Emblem : leftHandWeapon.Color);
+							}
+							pak.WriteShortLowEndian(leftHandWeaponColor);
+
+							ushort torsoColor = 0;
+							if (torso != null)
+							{
+								torsoColor = (ushort)(torso.Emblem != 0 ? torso.Emblem : torso.Color);
+							}
+							pak.WriteShortLowEndian(torsoColor);
+
+							ushort cloakColor = 0;
+							if (cloak != null)
+							{
+								cloakColor = (ushort)(cloak.Emblem != 0 ? cloak.Emblem : cloak.Color);
+							}
+							pak.WriteShortLowEndian(cloakColor);
+
+							ushort legsColor = 0;
+							if (legs != null)
+							{
+								legsColor = (ushort)(legs.Emblem != 0 ? legs.Emblem : legs.Color);
+							}
+							pak.WriteShortLowEndian(legsColor);
+
+							ushort armsColor = 0;
+							if (arms != null)
+							{
+								armsColor = (ushort)(arms.Emblem != 0 ? arms.Emblem : arms.Color);
+							}
+							pak.WriteShortLowEndian(armsColor);
+
+							//weapon models
+
+							pak.WriteShortLowEndian((ushort)(rightHandWeapon != null ? rightHandWeapon.Model : 0));
+							pak.WriteShortLowEndian((ushort)(leftHandWeapon != null ? leftHandWeapon.Model : 0));
+							pak.WriteShortLowEndian((ushort)(twoHandWeapon != null ? twoHandWeapon.Model : 0));
+							pak.WriteShortLowEndian((ushort)(distanceWeapon != null ? distanceWeapon.Model : 0));
+
+							//pak.WriteInt(0x0); // Internal database ID
+							pak.WriteByte((byte)c.Strength);
+							pak.WriteByte((byte)c.Dexterity);
+							pak.WriteByte((byte)c.Constitution);
+							pak.WriteByte((byte)c.Quickness);
+							pak.WriteByte((byte)c.Intelligence);
+							pak.WriteByte((byte)c.Piety);
+							pak.WriteByte((byte)c.Empathy);
+							pak.WriteByte((byte)c.Charisma);
+							pak.WriteByte((byte)c.Class); // moved
+							pak.WriteByte((byte)c.Realm); // moved                            
+							pak.WriteByte((byte)((((c.Race & 0x10) << 2) + (c.Race & 0x0F)) | (c.Gender << 4)));
+
+							if (c.ActiveWeaponSlot == (byte)GameLiving.eActiveWeaponSlot.TwoHanded)
+							{
+								pak.WriteByte(0x02);
+								pak.WriteByte(0x02);
+							}
+							else if (c.ActiveWeaponSlot == (byte)GameLiving.eActiveWeaponSlot.Distance)
+							{
+								pak.WriteByte(0x03);
+								pak.WriteByte(0x03);
+							}
+							else
+							{
+								byte righthand = 0xFF;
+								byte lefthand = 0xFF;
+
+								if (rightHandWeapon != null)
+								{
+									righthand = 0x00;
+								}
+
+								if (leftHandWeapon != null)
+								{
+									lefthand = 0x01;
+								}
+
+								pak.WriteByte(righthand);
+								pak.WriteByte(lefthand);
+							}
+
+							if (region == null || region.Expansion != 1)
+							{
+								pak.WriteByte(0x00);
+							}
+							else
+							{
+								pak.WriteByte(0x01); //0x01=char in SI zone, classic client can't "play"
+							}
+
+							pak.WriteByte((byte)c.Constitution);
+						}
+					}
+				}
+
+				SendTCP(pak);
+			}
+		}
+
+		/// <summary>
+		/// 1125 UDPinit reply
+		/// </summary>
+		public override void SendUDPInitReply()
+		{
+			using (var pak = new GSUDPPacketOut(GetPacketCode(eServerPackets.UDPInitReply)))
+			{
+
+				if (!m_gameClient.Socket.Connected) // not using RC4, wont accept UDP packets anyway.
+				{
+					return;
+				}
+
+				ulong datetimenow = (ulong)DateTime.Now.Ticks >> 24; //shift 24 bits to match live value
+				pak.WriteLongLowEndian(datetimenow);
+				SendUDP(pak, true);
+			}
+		}
+
+
+		/// <summary>
+		/// 1125d+ Market Explorer
+		/// </summary>
+		public override void SendMarketExplorerWindow(IList<InventoryItem> items, byte page, byte maxpage)
+		{
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.MarketExplorerWindow)))
+			{
+				pak.WriteByte((byte)items.Count);
+				pak.WriteByte(page);
+				pak.WriteByte(maxpage);
+				pak.WriteByte(0);
+				foreach (InventoryItem item in items)
+				{
+					pak.WriteByte((byte)items.IndexOf(item));
+					pak.WriteByte((byte)item.Level);
+					int value1; // some object types use this field to display count
+					int value2; // some object types use this field to display count
+					switch (item.Object_Type)
+					{
+						case (int)eObjectType.Arrow:
+						case (int)eObjectType.Bolt:
+						case (int)eObjectType.Poison:
+						case (int)eObjectType.GenericItem:
+							value1 = item.PackSize;
+							value2 = item.SPD_ABS; break;
+						case (int)eObjectType.Thrown:
+							value1 = item.DPS_AF;
+							value2 = item.PackSize; break;
+						case (int)eObjectType.Instrument:
+							value1 = (item.DPS_AF == 2 ? 0 : item.DPS_AF); // 0x00 = Lute ; 0x01 = Drum ; 0x03 = Flute
+							value2 = 0; break; // unused
+						case (int)eObjectType.Shield:
+							value1 = item.Type_Damage;
+							value2 = item.DPS_AF; break;
+						case (int)eObjectType.GardenObject:
+						case (int)eObjectType.HouseWallObject:
+						case (int)eObjectType.HouseFloorObject:
+							value1 = 0;
+							value2 = item.SPD_ABS; break;
+						default:
+							value1 = item.DPS_AF;
+							value2 = item.SPD_ABS; break;
+					}
+					pak.WriteByte((byte)value1);
+					pak.WriteByte((byte)value2);
+					if (item.Object_Type == (int)eObjectType.GardenObject)
+					{
+						pak.WriteByte((byte)(item.DPS_AF));
+					}
+					else
+					{
+						pak.WriteByte((byte)(item.Hand << 6));
+					}
+
+					pak.WriteByte((byte)((item.Type_Damage > 3 ? 0 : item.Type_Damage << 6) | item.Object_Type));
+					pak.WriteByte((byte)(m_gameClient.Player.HasAbilityToUseItem(item.Template) ? 0 : 1));
+					pak.WriteShortLowEndian((ushort)(item.PackSize > 1 ? item.Weight * item.PackSize : item.Weight)); // 
+
+					pak.WriteByte((byte)item.ConditionPercent);
+					pak.WriteByte((byte)item.DurabilityPercent);
+					pak.WriteByte((byte)item.Quality);
+					pak.WriteByte((byte)item.Bonus);
+					pak.WriteShortLowEndian((ushort)item.Model);
+
+					if (item.Emblem != 0)
+					{
+						pak.WriteShortLowEndian((ushort)item.Emblem); // untested for low endian but probabaly
+					}
+					else
+					{
+						pak.WriteShortLowEndian((ushort)item.Color); // untested for low endian but probabaly
+					}
+
+					pak.WriteShortLowEndian((byte)item.Effect); // untested for low endian but probabaly
+					pak.WriteShortLowEndian(item.OwnerLot);//lot
+					pak.WriteIntLowEndian((uint)item.SellPrice);
+
+					if (ServerProperties.Properties.CONSIGNMENT_USE_BP)
+					{
+						string bpPrice = "";
+						if (item.SellPrice > 0)
+						{
+							bpPrice = "[" + item.SellPrice.ToString() + " BP";
+						}
+
+						if (item.Count > 1)
+						{
+							pak.WritePascalStringIntLE(item.Count + " " + item.Name);
+						}
+						else if (item.PackSize > 1)
+						{
+							pak.WritePascalStringIntLE(item.PackSize + " " + item.Name + bpPrice);
+						}
+						else
+						{
+							pak.WritePascalStringIntLE(item.Name + bpPrice);
+						}
+					}
+					else
+					{
+						if (item.Count > 1)
+						{
+							pak.WritePascalStringIntLE(item.Count + " " + item.Name);
+						}
+						else if (item.PackSize > 1)
+						{
+							pak.WritePascalStringIntLE(item.PackSize + " " + item.Name);
+						}
+						else
+						{
+							pak.WritePascalStringIntLE(item.Name);
+						}
+					}
+				}
+
+				SendTCP(pak);
+			}
+		}
+
+		/// <summary>
+		/// 1125d+ Merchant window
+		/// </summary>  
+		public override void SendMerchantWindow(MerchantTradeItems tradeItemsList, eMerchantWindowType windowType)
+		{
+			if (tradeItemsList != null)
+			{
+				for (byte page = 0; page < MerchantTradeItems.MAX_PAGES_IN_TRADEWINDOWS; page++)
+				{
+					IDictionary itemsInPage = tradeItemsList.GetItemsInPage((int)page);
+					if (itemsInPage == null || itemsInPage.Count == 0)
+					{
+						continue;
+					}
+
+					using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.MerchantWindow)))
+					{
+						pak.WriteByte((byte)itemsInPage.Count); //Item count on this page
+						pak.WriteByte((byte)windowType);
+						pak.WriteByte((byte)page); //Page number
+												   //pak.WriteByte(0x00); //Unused // testing
+
+						for (ushort i = 0; i < MerchantTradeItems.MAX_ITEM_IN_TRADEWINDOWS; i++)
+						{
+							if (!itemsInPage.Contains((int)i))
+							{
+								continue;
+							}
+
+							var item = (ItemTemplate)itemsInPage[(int)i];
+							if (item != null)
+							{
+								pak.WriteByte((byte)i); //Item index on page
+								pak.WriteByte((byte)item.Level);
+								// some objects use this for count
+								int value1;
+								int value2;
+								switch (item.Object_Type)
+								{
+									case (int)eObjectType.Arrow:
+									case (int)eObjectType.Bolt:
+									case (int)eObjectType.Poison:
+									case (int)eObjectType.GenericItem:
+										{
+											value1 = item.PackSize;
+											value2 = value1 * item.Weight;
+											break;
+										}
+									case (int)eObjectType.Thrown:
+										{
+											value1 = item.DPS_AF;
+											value2 = item.PackSize;
+											break;
+										}
+									case (int)eObjectType.Shield:
+										{
+											value1 = item.Type_Damage;
+											value2 = item.Weight;
+											break;
+										}
+									case (int)eObjectType.GardenObject:
+										{
+											value1 = 0;
+											value2 = item.Weight;
+											break;
+										}
+									default:
+										{
+											value1 = item.DPS_AF;
+											value2 = item.Weight;
+											break;
+										}
+								}
+								pak.WriteByte((byte)value1);
+								pak.WriteByte((byte)item.SPD_ABS);
+								if (item.Object_Type == (int)eObjectType.GardenObject)
+								{
+									pak.WriteByte((byte)(item.DPS_AF));
+								}
+								else
+								{
+									pak.WriteByte((byte)(item.Hand << 6));
+								}
+
+								pak.WriteByte((byte)((item.Type_Damage << 6) | item.Object_Type));
+								//1 if item cannot be used by your class (greyed out)
+								if (m_gameClient.Player != null && m_gameClient.Player.HasAbilityToUseItem(item))
+								{
+									pak.WriteByte(0x01); // these maybe switched in 1125 earlier revs
+								}
+								else
+								{
+									pak.WriteByte(0x00); // these maybe switched in 1125 earlier revs
+								}
+
+								pak.WriteShortLowEndian((ushort)value2);
+								pak.WriteIntLowEndian((uint)item.Price);
+								pak.WriteShortLowEndian((ushort)item.Model);
+								pak.WritePascalStringIntLE(item.Name);
+							}
+							else
+							{
+								if (log.IsErrorEnabled)
+								{
+									log.Error("Merchant item template '" +
+											  ((MerchantItem)itemsInPage[page * MerchantTradeItems.MAX_ITEM_IN_TRADEWINDOWS + i]).ItemTemplateID +
+											  "' not found, abort!!!");
+								}
+
+								return;
+							}
+						}
+						SendTCP(pak);
+					}
+				}
+			}
+			else
+			{
+				using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.MerchantWindow)))
+				{
+					pak.WriteByte(0); //Item count on this page
+					pak.WriteByte((byte)windowType); //Unknown 0x00
+					pak.WriteByte(0); //Page number
+					pak.WriteByte(0x00); //Unused
+					SendTCP(pak);
+				}
+			}
 		}
 	}
 }

--- a/GameServer/packets/Server/PacketLib1126.cs
+++ b/GameServer/packets/Server/PacketLib1126.cs
@@ -1,0 +1,318 @@
+﻿/*
+ * DAWN OF LIGHT - The first free open source DAoC server emulator
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ */
+using DOL.Database;
+using log4net;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Reflection;
+
+namespace DOL.GS.PacketHandler
+{
+	[PacketLib(1126, GameClient.eClientVersion.Version1126)]
+	public class PacketLib1126 : PacketLib1125
+	{
+		private static readonly ILog log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+
+		/// <summary>
+		/// Constructs a new PacketLib for Client Version 1.125
+		/// </summary>
+		/// <param name="client">the gameclient this lib is associated with</param>
+		public PacketLib1126(GameClient client)
+			: base(client)
+		{
+		}
+
+		/// <summary>
+		/// Reply on Server Opening to Client Encryption Request
+		/// Actually forces Encryption Off to work with Portal.
+		/// </summary>
+		public override void SendVersionAndCryptKey()
+		{
+			//Construct the new packet
+			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.CryptKey)))
+			{
+				//Disable encryption (1110+ always encrypt)
+				var key = new byte[32];
+				for (int i = 0; i < key.Length; ++i)
+					key[i] = (byte)i;
+				pak.WriteIntLowEndian((uint)key.Length);
+				pak.Write(key, 0, key.Length);
+
+				// From now on we expect RSA!
+				// _gameClient.PacketProcessor.Encoding.EncryptionState = eEncryptionState.PseudoRC4Encrypted; // disabled by the launcher
+
+				// Reply with current version
+				pak.WriteString((((int)m_gameClient.Version) / 1000) + "." + (((int)m_gameClient.Version) - 1000), 5);
+
+				// revision, last seen (c) 0x63
+				pak.WriteByte(0x00);
+
+				// Build number
+				pak.WriteByte(0x00); // last seen : 0x44 0x05
+				pak.WriteByte(0x00);
+				SendTCP(pak);
+			}
+		}
+
+		public override void SendCharacterOverview(eRealm realm)
+		{
+			if (realm < eRealm._FirstPlayerRealm || realm > eRealm._LastPlayerRealm)
+				throw new Exception($"CharacterOverview requested for unknown realm {realm}");
+
+			int firstSlot = (byte)realm * 100;
+
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.CharacterOverview1126)))
+			{
+				pak.WriteIntLowEndian(0); // 0x01 & 0x02 are flags
+				pak.WriteIntLowEndian(0);
+				pak.WriteIntLowEndian(0);
+				pak.WriteIntLowEndian(0);
+				if (m_gameClient.Account.Characters == null || m_gameClient.Account.Characters.Length == 0)
+				{
+					SendTCP(pak);
+					return;
+				}
+
+				Dictionary<int, DOLCharacters> charsBySlot = new Dictionary<int, DOLCharacters>();
+				foreach (DOLCharacters c in m_gameClient.Account.Characters)
+				{
+					try
+					{
+						charsBySlot.Add(c.AccountSlot, c);
+					}
+					catch (Exception ex)
+					{
+						log.Error($"SendCharacterOverview - Duplicate char in slot? Slot: {c.AccountSlot}, Account: {c.AccountName}", ex);
+					}
+				}
+				var itemsByOwnerID = new Dictionary<string, Dictionary<eInventorySlot, InventoryItem>>();
+
+				if (charsBySlot.Any())
+				{
+					var allItems = GameServer.Database.SelectObjects<InventoryItem>(
+							"`OwnerID` = @OwnerID AND `SlotPosition` >= @MinEquipable AND `SlotPosition` <= @MaxEquipable",
+							charsBySlot.Select(kv => new[] {
+								new QueryParameter("@OwnerID", kv.Value.ObjectId),
+								new QueryParameter("@MinEquipable", (int)eInventorySlot.MinEquipable),
+								new QueryParameter("@MaxEquipable", (int)eInventorySlot.MaxEquipable)
+							})
+						)
+						.SelectMany(objs => objs);
+
+					foreach (InventoryItem item in allItems)
+					{
+						try
+						{
+							if (!itemsByOwnerID.ContainsKey(item.OwnerID))
+								itemsByOwnerID.Add(item.OwnerID, new Dictionary<eInventorySlot, InventoryItem>());
+
+							itemsByOwnerID[item.OwnerID].Add((eInventorySlot)item.SlotPosition, item);
+						}
+						catch (Exception ex)
+						{
+							log.Error($"SendCharacterOverview - Duplicate item on character? OwnerID: {item.OwnerID}, SlotPosition: {item.SlotPosition}, Account: {m_gameClient.Account.Name}", ex);
+						}
+					}
+				}
+
+				// send each characters
+				for (int i = firstSlot; i < (firstSlot + 10); i++)
+				{
+					DOLCharacters c = null;
+					if (!charsBySlot.TryGetValue(i, out c))
+					{
+						pak.WriteByte(0);
+						continue;
+					}
+
+					Dictionary<eInventorySlot, InventoryItem> charItems = null;
+
+					if (!itemsByOwnerID.TryGetValue(c.ObjectId, out charItems))
+						charItems = new Dictionary<eInventorySlot, InventoryItem>();
+
+					byte extensionTorso = 0;
+					byte extensionGloves = 0;
+					byte extensionBoots = 0;
+
+					InventoryItem item = null;
+					if (charItems.TryGetValue(eInventorySlot.TorsoArmor, out item))
+						extensionTorso = item.Extension;
+					if (charItems.TryGetValue(eInventorySlot.HandsArmor, out item))
+						extensionGloves = item.Extension;
+					if (charItems.TryGetValue(eInventorySlot.FeetArmor, out item))
+						extensionBoots = item.Extension;
+
+					string locationDescription = string.Empty;
+					Region region = WorldMgr.GetRegion((ushort)c.Region);
+					if (region != null)
+						locationDescription = m_gameClient.GetTranslatedSpotDescription(region, c.Xpos, c.Ypos, c.Zpos);
+					string classname = "";
+					if (c.Class != 0)
+						classname = ((eCharacterClass)c.Class).ToString();
+					string racename = m_gameClient.RaceToTranslatedName(c.Race, c.Gender);
+
+					charItems.TryGetValue(eInventorySlot.RightHandWeapon, out InventoryItem rightHandWeapon);
+					charItems.TryGetValue(eInventorySlot.LeftHandWeapon, out InventoryItem leftHandWeapon);
+					charItems.TryGetValue(eInventorySlot.TwoHandWeapon, out InventoryItem twoHandWeapon);
+					charItems.TryGetValue(eInventorySlot.DistanceWeapon, out InventoryItem distanceWeapon);
+					charItems.TryGetValue(eInventorySlot.HeadArmor, out InventoryItem helmet);
+					charItems.TryGetValue(eInventorySlot.HandsArmor, out InventoryItem gloves);
+					charItems.TryGetValue(eInventorySlot.FeetArmor, out InventoryItem boots);
+					charItems.TryGetValue(eInventorySlot.TorsoArmor, out InventoryItem torso);
+					charItems.TryGetValue(eInventorySlot.Cloak, out InventoryItem cloak);
+					charItems.TryGetValue(eInventorySlot.LegsArmor, out InventoryItem legs);
+					charItems.TryGetValue(eInventorySlot.ArmsArmor, out InventoryItem arms);
+
+					ushort rightHandColor = 0;
+					if (rightHandWeapon != null)
+						rightHandColor = (ushort)(rightHandWeapon.Emblem != 0 ? rightHandWeapon.Emblem : rightHandWeapon.Color);
+					ushort helmetColor = 0;
+					if (helmet != null)
+						helmetColor = (ushort)(helmet.Emblem != 0 ? helmet.Emblem : helmet.Color);
+					ushort glovesColor = 0;
+					if (gloves != null)
+						glovesColor = (ushort)(gloves.Emblem != 0 ? gloves.Emblem : gloves.Color);
+					ushort bootsColor = 0;
+					if (boots != null)
+						bootsColor = (ushort)(boots.Emblem != 0 ? boots.Emblem : boots.Color);
+					ushort leftHandWeaponColor = 0;
+					if (leftHandWeapon != null)
+						leftHandWeaponColor = (ushort)(leftHandWeapon.Emblem != 0 ? leftHandWeapon.Emblem : leftHandWeapon.Color);
+					ushort torsoColor = 0;
+					if (torso != null)
+						torsoColor = (ushort)(torso.Emblem != 0 ? torso.Emblem : torso.Color);
+					ushort cloakColor = 0;
+					if (cloak != null)
+						cloakColor = (ushort)(cloak.Emblem != 0 ? cloak.Emblem : cloak.Color);
+					ushort legsColor = 0;
+					if (legs != null)
+						legsColor = (ushort)(legs.Emblem != 0 ? legs.Emblem : legs.Color);
+					ushort armsColor = 0;
+					if (arms != null)
+						armsColor = (ushort)(arms.Emblem != 0 ? arms.Emblem : arms.Color);
+
+					pak.WriteByte((byte)c.Level);
+					pak.WritePascalStringIntLE(c.Name);
+					pak.WriteIntLowEndian(0x18);
+					pak.WriteByte(1); // always 1 ?
+					pak.WriteByte(c.EyeSize); // seems to be : 0xF0 = eyes, 0x0F = nose
+					pak.WriteByte(c.LipSize); // seems to be : 0xF0 = lips, 0xF = jaw
+					pak.WriteByte(c.EyeColor); // seems to be : 0xF0 = eye color, 0x0F = skin tone
+					pak.WriteByte(c.HairColor);
+					pak.WriteByte(c.FaceType); // seems to be : 0xF0 = face
+					pak.WriteByte(c.HairStyle); // seems to be : 0xF0 = hair
+					pak.WriteByte((byte)((extensionBoots << 4) | extensionGloves));
+					pak.WriteByte((byte)((extensionTorso << 4) | (c.IsCloakHoodUp ? 0x1 : 0x0)));
+					pak.WriteByte(c.CustomisationStep); //1 = auto generate config, 2= config ended by player, 3= enable config to player
+					pak.WriteByte(c.MoodType);
+					pak.Fill(0x0, 13);
+					pak.WritePascalStringIntLE(locationDescription);
+					pak.WritePascalStringIntLE(classname);
+					pak.WritePascalStringIntLE(racename);
+					pak.WriteShortLowEndian((ushort)c.CurrentModel);
+
+					pak.WriteByte((byte)c.Region);
+					if (region == null || (int)m_gameClient.ClientType > region.Expansion)
+						pak.WriteByte(0x00);
+					else
+						pak.WriteByte((byte)(region.Expansion + 1)); //0x04-Cata zone, 0x05 - DR zone
+
+					pak.WriteShortLowEndian((ushort)(helmet != null ? helmet.Model : 0));
+					pak.WriteShortLowEndian((ushort)(gloves != null ? gloves.Model : 0));
+					pak.WriteShortLowEndian((ushort)(boots != null ? boots.Model : 0));
+					pak.WriteShortLowEndian(rightHandColor);
+					pak.WriteShortLowEndian((ushort)(torso != null ? torso.Model : 0));
+					pak.WriteShortLowEndian((ushort)(cloak != null ? cloak.Model : 0));
+					pak.WriteShortLowEndian((ushort)(legs != null ? legs.Model : 0));
+					pak.WriteShortLowEndian((ushort)(arms != null ? arms.Model : 0));
+
+					pak.WriteShortLowEndian(helmetColor);
+					pak.WriteShortLowEndian(glovesColor);
+					pak.WriteShortLowEndian(bootsColor);
+					pak.WriteShortLowEndian(leftHandWeaponColor);
+					pak.WriteShortLowEndian(torsoColor);
+					pak.WriteShortLowEndian(cloakColor);
+					pak.WriteShortLowEndian(legsColor);
+					pak.WriteShortLowEndian(armsColor);
+
+					//weapon models
+					pak.WriteShortLowEndian((ushort)(rightHandWeapon != null ? rightHandWeapon.Model : 0));
+					pak.WriteShortLowEndian((ushort)(leftHandWeapon != null ? leftHandWeapon.Model : 0));
+					pak.WriteShortLowEndian((ushort)(twoHandWeapon != null ? twoHandWeapon.Model : 0));
+					pak.WriteShortLowEndian((ushort)(distanceWeapon != null ? distanceWeapon.Model : 0));
+
+					pak.WriteByte((byte)c.Strength);
+					pak.WriteByte((byte)c.Quickness);
+					pak.WriteByte((byte)c.Constitution);
+					pak.WriteByte((byte)c.Dexterity);
+					pak.WriteByte((byte)c.Intelligence);
+					pak.WriteByte((byte)c.Piety);
+					pak.WriteByte((byte)c.Empathy); // ?
+					pak.WriteByte((byte)c.Charisma); // ?
+
+					pak.WriteByte((byte)c.Class);
+					pak.WriteByte((byte)c.Realm); // ok?
+					pak.WriteByte((byte)((((c.Race & 0x10) << 2) + (c.Race & 0x0F)) | (c.Gender << 4)));
+					if (c.ActiveWeaponSlot == (byte)GameLiving.eActiveWeaponSlot.TwoHanded)
+					{
+						pak.WriteByte(0x02);
+						pak.WriteByte(0x02);
+					}
+					else if (c.ActiveWeaponSlot == (byte)GameLiving.eActiveWeaponSlot.Distance)
+					{
+						pak.WriteByte(0x03);
+						pak.WriteByte(0x03);
+					}
+					else
+					{
+						pak.WriteByte((byte)(rightHandWeapon != null ? 0x00 : 0xFF));
+						pak.WriteByte((byte)(leftHandWeapon != null ? 0x01 : 0xFF));
+					}
+					pak.WriteByte(0); // SI = 1, Classic = 0
+					pak.WriteByte((byte)c.Constitution); // ok
+					pak.WriteByte(0); // unknown
+				}
+
+				SendTCP(pak);
+			}
+		}
+
+		public override void SendRegions()
+		{
+			if (!m_gameClient.Socket.Connected || m_gameClient.Player == null)
+				return;
+
+			Region region = WorldMgr.GetRegion(m_gameClient.Player.CurrentRegionID);
+			if (region == null)
+				return;
+			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.ClientRegion)))
+			{
+				var ip = region.ServerIP;
+				if (ip == "any" || ip == "0.0.0.0" || ip == "127.0.0.1" || ip.StartsWith("10.") || ip.StartsWith("192.168."))
+					ip = ((IPEndPoint)m_gameClient.Socket.LocalEndPoint).Address.ToString();
+				pak.WritePascalStringIntLE(ip);
+				pak.WriteIntLowEndian(region.ServerPort);
+				pak.WriteIntLowEndian(region.ServerPort);
+				SendTCP(pak);
+			}
+		}
+	}
+}

--- a/GameServer/packets/Server/PacketLib168.cs
+++ b/GameServer/packets/Server/PacketLib168.cs
@@ -361,7 +361,7 @@ namespace DOL.GS.PacketHandler
 			}
 		}
 
-		public virtual void SendDupNameCheckReply(string name, bool nameExists)
+		public virtual void SendDupNameCheckReply(string name, byte nameExists)
 		{
 			if (m_gameClient == null || m_gameClient.Account == null)
 				return;
@@ -370,7 +370,7 @@ namespace DOL.GS.PacketHandler
 			{
 				pak.FillString(name, 30);
 				pak.FillString(m_gameClient.Account.Name, 20);
-				pak.WriteByte((byte) (nameExists ? 0x1 : 0x0));
+				pak.WriteByte(nameExists);
 				pak.Fill(0x0, 3);
 				SendTCP(pak);
 			}
@@ -3021,9 +3021,14 @@ namespace DOL.GS.PacketHandler
 				m_gameClient.GameObjectUpdateArray.TryRemove(new Tuple<ushort, ushort>(obj.CurrentRegionID, (ushort)obj.ObjectID), out dummy);
 			}
 
+			SendObjectDelete((ushort)obj.ObjectID);
+		}
+
+		public void SendObjectDelete(ushort oid)
+		{
 			using (var pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.ObjectDelete)))
 			{
-				pak.WriteShort((ushort) obj.ObjectID);
+				pak.WriteShort(oid);
 				pak.WriteShort(1); //TODO: unknown
 				SendTCP(pak);
 			}

--- a/GameServer/spells/Animist/SummonAnimistPet.cs
+++ b/GameServer/spells/Animist/SummonAnimistPet.cs
@@ -84,6 +84,13 @@ namespace DOL.GS.Spells
                 return;
 			}
 
+			if (!Caster.GroundTargetInView)
+			{
+				if (Caster is GamePlayer)
+					MessageToCaster(LanguageMgr.GetTranslation((Caster as GamePlayer).Client, "SummonAnimistPet.CheckBeginCast.GroundTargetNotInView"), eChatType.CT_SpellResisted);
+				return;
+			}
+
 			if (!Caster.IsWithinRadius(Caster.GroundTarget, CalculateSpellRange()))
 			{
                 if (Caster is GamePlayer)

--- a/GameServer/world/Point3D.cs
+++ b/GameServer/world/Point3D.cs
@@ -48,6 +48,11 @@ namespace DOL.GS
 			m_z = z;
 		}
 
+		public Point3D(float x, float y, float z) : this((int)x, (int)y, (int)z)
+		{
+
+		}
+
 		/// <summary>
 		/// Constructs a new 3D point object
 		/// </summary>

--- a/GameServer/world/WorldMgr.cs
+++ b/GameServer/world/WorldMgr.cs
@@ -1174,9 +1174,9 @@ namespace DOL.GS
 		/// </summary>
 		/// <param name="id">ID to search</param>
 		/// <returns>The found GameClient or null if not found</returns>
-		public static GameClient GetClientFromID(int id)
+		public static GameClient GetClientFromID(uint id)
 		{
-			int i = id;
+			var i = id;
 			if (i <= 0 || i > m_clients.Length)
 				return null;
 			return m_clients[i - 1];

--- a/IntegrationTests/TestPacketLib.cs
+++ b/IntegrationTests/TestPacketLib.cs
@@ -140,8 +140,8 @@ namespace DOL.Tests
 		{
 			if (SendCharacterOverviewMethod != null) SendCharacterOverviewMethod(this, realm);
 		}
-		public Action<TestPacketLib, string, bool> SendDupNameCheckReplyMethod { get; set; }
-		public void SendDupNameCheckReply(string name, bool nameExists)
+		public Action<TestPacketLib, string, byte> SendDupNameCheckReplyMethod { get; set; }
+		public void SendDupNameCheckReply(string name, byte nameExists)
 		{
 			if (SendDupNameCheckReplyMethod != null) SendDupNameCheckReplyMethod(this, name, nameExists);
 		}
@@ -592,6 +592,11 @@ namespace DOL.Tests
 		public void SendObjectDelete(GameObject obj)
 		{
 			if (SendObjectDeleteMethod != null) SendObjectDeleteMethod(this, obj);
+		}
+		public Action<TestPacketLib, ushort> SendObjectIdDeleteMethod { get; set; }
+		public void SendObjectDelete(ushort objId)
+		{
+			if (SendObjectIdDeleteMethod != null) SendObjectIdDeleteMethod(this, objId);
 		}
 		public Action<TestPacketLib, GameObject> SendObjectUpdateMethod { get; set; }
 		public void SendObjectUpdate(GameObject obj)


### PR DESCRIPTION
add 1.124+ basic support (based on Los-Ojos/DOLSharp-1126 branch) + few fixes/optimizations

fix WeakMulticastDelegate.InvokeSafe
remove virtual from Packets Read/Write methods

A big change between 1.109 and 1.124+ is the position system which is from int to float for player's positions (not handled like that in this commit, I convert everything to int) and refresh rate for updates.

It's a really basic support, there are some untested packets (especially about quests).

I don't recommend to allow 1.109 and 1.124 clients on the same server (fix your server properties), with the different refresh rate, 1.109 player movements aren't smooths for 1.124 players.