### PR TITLE
Fix Quest Mob Selection

### DIFF
--- a/GameServerScripts/quests/Albion/epic/Academy50.cs
+++ b/GameServerScripts/quests/Albion/epic/Academy50.cs
@@ -106,7 +106,16 @@ namespace DOL.GS.Quests.Albion
 			#region defineNPCs
 
             GameNPC[] npcs = WorldMgr.GetNPCsByName("Master Ferowl", eRealm.Albion);
-			if (npcs.Length == 0)
+
+			if (npcs.Length > 0)
+				foreach (GameNPC npc in npcs)
+					if (npc.CurrentRegionID == 1 && npc.X == 559690 && npc.Y == 510258)
+					{
+						Ferowl = npc;
+						break;
+					}
+
+			if (Ferowl == null)
 			{
 				Ferowl = new GameNPC();
 				Ferowl.Model = 61;
@@ -118,8 +127,8 @@ namespace DOL.GS.Quests.Albion
 				Ferowl.CurrentRegionID = 1;
 				Ferowl.Size = 51;
 				Ferowl.Level = 40;
-				Ferowl.X = 559716;
-				Ferowl.Y = 510733;
+				Ferowl.X = 559690;
+				Ferowl.Y = 510258;
 				Ferowl.Z = 2720;
 				Ferowl.Heading = 703;
 				Ferowl.AddToWorld();
@@ -127,12 +136,19 @@ namespace DOL.GS.Quests.Albion
 				if (SAVE_INTO_DATABASE)
 					Ferowl.SaveIntoDatabase();
 			}
-			else
-				Ferowl = npcs[0];
 			// end npc
 
 			npcs = WorldMgr.GetNPCsByName("Morgana", eRealm.None);
-			if (npcs.Length == 0)
+
+			if (npcs.Length > 0)
+				foreach (GameNPC npc in npcs)
+					if (npc.CurrentRegionID == 1 && npc.X == 306056 && npc.Y == 670106)
+					{
+						Morgana = npc;
+						break;
+					}
+
+			if (Morgana == null)
 			{
 				Morgana = new GameNPC();
 				Morgana.Model = 283;
@@ -167,11 +183,19 @@ namespace DOL.GS.Quests.Albion
 				if (SAVE_INTO_DATABASE)
 					Morgana.SaveIntoDatabase();
 			}
-			else
-				Morgana = npcs[0];
+			// end npc
 
 			npcs = WorldMgr.GetNPCsByName("Bechard", eRealm.None);
-			if (npcs.Length == 0)
+
+			if (npcs.Length > 0)
+				foreach (GameNPC npc in npcs)
+					if (npc.CurrentRegionID == 1 && npc.X == 306025 && npc.Y == 670473)
+					{
+						Bechard = npc;
+						break;
+					}
+
+			if (Bechard == null)
 			{
 				if (log.IsWarnEnabled)
 					log.Warn("Could not find Bechard , creating it ...");
@@ -192,12 +216,19 @@ namespace DOL.GS.Quests.Albion
 				if (SAVE_INTO_DATABASE)
 					Bechard.SaveIntoDatabase();
 			}
-			else
-				Bechard = npcs[0];
 			// end npc
 
 			npcs = WorldMgr.GetNPCsByName("Silcharde", eRealm.None);
-			if (npcs.Length == 0)
+
+			if (npcs.Length > 0)
+				foreach (GameNPC npc in npcs)
+					if (npc.CurrentRegionID == 1 && npc.X == 306252 && npc.Y == 670274)
+					{
+						Silcharde = npc;
+						break;
+					}
+
+			if (Silcharde == null)
 			{
 				if (log.IsWarnEnabled)
 					log.Warn("Could not find Silcharde , creating it ...");
@@ -217,10 +248,7 @@ namespace DOL.GS.Quests.Albion
 
 				if (SAVE_INTO_DATABASE)
 					Silcharde.SaveIntoDatabase();
-
 			}
-			else
-				Silcharde = npcs[0];
 			// end npc
 
 			#endregion

--- a/GameServerScripts/quests/Albion/epic/Church50.cs
+++ b/GameServerScripts/quests/Albion/epic/Church50.cs
@@ -96,7 +96,15 @@ namespace DOL.GS.Quests.Albion
 
 			GameNPC[] npcs = WorldMgr.GetNPCsByName("Roben Fraomar", eRealm.Albion);
 
-			if (npcs.Length == 0)
+			if (npcs.Length > 0)
+				foreach (GameNPC npc in npcs)
+					if (npc.CurrentRegionID == 1 && npc.X == 408557 && npc.Y == 651675)
+					{
+						Roben = npc;
+						break;
+					}
+
+			if (Roben == null)
 			{
 				if (log.IsWarnEnabled)
 					log.Warn("Could not find Roben , creating it ...");
@@ -117,12 +125,19 @@ namespace DOL.GS.Quests.Albion
 				if (SAVE_INTO_DATABASE)
 					Roben.SaveIntoDatabase();
 			}
-			else
-				Roben = npcs[0];
 			// end npc
 
 			npcs = WorldMgr.GetNPCsByName("Sister Blythe", eRealm.None);
-			if (npcs.Length == 0)
+
+			if (npcs.Length > 0)
+				foreach (GameNPC npc in npcs)
+					if (npc.CurrentRegionID == 1 && npc.X == 322231 && npc.Y == 671546)
+					{
+						Blythe = npc;
+						break;
+					}
+
+			if (Blythe == null)
 			{
 				if (log.IsWarnEnabled)
 					log.Warn("Could not find Blythe , creating it ...");
@@ -143,8 +158,6 @@ namespace DOL.GS.Quests.Albion
 				if (SAVE_INTO_DATABASE)
 					Blythe.SaveIntoDatabase();
 			}
-			else
-				Blythe = npcs[0];
 			// end npc
 
 			#endregion

--- a/GameServerScripts/quests/Albion/epic/Defenders50.cs
+++ b/GameServerScripts/quests/Albion/epic/Defenders50.cs
@@ -97,7 +97,15 @@ namespace DOL.GS.Quests.Albion
 
 			GameNPC[] npcs = WorldMgr.GetNPCsByName("Lidmann Halsey", eRealm.Albion);
 
-			if (npcs.Length == 0)
+			if (npcs.Length > 0)
+				foreach (GameNPC npc in npcs)
+					if (npc.CurrentRegionID == 1 && npc.X == 466464 && npc.Y == 634554)
+					{
+						Lidmann = npc;
+						break;
+					}
+
+			if (Lidmann == null)
 			{
 
 				Lidmann = new GameNPC();
@@ -123,13 +131,19 @@ namespace DOL.GS.Quests.Albion
 				}
 
 			}
-			else
-				Lidmann = npcs[0];
 			// end npc
 
 			npcs = WorldMgr.GetNPCsByName("Cailleach Uragaig", eRealm.None);
 
-			if (npcs.Length == 0)
+			if (npcs.Length > 0)
+				foreach (GameNPC npc in npcs)
+					if (npc.CurrentRegionID == 1 && npc.X == 316218 && npc.Y == 664484)
+					{
+						Uragaig = npc;
+						break;
+					}
+
+			if (Uragaig == null)
 			{
 				if (log.IsWarnEnabled)
 					log.Warn("Could not find Uragaig , creating it ...");
@@ -152,8 +166,6 @@ namespace DOL.GS.Quests.Albion
 				}
 
 			}
-			else
-				Uragaig = npcs[0];
 			// end npc
 
 			#endregion

--- a/GameServerScripts/quests/Albion/epic/Shadows50.cs
+++ b/GameServerScripts/quests/Albion/epic/Shadows50.cs
@@ -106,7 +106,15 @@ namespace DOL.GS.Quests.Albion
 
 			GameNPC[] npcs = WorldMgr.GetNPCsByName("Lidmann Halsey", eRealm.Albion);
 
-			if (npcs.Length == 0)
+			if (npcs.Length > 0)
+				foreach (GameNPC npc in npcs)
+					if (npc.CurrentRegionID == 1 && npc.X == 466464 && npc.Y == 634554)
+					{
+						Lidmann = npc;
+						break;
+					}
+
+			if (Lidmann == null)
 			{
 				if (log.IsWarnEnabled)
 					log.Warn("Could not find Lidmann Halsey, creating it ...");
@@ -127,15 +135,20 @@ namespace DOL.GS.Quests.Albion
 				{
 					Lidmann.SaveIntoDatabase();
 				}
-
 			}
-			else
-				Lidmann = npcs[0];
 			// end npc
 
 			npcs = WorldMgr.GetNPCsByName("Cailleach Uragaig", eRealm.None);
 
-			if (npcs.Length == 0)
+			if (npcs.Length > 0)
+				foreach (GameNPC npc in npcs)
+					if (npc.CurrentRegionID == 1 && npc.X == 316218 && npc.Y == 664484)
+					{
+						Uragaig = npc;
+						break;
+					}
+
+			if (Uragaig == null)
 			{
 				if (log.IsWarnEnabled)
 					log.Warn("Could not find Uragaig , creating it ...");
@@ -156,10 +169,7 @@ namespace DOL.GS.Quests.Albion
 				{
 					Uragaig.SaveIntoDatabase();
 				}
-
 			}
-			else
-				Uragaig = npcs[0];
 			// end npc
 
 			#endregion

--- a/GameServerScripts/quests/Hibernia/epic/Essence50.cs
+++ b/GameServerScripts/quests/Hibernia/epic/Essence50.cs
@@ -114,7 +114,15 @@ namespace DOL.GS.Quests.Hibernia
 
 			GameNPC[] npcs = WorldMgr.GetNPCsByName("Brigit", eRealm.Hibernia);
 
-			if (npcs.Length == 0)
+			if (npcs.Length > 0)
+				foreach (GameNPC npc in npcs)
+					if (npc.CurrentRegionID == 201 && npc.X == 32927 && npc.Y == 32743)
+					{
+						Brigit = npc;
+						break;
+					}
+
+			if (Brigit == null)
 			{
 				if (log.IsWarnEnabled)
 					log.Warn("Could not find Brigit , creating it ...");
@@ -126,8 +134,8 @@ namespace DOL.GS.Quests.Hibernia
 				Brigit.CurrentRegionID = 201;
 				Brigit.Size = 51;
 				Brigit.Level = 50;
-				Brigit.X = 33131;
-				Brigit.Y = 32922;
+				Brigit.X = 32927;
+				Brigit.Y = 32743;
 				Brigit.Z = 8008;
 				Brigit.Heading = 3254;
 				Brigit.AddToWorld();
@@ -135,15 +143,20 @@ namespace DOL.GS.Quests.Hibernia
 				{
 					Brigit.SaveIntoDatabase();
 				}
-
 			}
-			else
-				Brigit = npcs[0];
 			// end npc
 
 			npcs = WorldMgr.GetNPCsByName("Caithor", eRealm.None);
 
-			if (npcs.Length == 0)
+			if (npcs.Length > 0)
+				foreach (GameNPC npc in npcs)
+					if (npc.CurrentRegionID == 200 && npc.X == 470547 && npc.Y == 531497)
+					{
+						Caithor = npc;
+						break;
+					}
+
+			if (Caithor == null)
 			{
 				if (log.IsWarnEnabled)
 					log.Warn("Could not find Caithor , creating it ...");
@@ -166,8 +179,6 @@ namespace DOL.GS.Quests.Hibernia
 				}
 
 			}
-			else
-				Caithor = npcs[0];
 			// end npc
 
 			#endregion

--- a/GameServerScripts/quests/Hibernia/epic/Focus50.cs
+++ b/GameServerScripts/quests/Hibernia/epic/Focus50.cs
@@ -114,7 +114,15 @@ namespace DOL.GS.Quests.Hibernia
 
 			GameNPC[] npcs = WorldMgr.GetNPCsByName("Ainrebh", eRealm.Hibernia);
 
-			if (npcs.Length == 0)
+			if (npcs.Length > 0)
+				foreach (GameNPC npc in npcs)
+					if (npc.CurrentRegionID == 200 && npc.X == 421281 && npc.Y == 516273)
+					{
+						Ainrebh = npc;
+						break;
+					}
+
+			if (Ainrebh == null)
 			{
 				if (log.IsWarnEnabled)
 					log.Warn("Could not find Ainrebh , creating it ...");
@@ -135,15 +143,20 @@ namespace DOL.GS.Quests.Hibernia
 				{
 					Ainrebh.SaveIntoDatabase();
 				}
-
 			}
-			else
-				Ainrebh = npcs[0];
 			// end npc
 
 			npcs = WorldMgr.GetNPCsByName("Green Maw", eRealm.None);
 
-			if (npcs.Length == 0)
+			if (npcs.Length > 0)
+				foreach (GameNPC npc in npcs)
+					if (npc.CurrentRegionID == 200 && npc.X == 488306 && npc.Y == 521440)
+					{
+						GreenMaw = npc;
+						break;
+					}
+
+			if (GreenMaw == null)
 			{
 				if (log.IsWarnEnabled)
 					log.Warn("Could not find GreenMaw , creating it ...");
@@ -164,10 +177,7 @@ namespace DOL.GS.Quests.Hibernia
 				{
 					GreenMaw.SaveIntoDatabase();
 				}
-
 			}
-			else
-				GreenMaw = npcs[0];
 			// end npc
 
 			#endregion

--- a/GameServerScripts/quests/Hibernia/epic/Harmony50.cs
+++ b/GameServerScripts/quests/Hibernia/epic/Harmony50.cs
@@ -114,7 +114,15 @@ namespace DOL.GS.Quests.Hibernia
 
 			GameNPC[] npcs = WorldMgr.GetNPCsByName("Revelin", eRealm.Hibernia);
 
-			if (npcs.Length == 0)
+			if (npcs.Length > 0)
+				foreach (GameNPC npc in npcs)
+					if (npc.CurrentRegionID == 200 && npc.X == 343442 && npc.Y == 706235)
+					{
+						Revelin = npc;
+						break;
+					}
+
+			if (Revelin == null)
 			{
 				if (log.IsWarnEnabled)
 					log.Warn("Could not find Revelin , creating it ...");
@@ -126,9 +134,9 @@ namespace DOL.GS.Quests.Hibernia
 				Revelin.CurrentRegionID = 200;
 				Revelin.Size = 42;
 				Revelin.Level = 20;
-				Revelin.X = 344387;
-				Revelin.Y = 706197;
-				Revelin.Z = 6351;
+				Revelin.X = 343442;
+				Revelin.Y = 706235;
+				Revelin.Z = 6336;
 				Revelin.Heading = 2127;
 				Revelin.Flags ^= GameNPC.eFlags.PEACE;
 				Revelin.AddToWorld();
@@ -136,15 +144,20 @@ namespace DOL.GS.Quests.Hibernia
 				{
 					Revelin.SaveIntoDatabase();
 				}
-
 			}
-			else
-				Revelin = npcs[0];
 			// end npc
 
 			npcs = WorldMgr.GetNPCsByName("Cailean", eRealm.None);
 
-			if (npcs.Length == 0)
+			if (npcs.Length > 0)
+				foreach (GameNPC npc in npcs)
+					if (npc.CurrentRegionID == 200 && npc.X == 479042 && npc.Y == 508134)
+					{
+						Cailean = npc;
+						break;
+					}
+
+			if (Cailean == null)
 			{
 				if (log.IsWarnEnabled)
 					log.Warn("Could not find Cailean , creating it ...");
@@ -165,10 +178,7 @@ namespace DOL.GS.Quests.Hibernia
 				{
 					Cailean.SaveIntoDatabase();
 				}
-
 			}
-			else
-				Cailean = npcs[0];
 			// end npc
 
 			#endregion
@@ -2227,7 +2237,7 @@ namespace DOL.GS.Quests.Hibernia
 				switch (Step)
 				{
 					case 1:
-						return "[Step #1] Seek out Cailean in Cursed Forest Loc 28k,24k kill him!";
+						return "[Step #1] Seek out Cailean in Cursed Forest Loc 26k, 23k and kill him!";
 					case 2:
 						return "[Step #2] Return to Revelin and give the Horn!";
 				}

--- a/GameServerScripts/quests/Midgard/epic/MidgardRogue50.cs
+++ b/GameServerScripts/quests/Midgard/epic/MidgardRogue50.cs
@@ -102,7 +102,15 @@ namespace DOL.GS.Quests.Midgard
 
 			GameNPC[] npcs = WorldMgr.GetNPCsByName("Masrim", eRealm.Midgard);
 
-			if (npcs.Length == 0)
+			if (npcs.Length > 0)
+				foreach (GameNPC npc in npcs)
+					if (npc.CurrentRegionID == 100 && npc.X == 749099 && npc.Y == 813104)
+					{
+						Masrim = npc;
+						break;
+					}
+
+			if (Masrim == null)
 			{
 				if (log.IsWarnEnabled)
 					log.Warn("Could not find Masrim , creating it ...");
@@ -123,15 +131,20 @@ namespace DOL.GS.Quests.Midgard
 				{
 					Masrim.SaveIntoDatabase();
 				}
-
 			}
-			else
-				Masrim = npcs[0];
 			// end npc
 
 			npcs = WorldMgr.GetNPCsByName("Oona", eRealm.None);
 
-			if (npcs.Length == 0)
+			if (npcs.Length > 0)
+				foreach (GameNPC npc in npcs)
+					if (npc.CurrentRegionID == 100 && npc.X == 607233 && npc.Y == 786850)
+					{
+						Oona = npc;
+						break;
+					}
+
+			if (Oona == null)
 			{
 				if (log.IsWarnEnabled)
 					log.Warn("Could not find Oona , creating it ...");
@@ -153,15 +166,20 @@ namespace DOL.GS.Quests.Midgard
 				{
 					Oona.SaveIntoDatabase();
 				}
-
 			}
-			else
-				Oona = npcs[0];
 			// end npc
 
 			npcs = WorldMgr.GetNPCsByName("Morlin Caan", eRealm.Midgard);
 
-			if (npcs.Length == 0)
+			if (npcs.Length > 0)
+				foreach (GameNPC npc in npcs)
+					if (npc.CurrentRegionID == 101 && npc.X == 33400 && npc.Y == 33620)
+					{
+						MorlinCaan = npc;
+						break;
+					}
+
+			if (MorlinCaan == null)
 			{
 				if (log.IsWarnEnabled)
 					log.Warn("Could not find Morlin Caan , creating it ...");
@@ -182,10 +200,7 @@ namespace DOL.GS.Quests.Midgard
 				{
 					MorlinCaan.SaveIntoDatabase();
 				}
-
 			}
-			else
-				MorlinCaan = npcs[0];
 			// end npc
 
 			#endregion

--- a/GameServerScripts/quests/Midgard/epic/Mystic50.cs
+++ b/GameServerScripts/quests/Midgard/epic/Mystic50.cs
@@ -119,7 +119,15 @@ namespace DOL.GS.Quests.Midgard
 
 			GameNPC[] npcs = WorldMgr.GetNPCsByName("Danica", eRealm.Midgard);
 
-			if (npcs.Length == 0)
+			if (npcs.Length > 0)
+				foreach (GameNPC npc in npcs)
+					if (npc.CurrentRegionID == 100 && npc.X == 802818 && npc.Y == 727413)
+					{
+						Danica = npc;
+						break;
+					}
+
+			if (Danica == null)
 			{
 				if (log.IsWarnEnabled)
 					log.Warn("Could not find Danica , creating it ...");
@@ -131,9 +139,9 @@ namespace DOL.GS.Quests.Midgard
 				Danica.CurrentRegionID = 100;
 				Danica.Size = 51;
 				Danica.Level = 50;
-				Danica.X = 804440;
-				Danica.Y = 722267;
-				Danica.Z = 4719;
+				Danica.X = 802818;
+				Danica.Y = 727413;
+				Danica.Z = 4760;
 				Danica.Heading = 2116;
 				Danica.AddToWorld();
 				if (SAVE_INTO_DATABASE)
@@ -141,12 +149,19 @@ namespace DOL.GS.Quests.Midgard
 					Danica.SaveIntoDatabase();
 				}
 			}
-			else
-				Danica = npcs[0];
 			// end npc
 
 			npcs = WorldMgr.GetNPCsByName("Kelic", eRealm.None);
-			if (npcs.Length == 0)
+
+			if (npcs.Length > 0)
+				foreach (GameNPC npc in npcs)
+					if (npc.CurrentRegionID == 100 && npc.X == 621577 && npc.Y == 745848)
+					{
+						Kelic = npc;
+						break;
+					}
+
+			if (Kelic == null)
 			{
 				if (log.IsWarnEnabled)
 					log.Warn("Could not find Kelic , creating it ...");
@@ -170,15 +185,13 @@ namespace DOL.GS.Quests.Midgard
 					Kelic.SaveIntoDatabase();
 				}
 			}
-			else
-				Kelic = npcs[0];
 			// end npc
 
-			#endregion
+				#endregion
 
-			#region defineItems
+				#region defineItems
 
-			kelics_totem = GameServer.Database.FindObjectByKey<ItemTemplate>("kelics_totem");
+				kelics_totem = GameServer.Database.FindObjectByKey<ItemTemplate>("kelics_totem");
 			if (kelics_totem == null)
 			{
 				if (log.IsWarnEnabled)

--- a/GameServerScripts/quests/Midgard/epic/Seer50.cs
+++ b/GameServerScripts/quests/Midgard/epic/Seer50.cs
@@ -103,7 +103,15 @@ namespace DOL.GS.Quests.Midgard
 
 			GameNPC[] npcs = WorldMgr.GetNPCsByName("Inaksha", eRealm.Midgard);
 
-			if (npcs.Length == 0)
+			if (npcs.Length > 0)
+				foreach (GameNPC npc in npcs)
+					if (npc.CurrentRegionID == 100 && npc.X == 805929 && npc.Y == 702449)
+					{
+						Inaksha = npc;
+						break;
+					}
+
+			if (Inaksha == null)
 			{
 				if (log.IsWarnEnabled)
 					log.Warn("Could not find Inaksha , creating it ...");
@@ -124,15 +132,20 @@ namespace DOL.GS.Quests.Midgard
 				{
 					Inaksha.SaveIntoDatabase();
 				}
-
 			}
-			else
-				Inaksha = npcs[0];
 			// end npc
 
 			npcs = WorldMgr.GetNPCsByName("Loken", eRealm.None);
 
-			if (npcs.Length == 0)
+			if (npcs.Length > 0)
+				foreach (GameNPC npc in npcs)
+					if (npc.CurrentRegionID == 100 && npc.X == 636784 && npc.Y == 762433)
+					{
+						Loken = npc;
+						break;
+					}
+
+			if (Loken == null)
 			{
 				if (log.IsWarnEnabled)
 					log.Warn("Could not find Loken , creating it ...");
@@ -153,15 +166,20 @@ namespace DOL.GS.Quests.Midgard
 				{
 					Loken.SaveIntoDatabase();
 				}
-
 			}
-			else
-				Loken = npcs[0];
 			// end npc
 
 			npcs = WorldMgr.GetNPCsByName("Miri", eRealm.Midgard);
 
-			if (npcs.Length == 0)
+			if (npcs.Length > 0)
+				foreach (GameNPC npc in npcs)
+					if (npc.CurrentRegionID == 101 && npc.X == 30641 && npc.Y == 32093)
+					{
+						Miri = npc;
+						break;
+					}
+
+			if (Miri == null)
 			{
 				if (log.IsWarnEnabled)
 					log.Warn("Could not find Miri , creating it ...");
@@ -182,10 +200,7 @@ namespace DOL.GS.Quests.Midgard
 				{
 					Miri.SaveIntoDatabase();
 				}
-
 			}
-			else
-				Miri = npcs[0];
 			// end npc
 
 			#endregion

--- a/GameServerScripts/quests/Midgard/epic/Viking50.cs
+++ b/GameServerScripts/quests/Midgard/epic/Viking50.cs
@@ -132,7 +132,15 @@ namespace DOL.GS.Quests.Midgard
 
 			GameNPC[] npcs = WorldMgr.GetNPCsByName("Lynnleigh", eRealm.Midgard);
 
-			if (npcs.Length == 0)
+			if (npcs.Length > 0)
+				foreach (GameNPC npc in npcs)
+					if (npc.CurrentRegionID == 100 && npc.X == 760118 && npc.Y == 758453)
+					{
+						Lynnleigh = npc;
+						break;
+					}
+
+			if (Lynnleigh == null)
 			{
 				if (log.IsWarnEnabled)
 					log.Warn("Could not find Lynnleigh , creating it ...");
@@ -144,9 +152,9 @@ namespace DOL.GS.Quests.Midgard
 				Lynnleigh.CurrentRegionID = 100;
 				Lynnleigh.Size = 51;
 				Lynnleigh.Level = 50;
-				Lynnleigh.X = 760085;
+				Lynnleigh.X = 760118;
 				Lynnleigh.Y = 758453;
-				Lynnleigh.Z = 4736;
+				Lynnleigh.Z = 4737;
 				Lynnleigh.Heading = 2197;
 				Lynnleigh.AddToWorld();
 				if (SAVE_INTO_DATABASE)
@@ -154,26 +162,31 @@ namespace DOL.GS.Quests.Midgard
 					Lynnleigh.SaveIntoDatabase();
 				}
 			}
-			else
-				Lynnleigh = npcs[0];
 			// end npc
 			npcs = WorldMgr.GetNPCsByName("Elizabeth", eRealm.Midgard);
 
-			if (npcs.Length == 0)
+			if (npcs.Length > 0)
+				foreach (GameNPC npc in npcs)
+					if (npc.CurrentRegionID == 100 && npc.X == 802597 && npc.Y == 727896)
+					{
+						Elizabeth = npc;
+						break;
+					}
+
+			if (Elizabeth == null)
 			{
 				if (log.IsWarnEnabled)
 					log.Warn("Could not find Elizabeth , creating it ...");
 				Elizabeth = new GameNPC();
 				Elizabeth.Model = 217;
 				Elizabeth.Name = "Elizabeth";
-				Elizabeth.GuildName = "Enchanter";
 				Elizabeth.Realm = eRealm.Midgard;
 				Elizabeth.CurrentRegionID = 100;
 				Elizabeth.Size = 51;
 				Elizabeth.Level = 41;
-				Elizabeth.X = 802849;
-				Elizabeth.Y = 727081;
-				Elizabeth.Z = 4681;
+				Elizabeth.X = 802597;
+				Elizabeth.Y = 727896;
+				Elizabeth.Z = 4760;
 				Elizabeth.Heading = 2480;
 				Elizabeth.AddToWorld();
 				if (SAVE_INTO_DATABASE)
@@ -182,13 +195,19 @@ namespace DOL.GS.Quests.Midgard
 				}
 
 			}
-			else
-				Elizabeth = npcs[0];
 			// end npc
 
 			npcs = WorldMgr.GetNPCsByName("Ydenia of Seithkona", eRealm.None);
 
-			if (npcs.Length == 0)
+			if (npcs.Length > 0)
+				foreach (GameNPC npc in npcs)
+					if (npc.CurrentRegionID == 100 && npc.X == 637680 && npc.Y == 767189)
+					{
+						Ydenia = npc;
+						break;
+					}
+
+			if (Ydenia == null)
 			{
 				if (log.IsWarnEnabled)
 					log.Warn("Could not find Ydenia , creating it ...");
@@ -211,10 +230,7 @@ namespace DOL.GS.Quests.Midgard
 				{
 					Ydenia.SaveIntoDatabase();
 				}
-
 			}
-			else
-				Ydenia = npcs[0];
 			// end npc
 
 			#endregion


### PR DESCRIPTION
Some quest mob names are reused (Elizabeth), and others are duplicated in strange places in Eve.  This made some quests impossible.  Quests now check for name, region, and x/y coordinates to make sure the correct NPC is being selected rather than assuming the first one in the list is the one we want.

Tweaked a few things as well, making coordinates match Eve and correcting incorrect quest text.