### PR TITLE
Fix ArtifactTurnInQuest breaking all Artifacts

### DIFF
--- a/GameServer/gameutils/Atlantis/InventoryArtifact.cs
+++ b/GameServer/gameutils/Atlantis/InventoryArtifact.cs
@@ -59,6 +59,7 @@ namespace DOL.GS
 			: base(template)
 			
 		{
+			Template = Template.Clone() as ItemTemplate;
 			ArtifactID = ArtifactMgr.GetArtifactIDFromItemID(template.Id_nb);
 			ArtifactLevel = 0;
 			m_levelRequirements = ArtifactMgr.GetLevelRequirements(ArtifactID);


### PR DESCRIPTION
Fixes a bug where all stats of an artifact (version) are reset globally when someone turns in an artifact quest (for this version). Bug was caused by altering the global cached ItemTemplate instead of a copy.