### PR TITLE
Bug Fix: Mobs adding through floors/ceilings/coming out of walls

### DIFF
--- a/GameServer/ai/brain/StandardMobBrain.cs
+++ b/GameServer/ai/brain/StandardMobBrain.cs
@@ -264,7 +264,7 @@ namespace DOL.AI.Brain
 			if (Body.AttackState)
 				return;
 
-			foreach (GamePlayer player in Body.GetPlayersInRadius((ushort)AggroRange, true))
+			foreach (GamePlayer player in Body.GetPlayersInRadius((ushort)AggroRange, Body.CurrentZone.IsDungeon ? false : true))
 			{
 				if (!GameServer.ServerRules.IsAllowedToAttack(Body, player, true)) continue;
 				// Don't aggro on immune players.


### PR DESCRIPTION
This small change to StandardMobBrain.CheckPlayerAggro() ensures that the Z-axis is respected in dungeons analogue to how it is done in CheckNpcAggro().

Mobs in dungeons will no longer aggro on players in rooms far above or below them.
In Darkness falls in particular this would cause body pulls of high level mobs appearing seemingly out of thin air or coming out of walls.