### PR TITLE
Fix null exception for BD pets without subpets

### DIFF
--- a/GameServer/gameobjects/CharacterClasses/Midgard/CharacterClassBoneDancer.cs
+++ b/GameServer/gameobjects/CharacterClasses/Midgard/CharacterClassBoneDancer.cs
@@ -58,7 +58,8 @@ namespace DOL.GS
 			//	trains, we have to re-scale spells for subpets from that spec.
 			if (DOL.GS.ServerProperties.Properties.PET_SCALE_SPELL_MAX_LEVEL > 0
 				&& DOL.GS.ServerProperties.Properties.PET_CAP_BD_MINION_SPELL_SCALING_BY_SPEC
-				&& player.ControlledBrain != null && player.ControlledBrain.Body is GamePet pet)
+				&& player.ControlledBrain != null && player.ControlledBrain.Body is GamePet pet
+				&& pet.ControlledNpcList != null)
 					foreach (ABrain subBrain in pet.ControlledNpcList)
 						if (subBrain != null && subBrain.Body is BDSubPet subPet && subPet.PetSpecLine == skill.KeyName)
 							subPet.SortSpells();


### PR DESCRIPTION
When pets level with owner, and BD pet spells are capped based on spec, and the current pet doesn't have any subpets, a null exception would be thrown which leads to the player's spell list not being updated.