### PR TITLE
Origins

### DIFF
--- a/DOLDatabase/Tables/Inventory.cs
+++ b/DOLDatabase/Tables/Inventory.cs
@@ -443,7 +443,14 @@ namespace DOL.Database
 
 		public virtual int Weight
 		{
-			get { return Template.Weight * m_count; }
+			get
+			{
+				if (Template.PackSize > 1)
+				{
+					return (int)((double)Template.Weight / (double)Template.PackSize * (double)m_count);
+				}
+				return Template.Weight * m_count;
+			}
 			set { Template.Weight = value; }
 		}
 

--- a/DOLDatabase/Tables/Inventory.cs
+++ b/DOLDatabase/Tables/Inventory.cs
@@ -443,14 +443,7 @@ namespace DOL.Database
 
 		public virtual int Weight
 		{
-			get
-			{
-				if (Template.PackSize > 1)
-				{
-					return (int)((double)Template.Weight / (double)Template.PackSize * (double)m_count);
-				}
-				return Template.Weight * m_count;
-			}
+			get { return Template.Weight * m_count; }
 			set { Template.Weight = value; }
 		}
 

--- a/GameServer/gameobjects/GameLiving.cs
+++ b/GameServer/gameobjects/GameLiving.cs
@@ -2481,15 +2481,64 @@ namespace DOL.GS
 					ticksToTarget = 1;
 				}
 
-				//Genesis : check attack range here, effect: npc's and players will start attack faster instead of waiting another round if the previous failed
-				if (attackTarget != null
-				    && owner.ActiveWeaponSlot != eActiveWeaponSlot.Distance
-				    && !owner.IsWithinRadius( attackTarget, owner.AttackRange ))
+				if (attackTarget != null && !owner.IsWithinRadius(attackTarget, owner.AttackRange) && owner.ActiveWeaponSlot != eActiveWeaponSlot.Distance)
 				{
-					Interval = 100;
-					return;
+					if (owner is GameNPC && (owner as GameNPC).Brain is StandardMobBrain && ((owner as GameNPC).Brain as StandardMobBrain).AggroTable.Count > 0 && (owner as GameNPC).Brain is IControlledBrain == false)
+					{
+						#region Attack another target in range
+
+						GameNPC npc = owner as GameNPC;
+						StandardMobBrain npc_brain = npc.Brain as StandardMobBrain;
+						GameLiving Possibly_target = null;
+						long maxaggro = 0, aggro = 0;
+
+						foreach (GamePlayer player_test in owner.GetPlayersInRadius((ushort)owner.AttackRange))
+						{
+							if (npc_brain.AggroTable.ContainsKey(player_test))
+							{
+								aggro = npc_brain.GetAggroAmountForLiving(player_test);
+								if (aggro <= 0) continue;
+								if (aggro > maxaggro)
+								{
+									Possibly_target = player_test;
+									maxaggro = aggro;
+								}
+							}
+						}
+						foreach (GameNPC target_possibility in owner.GetNPCsInRadius((ushort)owner.AttackRange))
+						{
+							if (npc_brain.AggroTable.ContainsKey(target_possibility))
+							{
+								aggro = npc_brain.GetAggroAmountForLiving(target_possibility);
+								if (aggro <= 0) continue;
+								if (aggro > maxaggro)
+								{
+									Possibly_target = target_possibility;
+									maxaggro = aggro;
+								}
+							}
+						}
+
+						if (Possibly_target == null)
+						{
+							Interval = 100;
+							return;
+						}
+						else
+						{
+							attackTarget = Possibly_target;
+						}
+
+						#endregion
+
+					}
+					else
+					{
+						Interval = 100;
+						return;
+					}
 				}
-				
+
 				new WeaponOnTargetAction(owner, attackTarget, attackWeapon, leftWeapon, effectiveness, interruptDuration, combatStyle).Start(ticksToTarget);  // really start the attack
 
 				//Are we inactive?

--- a/GameServer/gameobjects/GamePlayer.cs
+++ b/GameServer/gameobjects/GamePlayer.cs
@@ -11378,21 +11378,11 @@ namespace DOL.GS
 				//if (item.ExtraBonusType < 20)
 				//Out.SendMessage(string.Format(LanguageMgr.GetTranslation(Client.Account.Language, "GamePlayer.OnItemEquipped.Increased", ItemBonusName(item.ExtraBonusType))), eChatType.CT_Skill, eChatLoc.CL_SystemWindow);
 			}
-			if (Client.Account.PrivLevel == (uint)ePrivLevel.Player)
-			{
-				if (item.SpellID > 0)
-				{
-					TempProperties.setProperty(LAST_CHARGED_ITEM_USE_TICK, CurrentRegion.Time);
-					TempProperties.setProperty(ITEM_USE_DELAY, (long)(60000 * 2));
+			//Check null on client.player bypass region change
+			if (Client.Account.PrivLevel == (uint)ePrivLevel.Player && Client.Player != null && Client.Player.ObjectState == eObjectState.Active)
+				if (item.SpellID > 0 || item.SpellID1 > 0)
 					TempProperties.setProperty("ITEMREUSEDELAY" + item.Id_nb, CurrentRegion.Time);
-				}
-				else if (item.SpellID1 > 0)
-				{
-					TempProperties.setProperty(LAST_CHARGED_ITEM_USE_TICK, CurrentRegion.Time);
-					TempProperties.setProperty(ITEM_USE_DELAY, (long)(60000 * 2));
-					TempProperties.setProperty("ITEMREUSEDELAY" + item.Id_nb, CurrentRegion.Time);
-				}
-			}
+
 			if (ObjectState == eObjectState.Active)
 			{
 				// TODO: remove when properties system is finished

--- a/GameServer/gameobjects/GamePlayer.cs
+++ b/GameServer/gameobjects/GamePlayer.cs
@@ -11378,7 +11378,21 @@ namespace DOL.GS
 				//if (item.ExtraBonusType < 20)
 				//Out.SendMessage(string.Format(LanguageMgr.GetTranslation(Client.Account.Language, "GamePlayer.OnItemEquipped.Increased", ItemBonusName(item.ExtraBonusType))), eChatType.CT_Skill, eChatLoc.CL_SystemWindow);
 			}
-
+			if (Client.Account.PrivLevel == (uint)ePrivLevel.Player)
+			{
+				if (item.SpellID > 0)
+				{
+					TempProperties.setProperty(LAST_CHARGED_ITEM_USE_TICK, CurrentRegion.Time);
+					TempProperties.setProperty(ITEM_USE_DELAY, (long)(60000 * 2));
+					TempProperties.setProperty("ITEMREUSEDELAY" + item.Id_nb, CurrentRegion.Time);
+				}
+				else if (item.SpellID1 > 0)
+				{
+					TempProperties.setProperty(LAST_CHARGED_ITEM_USE_TICK, CurrentRegion.Time);
+					TempProperties.setProperty(ITEM_USE_DELAY, (long)(60000 * 2));
+					TempProperties.setProperty("ITEMREUSEDELAY" + item.Id_nb, CurrentRegion.Time);
+				}
+			}
 			if (ObjectState == eObjectState.Active)
 			{
 				// TODO: remove when properties system is finished


### PR DESCRIPTION
Added code attack on Gameliving for be able to attack another target that the main target if this one is out of range. 
Exemple with Pet: if the owner take aggro and become the main target, the mob will try to hit anyone in his aggrolist that is in attack range before he can reach the owner of the pet..

Added use item desactivation for 2 mn (i don't know what's the timer on live) on new equipped items.