### PR TITLE
Deprecate explicitly parameterized SelectObject(s) queries

### DIFF
--- a/DOLDatabase/Handlers/MySQLObjectDatabase.cs
+++ b/DOLDatabase/Handlers/MySQLObjectDatabase.cs
@@ -30,18 +30,12 @@ using IsolationLevel = DOL.Database.Transaction.IsolationLevel;
 
 using MySql.Data.MySqlClient;
 
-using log4net;
 using System.Data.Common;
 
 namespace DOL.Database.Handlers
 {
 	public class MySQLObjectDatabase : SQLObjectDatabase
 	{
-		/// <summary>
-		/// Defines a logger for this class.
-		/// </summary>
-		private static readonly ILog log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
-
 		/// <summary>
 		/// Create a new instance of <see cref="MySQLObjectDatabase"/>
 		/// </summary>

--- a/DOLDatabase/Handlers/MySQLObjectDatabase.cs
+++ b/DOLDatabase/Handlers/MySQLObjectDatabase.cs
@@ -31,6 +31,7 @@ using IsolationLevel = DOL.Database.Transaction.IsolationLevel;
 using MySql.Data.MySqlClient;
 
 using log4net;
+using System.Data.Common;
 
 namespace DOL.Database.Handlers
 {
@@ -498,26 +499,24 @@ namespace DOL.Database.Handlers
 			{
 				repeat = false;
 
+				if (!parameters.Any()) throw new ArgumentException("No parameter list was given.");
+
 				using (var conn = new MySqlConnection(ConnectionString))
 				{
 					using (var cmd = conn.CreateCommand())
 					{
 						try
 						{
-						    cmd.CommandText = SQLCommand;
 							conn.Open();
 						    long start = (DateTime.UtcNow.Ticks / 10000);
-						    
-						    // Register Parameters
-						    foreach(var param in parameters.First().Select(kv => new { kv.Name, Type = GuessQueryParameterDbType(kv) }))
-						    	cmd.Parameters.Add(param.Name, param.Type);
-							cmd.Prepare();
-						    
-						    foreach(var parameter in parameters.Skip(current))
-						    {
-					    		FillSQLParameter(parameter, cmd.Parameters);
 
-					    		using (var reader = cmd.ExecuteReader())
+                            foreach (var parameter in parameters.Skip(current))
+							{
+								cmd.CommandText = SQLCommand;
+								FillSQLParameter(parameter, cmd.Parameters);
+								cmd.Prepare();
+
+								using (var reader = cmd.ExecuteReader())
 							    {
 							    	try
 							    	{
@@ -558,7 +557,21 @@ namespace DOL.Database.Handlers
 			}
 			while (repeat);
 		}
-		
+
+		protected override DbParameter ConvertToDBParameter(QueryParameter queryParameter)
+		{
+			var dbParam = new MySqlParameter();
+			dbParam.ParameterName = queryParameter.Name;
+			dbParam.MySqlDbType = GuessQueryParameterDbType(queryParameter);
+
+			if (queryParameter.Value is char)
+				dbParam.Value = Convert.ToUInt16(queryParameter.Value);
+			else
+				dbParam.Value = queryParameter.Value;
+
+			return dbParam;
+		}
+
 		/// <summary>
 		/// Implementation of Raw Non-Query with Parameters for Prepared Query
 		/// </summary>
@@ -577,6 +590,8 @@ namespace DOL.Database.Handlers
 			{
 				repeat = false;
 
+				if (!parameters.Any()) throw new ArgumentException("No parameter list was given.");
+
 				using (var conn = new MySqlConnection(ConnectionString))
 				{
 					using (var cmd = conn.CreateCommand())
@@ -587,16 +602,12 @@ namespace DOL.Database.Handlers
 						    conn.Open();
 						    long start = (DateTime.UtcNow.Ticks / 10000);
 						    
-						    // Register Parameters
-						    foreach(var param in parameters.First().Select(kv => new { kv.Name, Type = GuessQueryParameterDbType(kv) }))
-						    	cmd.Parameters.Add(param.Name, param.Type);
-						    cmd.Prepare();
-						    
 						    foreach(var parameter in parameters.Skip(current))
 						    {
 					    		FillSQLParameter(parameter, cmd.Parameters);
-					    		
-					    		var result = -1;
+								cmd.Prepare();
+
+								var result = -1;
 					    		try
 					    		{
 							    	result = cmd.ExecuteNonQuery();
@@ -663,7 +674,9 @@ namespace DOL.Database.Handlers
 			do
 			{
 				repeat = false;
-				
+
+				if (!parameters.Any()) throw new ArgumentException("No parameter list was given.");
+
 				using (var conn = new MySqlConnection(ConnectionString))
 				{
 					using (var cmd = conn.CreateCommand())
@@ -673,17 +686,13 @@ namespace DOL.Database.Handlers
 						    cmd.CommandText = SQLCommand;
 							conn.Open();
 						    long start = (DateTime.UtcNow.Ticks / 10000);
-
-						    // Register Parameters
-						    foreach(var param in parameters.First().Select(kv => new { kv.Name, Type = GuessQueryParameterDbType(kv) }))
-						    	cmd.Parameters.Add(param.Name, param.Type);
-							cmd.Prepare();
 						    
 						    foreach(var parameter in parameters.Skip(current))
 						    {
 					    		FillSQLParameter(parameter, cmd.Parameters);
-					    		
-					    		if (retrieveLastInsertID)
+								cmd.Prepare();
+
+								if (retrieveLastInsertID)
 					    		{
 					    			using (var tran = conn.BeginTransaction(System.Data.IsolationLevel.ReadUncommitted))
 					    			{

--- a/DOLDatabase/Handlers/MySQLObjectDatabase.cs
+++ b/DOLDatabase/Handlers/MySQLObjectDatabase.cs
@@ -20,17 +20,13 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using System.Data;
-using DataTable = System.Data.DataTable;
-
-using DOL.Database.Connection;
-using DOL.Database.Transaction;
-using IsolationLevel = DOL.Database.Transaction.IsolationLevel;
+using System.Data.Common;
 
 using MySql.Data.MySqlClient;
 
-using System.Data.Common;
+using DOL.Database.Connection;
+using IsolationLevel = DOL.Database.Transaction.IsolationLevel;
 
 namespace DOL.Database.Handlers
 {
@@ -476,251 +472,6 @@ namespace DOL.Database.Handlers
 		
 		#region SQLObject Implementation
 		/// <summary>
-		/// Raw SQL Select Implementation with Parameters for Prepared Query
-		/// </summary>
-		/// <param name="SQLCommand">Command for reading</param>
-		/// <param name="parameters">Collection of Parameters for Single/Multiple Read</param>
-		/// <param name="Reader">Reader Method</param>
-		/// <param name="Isolation">Transaction Isolation</param>
-		protected override void ExecuteSelectImpl(string SQLCommand, IEnumerable<IEnumerable<QueryParameter>> parameters, Action<IDataReader> Reader, IsolationLevel Isolation)
-		{
-			if (log.IsDebugEnabled)
-				log.DebugFormat("ExecuteSelectImpl: {0}", SQLCommand);
-
-			var repeat = false;
-			var current = 0;
-			do
-			{
-				repeat = false;
-
-				if (!parameters.Any()) throw new ArgumentException("No parameter list was given.");
-
-				using (var conn = new MySqlConnection(ConnectionString))
-				{
-					using (var cmd = conn.CreateCommand())
-					{
-						try
-						{
-							conn.Open();
-						    long start = (DateTime.UtcNow.Ticks / 10000);
-
-                            foreach (var parameter in parameters.Skip(current))
-							{
-								cmd.CommandText = SQLCommand;
-								FillSQLParameter(parameter, cmd.Parameters);
-								cmd.Prepare();
-
-								using (var reader = cmd.ExecuteReader())
-							    {
-							    	try
-							    	{
-							        	Reader(reader);
-							    	}
-							    	catch (Exception es)
-							    	{
-							    		if(log.IsWarnEnabled)
-							    			log.WarnFormat("ExecuteSelectImpl: Exception in Select Callback : {2}{0}{2}{1}", es, Environment.StackTrace, Environment.NewLine);
-							    	}
-							    	finally
-							    	{
-							    		reader.Close();
-							    	}
-							    }
-					    		current++;
-						    }
-					    
-						    if (log.IsDebugEnabled)
-								log.DebugFormat("ExecuteSelectImpl: SQL Select ({0}) exec time {1}ms", Isolation, ((DateTime.UtcNow.Ticks / 10000) - start));
-							else if (log.IsWarnEnabled && (DateTime.UtcNow.Ticks / 10000) - start > 500)
-								log.WarnFormat("ExecuteSelectImpl: SQL Select ({0}) took {1}ms!\n{2}", Isolation, ((DateTime.UtcNow.Ticks / 10000) - start), SQLCommand);
-						
-						}
-						catch (Exception e)
-						{
-							if (!HandleException(e))
-							{
-								if (log.IsErrorEnabled)
-									log.ErrorFormat("ExecuteSelectImpl: UnHandled Exception in Select Query \"{0}\"\n{1}", SQLCommand, e);
-								
-								throw;
-							}
-							repeat = true;
-						}
-					}
-				}
-			}
-			while (repeat);
-		}
-
-		protected override void ExecuteSelectImpl(string selectFromExpression, IEnumerable<WhereExpression> whereExpressionBatch, Action<IDataReader> Reader, IsolationLevel Isolation)
-		{
-			if (!whereExpressionBatch.Any()) throw new ArgumentException("No parameter list was given.");
-
-			if (log.IsDebugEnabled)
-				log.DebugFormat("ExecuteSelectImpl: {0}", selectFromExpression);
-
-			bool repeat;
-			var current = 0;
-			do
-			{
-				repeat = false;
-
-				using (var conn = new MySqlConnection(ConnectionString))
-				{
-					using (var cmd = conn.CreateCommand())
-					{
-						try
-						{
-							conn.Open();
-							long start = (DateTime.UtcNow.Ticks / 10000);
-
-							foreach (var whereExpression in whereExpressionBatch.Skip(current))
-							{
-								cmd.CommandText = selectFromExpression + whereExpression.WhereClause;
-								FillSQLParameter(whereExpression.QueryParameters, cmd.Parameters);
-								cmd.Prepare();
-
-								using (var reader = cmd.ExecuteReader())
-								{
-									try
-									{
-										Reader(reader);
-									}
-									catch (Exception es)
-									{
-										if (log.IsWarnEnabled)
-											log.WarnFormat("ExecuteSelectImpl: Exception in Select Callback : {2}{0}{2}{1}", es, Environment.StackTrace, Environment.NewLine);
-									}
-									finally
-									{
-										reader.Close();
-									}
-								}
-								current++;
-							}
-
-							if (log.IsDebugEnabled)
-								log.DebugFormat("ExecuteSelectImpl: SQL Select ({0}) exec time {1}ms", Isolation, ((DateTime.UtcNow.Ticks / 10000) - start));
-							else if (log.IsWarnEnabled && (DateTime.UtcNow.Ticks / 10000) - start > 500)
-								log.WarnFormat("ExecuteSelectImpl: SQL Select ({0}) took {1}ms!\n{2}", Isolation, ((DateTime.UtcNow.Ticks / 10000) - start), selectFromExpression);
-
-						}
-						catch (Exception e)
-						{
-							if (!HandleException(e))
-							{
-								if (log.IsErrorEnabled)
-									log.ErrorFormat("ExecuteSelectImpl: UnHandled Exception in Select Query \"{0}\"\n{1}", selectFromExpression, e);
-
-								throw;
-							}
-							repeat = true;
-						}
-					}
-				}
-			}
-			while (repeat);
-		}
-
-		protected override DbParameter ConvertToDBParameter(QueryParameter queryParameter)
-		{
-			var dbParam = new MySqlParameter();
-			dbParam.ParameterName = queryParameter.Name;
-			dbParam.MySqlDbType = GuessQueryParameterDbType(queryParameter);
-
-			if (queryParameter.Value is char)
-				dbParam.Value = Convert.ToUInt16(queryParameter.Value);
-			else
-				dbParam.Value = queryParameter.Value;
-
-			return dbParam;
-		}
-
-		/// <summary>
-		/// Implementation of Raw Non-Query with Parameters for Prepared Query
-		/// </summary>
-		/// <param name="SQLCommand">Raw Command</param>
-		/// <param name="parameters">Collection of Parameters for Single/Multiple Read</param>
-		/// <returns>True if the Command succeeded</returns>
-		protected override IEnumerable<int> ExecuteNonQueryImpl(string SQLCommand, IEnumerable<IEnumerable<QueryParameter>> parameters)
-		{
-			if (log.IsDebugEnabled)
-				log.DebugFormat("ExecuteNonQueryImpl: {0}", SQLCommand);
-
-			var affected = new List<int>();
-			var repeat = false;
-			var current = 0;
-			do
-			{
-				repeat = false;
-
-				if (!parameters.Any()) throw new ArgumentException("No parameter list was given.");
-
-				using (var conn = new MySqlConnection(ConnectionString))
-				{
-					using (var cmd = conn.CreateCommand())
-					{
-						try
-						{
-						    cmd.CommandText = SQLCommand;
-						    conn.Open();
-						    long start = (DateTime.UtcNow.Ticks / 10000);
-						    
-						    foreach(var parameter in parameters.Skip(current))
-						    {
-					    		FillSQLParameter(parameter, cmd.Parameters);
-								cmd.Prepare();
-
-								var result = -1;
-					    		try
-					    		{
-							    	result = cmd.ExecuteNonQuery();
-								    affected.Add(result);
-					    		}
-					    		catch (MySqlException sqle)
-					    		{
-					    			if (HandleSQLException(sqle))
-					    			{
-    									affected.Add(result);
-    									if (log.IsErrorEnabled)
-											log.ErrorFormat("ExecuteNonQueryImpl: Constraint Violation for raw query \"{0}\"\n{1}\n{2}", SQLCommand, sqle, Environment.StackTrace);
-					    			}
-					    			else
-					    			{
-					    				throw;
-					    			}
-					    		}
-							    current++;
-							    
-							    if (log.IsDebugEnabled && result < 1)
-							    	log.DebugFormat("ExecuteNonQueryImpl: No Change for raw query \"{0}\"", SQLCommand);
-						    }
-						    
-						    if (log.IsDebugEnabled)
-								log.DebugFormat("ExecuteNonQueryImpl: SQL NonQuery exec time {0}ms", ((DateTime.UtcNow.Ticks / 10000) - start));
-							else if (log.IsWarnEnabled && (DateTime.UtcNow.Ticks / 10000) - start > 500)
-								log.WarnFormat("ExecuteNonQueryImpl: SQL NonQuery took {0}ms!\n{1}", ((DateTime.UtcNow.Ticks / 10000) - start), SQLCommand);
-						}
-						catch (Exception e)
-						{
-							if (!HandleException(e))
-							{
-								if(log.IsErrorEnabled)
-									log.ErrorFormat("ExecuteNonQueryImpl: UnHandled Exception for raw query \"{0}\"\n{1}", SQLCommand, e);
-
-								throw;
-							}
-							repeat = true;
-						}
-					}
-				}
-			} 
-			while (repeat);
-
-			return affected;
-		}
-
-		/// <summary>
 		/// Implementation of Scalar Query with Parameters for Prepared Query
 		/// </summary>
 		/// <param name="SQLCommand">Scalar Command</param>
@@ -747,74 +498,77 @@ namespace DOL.Database.Handlers
 					{
 						try
 						{
-						    cmd.CommandText = SQLCommand;
+							cmd.CommandText = SQLCommand;
 							conn.Open();
-						    long start = (DateTime.UtcNow.Ticks / 10000);
-						    
-						    foreach(var parameter in parameters.Skip(current))
-						    {
-					    		FillSQLParameter(parameter, cmd.Parameters);
+							long start = (DateTime.UtcNow.Ticks / 10000);
+
+							foreach (var parameter in parameters.Skip(current))
+							{
+								FillSQLParameter(parameter, cmd.Parameters);
 								cmd.Prepare();
 
 								if (retrieveLastInsertID)
-					    		{
-					    			using (var tran = conn.BeginTransaction(System.Data.IsolationLevel.ReadUncommitted))
-					    			{
-					    				try
-					    				{
-						    				cmd.Transaction = tran;
-						    				try
-						    				{
-							    				cmd.ExecuteNonQuery();
-							    				obj.Add(cmd.LastInsertedId);
-						    				}
-								    		catch (MySqlException sqle)
-								    		{
-								    			if (HandleSQLException(sqle))
-								    			{
-			    									obj.Add(-1);
-			    									if (log.IsErrorEnabled)
-														log.ErrorFormat("ExecuteScalarImpl: Constraint Violation for command \"{0}\"\n{1}\n{2}", SQLCommand, sqle, Environment.StackTrace);
-								    			}
-								    			else
-								    			{
-								    				throw;
-								    			}
-								    		}
-							    			tran.Commit();
-					    				}
-					    				catch (Exception te)
-					    				{
-					    					tran.Rollback();
-					    					if (log.IsErrorEnabled)
-					    						log.ErrorFormat("ExecuteScalarImpl: Error in Transaction (Rollback) for command : {0}\n{1}", SQLCommand, te);
-					    				}
-					    				
-					    			}
-					    		}
-					    		else
-					    		{
-							    	var result = cmd.ExecuteScalar();
-							    	obj.Add(result);
-					    		}
-						    	current++;
-						    }
-						    
+								{
+									using (var tran = conn.BeginTransaction(System.Data.IsolationLevel.ReadUncommitted))
+									{
+										try
+										{
+											cmd.Transaction = tran;
+											try
+											{
+												cmd.ExecuteNonQuery();
+												obj.Add(cmd.LastInsertedId);
+											}
+											catch (Exception ex)
+											{
+												if (HandleSQLException(ex))
+												{
+													obj.Add(-1);
+													if (log.IsErrorEnabled)
+														log.ErrorFormat("ExecuteScalarImpl: Constraint Violation for command \"{0}\"\n{1}\n{2}", SQLCommand, ex, Environment.StackTrace);
+												}
+												else
+												{
+													throw;
+												}
+											}
+											tran.Commit();
+										}
+										catch (Exception te)
+										{
+											tran.Rollback();
+											if (log.IsErrorEnabled)
+												log.ErrorFormat("ExecuteScalarImpl: Error in Transaction (Rollback) for command : {0}\n{1}", SQLCommand, te);
+										}
+									}
+								}
+								else
+								{
+									var result = cmd.ExecuteScalar();
+									obj.Add(result);
+								}
+								current++;
+							}
+
 							if (log.IsDebugEnabled)
-								log.DebugFormat("ExecuteScalar: SQL ScalarQuery exec time {0}ms", ((DateTime.UtcNow.Ticks / 10000) - start));
+								log.DebugFormat("ExecuteScalarImpl: SQL ScalarQuery exec time {0}ms", ((DateTime.UtcNow.Ticks / 10000) - start));
 							else if (log.IsWarnEnabled && (DateTime.UtcNow.Ticks / 10000) - start > 500)
-								log.WarnFormat("ExecuteScalar: SQL ScalarQuery took {0}ms!\n{1}", ((DateTime.UtcNow.Ticks / 10000) - start), SQLCommand);
+								log.WarnFormat("ExecuteScalarImpl: SQL ScalarQuery took {0}ms!\n{1}", ((DateTime.UtcNow.Ticks / 10000) - start), SQLCommand);
 						}
 						catch (Exception e)
 						{
 							if (!HandleException(e))
 							{
 								if (log.IsErrorEnabled)
-									log.ErrorFormat("ExecuteScalar: UnHandled Exception for command \"{0}\"\n{1}", SQLCommand, e);
-								
+									log.ErrorFormat("ExecuteScalarImpl: UnHandled Exception for command \"{0}\"\n{1}", SQLCommand, e);
+
 								throw;
 							}
 							repeat = true;
+						}
+						finally
+						{
+							CloseConnection(conn);
 						}
 					}
 				}
@@ -824,6 +578,7 @@ namespace DOL.Database.Handlers
 			return obj.ToArray();
 		}
 		#endregion
+
 		/// <summary>
 		/// Retrieve Query Parameter DB Type from Table Type or Runtime Type
 		/// </summary>
@@ -864,21 +619,50 @@ namespace DOL.Database.Handlers
 			
 			return MySqlDbType.Blob;
 		}
+
+		protected override DbConnection CreateConnection(string connectionsString)
+		{
+			return new MySqlConnection(ConnectionString);
+		}
+
+		protected override void CloseConnection(DbConnection connection)
+		{
+			//Do nothing. Connection is closed on calling connection.Dispose()
+		}
+
+		protected override DbParameter ConvertToDBParameter(QueryParameter queryParameter)
+		{
+			var dbParam = new MySqlParameter();
+			dbParam.ParameterName = queryParameter.Name;
+			dbParam.MySqlDbType = GuessQueryParameterDbType(queryParameter);
+
+			if (queryParameter.Value is char)
+				dbParam.Value = Convert.ToUInt16(queryParameter.Value);
+			else
+				dbParam.Value = queryParameter.Value;
+
+			return dbParam;
+		}
+
 		/// <summary>
 		/// Handle Non Fatal SQL Query Exception
 		/// </summary>
-		/// <param name="sqle">SQL Excepiton</param>
+		/// <param name="e">SQL Excepiton</param>
 		/// <returns>True if handled, False otherwise</returns>
-		protected static bool HandleSQLException(MySqlException sqle)
+		protected override bool HandleSQLException(Exception e)
 		{
-			switch ((MySqlErrorCode)sqle.Number)
+			if (e is MySqlException sqle)
 			{
-				case MySqlErrorCode.DuplicateUnique:
-				case MySqlErrorCode.DuplicateKeyEntry:
-					return true;
-				default:
-					return false;
+				switch ((MySqlErrorCode)sqle.Number)
+				{
+					case MySqlErrorCode.DuplicateUnique:
+					case MySqlErrorCode.DuplicateKeyEntry:
+						return true;
+					default:
+						return false;
+				}
 			}
+			return false;
 		}
 	}
 }

--- a/DOLDatabase/Handlers/MySQLObjectDatabase.cs
+++ b/DOLDatabase/Handlers/MySQLObjectDatabase.cs
@@ -213,21 +213,22 @@ namespace DOL.Database.Handlers
 			try
 			{
 				ExecuteSelectImpl(string.Format("DESCRIBE `{0}`", table.TableName),
-				                  reader =>
-				                  {
-				                  	while (reader.Read())
-				                  	{
-				                  		var column = reader.GetString(0);
-				                  		var colType = reader.GetString(1);
-				                  		var allowNull = reader.GetString(2).ToLower() == "yes";
-				                  		var primary = reader.GetString(3).ToLower() == "pri";
-				                  		currentTableColumns.Add(new TableRowBindind(column, colType, allowNull, primary));
-				                  		if (log.IsDebugEnabled)
-				                  			log.DebugFormat("CheckOrCreateTable: Found Column {0} in existing table {1}", column, table.TableName);
-				                  	}
-				                  	if (log.IsDebugEnabled)
-				                  		log.DebugFormat("CheckOrCreateTable: {0} columns existing in table {1}", currentTableColumns.Count, table.TableName);
-				                  }, IsolationLevel.DEFAULT);
+					new[] { new QueryParameter[] { } },
+					reader =>
+					{
+						while (reader.Read())
+						{
+							var column = reader.GetString(0);
+							var colType = reader.GetString(1);
+							var allowNull = reader.GetString(2).ToLower() == "yes";
+							var primary = reader.GetString(3).ToLower() == "pri";
+							currentTableColumns.Add(new TableRowBindind(column, colType, allowNull, primary));
+							if (log.IsDebugEnabled)
+								log.DebugFormat("CheckOrCreateTable: Found Column {0} in existing table {1}", column, table.TableName);
+						}
+						if (log.IsDebugEnabled)
+							log.DebugFormat("CheckOrCreateTable: {0} columns existing in table {1}", currentTableColumns.Count, table.TableName);
+					});
 			}
 			catch (Exception e)
 			{
@@ -313,20 +314,21 @@ namespace DOL.Database.Handlers
 			try
 			{
 				ExecuteSelectImpl(string.Format("SHOW INDEX FROM `{0}`", table.TableName),
-				                  reader =>
-				                  {
-				                  	while (reader.Read())
-				                  	{
-				                  		var unique = reader.GetInt64(1) < 1;
-				                  		var indexname = reader.GetString(2);
-				                  		var column = reader.GetString(4);
-				                  		indexes.Add(new Tuple<bool, string, string>(unique, indexname, column));
-				                  		if (log.IsDebugEnabled)
-				                  			log.DebugFormat("AlterTable: Found Index `{0}` (Unique:{1}) on `{2}` in existing table {3}", indexname, unique, column, table.TableName);
-				                  	}
-				                  	if (log.IsDebugEnabled)
-				                  		log.DebugFormat("AlterTable: {0} Indexes existing in table {1}", indexes.Count, table.TableName);
-				                  }, IsolationLevel.DEFAULT);
+					new[] { new QueryParameter[] { } },
+					reader =>
+					{
+						while (reader.Read())
+						{
+							var unique = reader.GetInt64(1) < 1;
+							var indexname = reader.GetString(2);
+							var column = reader.GetString(4);
+							indexes.Add(new Tuple<bool, string, string>(unique, indexname, column));
+							if (log.IsDebugEnabled)
+								log.DebugFormat("AlterTable: Found Index `{0}` (Unique:{1}) on `{2}` in existing table {3}", indexname, unique, column, table.TableName);
+						}
+						if (log.IsDebugEnabled)
+							log.DebugFormat("AlterTable: {0} Indexes existing in table {1}", indexes.Count, table.TableName);
+					});
 			}
 			catch (Exception e)
 			{

--- a/DOLDatabase/Handlers/SQLiteObjectDatabase.cs
+++ b/DOLDatabase/Handlers/SQLiteObjectDatabase.cs
@@ -20,17 +20,12 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using System.Data;
 using System.Data.Common;
-using DataTable = System.Data.DataTable;
-
-using DOL.Database.Connection;
-using DOL.Database.Transaction;
-using IsolationLevel = DOL.Database.Transaction.IsolationLevel;
-
 using System.Data.SQLite;
 
+using DOL.Database.Connection;
+using IsolationLevel = DOL.Database.Transaction.IsolationLevel;
 
 namespace DOL.Database.Handlers
 {
@@ -583,267 +578,6 @@ namespace DOL.Database.Handlers
 		
 		#region SQLObject Implementation
 		/// <summary>
-		/// Raw SQL Select Implementation with Parameters for Prepared Query
-		/// </summary>
-		/// <param name="SQLCommand">Command for reading</param>
-		/// <param name="parameters">Collection of Parameters for Single/Multiple Read</param>
-		/// <param name="Reader">Reader Method</param>
-		/// <param name="Isolation">Transaction Isolation</param>
-		protected override void ExecuteSelectImpl(string SQLCommand, IEnumerable<IEnumerable<QueryParameter>> parameters, Action<IDataReader> Reader, IsolationLevel Isolation)
-		{
-			if (log.IsDebugEnabled)
-				log.DebugFormat("ExecuteSelectImpl: {0}", SQLCommand);
-
-			var repeat = false;
-			var current = 0;
-			do
-			{
-				repeat = false;
-
-				if (!parameters.Any()) throw new ArgumentException("No parameter list was given.");
-
-				using (var conn = new SQLiteConnection(ConnectionString))
-				{
-				    using (var cmd = conn.CreateCommand())
-					{
-						try
-						{
-					    	conn.Open();
-					    	long start = (DateTime.UtcNow.Ticks / 10000);
-
-							foreach (var parameter in parameters.Skip(current))
-							{
-								cmd.CommandText = SQLCommand;
-								FillSQLParameter(parameter, cmd.Parameters);
-								cmd.Prepare();
-					    	
-							    using (var reader = cmd.ExecuteReader())
-							    {
-							    	try
-							    	{
-							        	Reader(reader);
-							    	}
-							    	catch (Exception es)
-							    	{
-							    		if(log.IsWarnEnabled)
-							    			log.WarnFormat("ExecuteSelectImpl: Exception in Select Callback : {2}{0}{2}{1}", es, Environment.StackTrace, Environment.NewLine);
-							    	}
-							    	finally
-							    	{
-							    		reader.Close();
-							    	}
-							    }
-							    current++;
-					    	}
-					    
-						    if (log.IsDebugEnabled)
-								log.DebugFormat("ExecuteSelectImpl: SQL Select ({0}) exec time {1}ms", Isolation, ((DateTime.UtcNow.Ticks / 10000) - start));
-							else if (log.IsWarnEnabled && (DateTime.UtcNow.Ticks / 10000) - start > 500)
-								log.WarnFormat("ExecuteSelectImpl: SQL Select ({0}) took {1}ms!\n{2}", Isolation, ((DateTime.UtcNow.Ticks / 10000) - start), SQLCommand);
-						
-						}
-						catch (Exception e)
-						{
-							if (!HandleException(e))
-							{
-								if (log.IsErrorEnabled)
-									log.ErrorFormat("ExecuteSelectImpl: UnHandled Exception for Select Query \"{0}\"\n{1}", SQLCommand, e);
-								
-								throw;
-							}
-							repeat = true;
-						}
-						finally
-						{
-							conn.Close();
-						}
-					}
-				}
-			}
-			while (repeat);
-		}
-
-		protected override void ExecuteSelectImpl(string selectFromExpression, IEnumerable<WhereExpression> whereExpressionBatch, Action<IDataReader> Reader, IsolationLevel Isolation)
-		{
-			if (!whereExpressionBatch.Any()) throw new ArgumentException("No parameter list was given.");
-
-			if (log.IsDebugEnabled)
-				log.DebugFormat("ExecuteSelectImpl: {0}", selectFromExpression);
-
-			bool repeat;
-			var current = 0;
-			do
-			{
-				repeat = false;
-
-				using (var conn = new SQLiteConnection(ConnectionString))
-				{
-					using (var cmd = conn.CreateCommand())
-					{
-						try
-						{
-							conn.Open();
-							long start = (DateTime.UtcNow.Ticks / 10000);
-
-							foreach (var whereExpression in whereExpressionBatch.Skip(current))
-							{
-								cmd.CommandText = selectFromExpression + whereExpression.WhereClause;
-								FillSQLParameter(whereExpression.QueryParameters, cmd.Parameters);
-								cmd.Prepare();
-
-								using (var reader = cmd.ExecuteReader())
-								{
-									try
-									{
-										Reader(reader);
-									}
-									catch (Exception es)
-									{
-										if (log.IsWarnEnabled)
-											log.WarnFormat("ExecuteSelectImpl: Exception in Select Callback : {2}{0}{2}{1}", es, Environment.StackTrace, Environment.NewLine);
-									}
-									finally
-									{
-										reader.Close();
-									}
-								}
-								current++;
-							}
-
-							if (log.IsDebugEnabled)
-								log.DebugFormat("ExecuteSelectImpl: SQL Select ({0}) exec time {1}ms", Isolation, ((DateTime.UtcNow.Ticks / 10000) - start));
-							else if (log.IsWarnEnabled && (DateTime.UtcNow.Ticks / 10000) - start > 500)
-								log.WarnFormat("ExecuteSelectImpl: SQL Select ({0}) took {1}ms!\n{2}", Isolation, ((DateTime.UtcNow.Ticks / 10000) - start), selectFromExpression);
-
-						}
-						catch (Exception e)
-						{
-							if (!HandleException(e))
-							{
-								if (log.IsErrorEnabled)
-									log.ErrorFormat("ExecuteSelectImpl: UnHandled Exception in Select Query \"{0}\"\n{1}", selectFromExpression, e);
-
-								throw;
-							}
-							repeat = true;
-						}
-						finally
-						{
-							conn.Close();
-						}
-					}
-				}
-			}
-			while (repeat);
-		}
-
-		protected override DbParameter ConvertToDBParameter(QueryParameter queryParameter)
-		{
-			var dbParam = new SQLiteParameter();
-			dbParam.ParameterName = queryParameter.Name;
-
-			if (queryParameter.Value is char)
-				dbParam.Value = Convert.ToUInt16(queryParameter.Value);
-			else if (queryParameter.Value is uint)
-				dbParam.Value = Convert.ToInt64(queryParameter.Value);
-			else if (dbParam.Value is ulong)
-				dbParam.Value = unchecked((long)Convert.ToUInt64(queryParameter.Value));
-			else
-				dbParam.Value = queryParameter.Value;
-
-			return dbParam;
-		}
-
-		/// <summary>
-		/// Implementation of Raw Non-Query with Parameters for Prepared Query
-		/// </summary>
-		/// <param name="SQLCommand">Raw Command</param>
-		/// <param name="parameters">Collection of Parameters for Single/Multiple Read</param>
-		/// <returns>True if the Command succeeded</returns>
-		protected override IEnumerable<int> ExecuteNonQueryImpl(string SQLCommand, IEnumerable<IEnumerable<QueryParameter>> parameters)
-		{
-			if (log.IsDebugEnabled)
-				log.DebugFormat("ExecuteNonQueryImpl: {0}", SQLCommand);
-
-			var affected = new List<int>();
-			var repeat = false;
-			var current = 0;
-			do
-			{
-				repeat = false;
-
-				if (!parameters.Any()) throw new ArgumentException("No parameter list was given.");
-
-				using (var conn = new SQLiteConnection(ConnectionString))
-				{
-					using (var cmd = new SQLiteCommand(SQLCommand, conn))
-					{
-						try
-						{
-					    	conn.Open();
-					    	cmd.Prepare();
-						    
-					    	long start = (DateTime.UtcNow.Ticks / 10000);
-					    	
-					    	foreach(var parameter in parameters.Skip(current))
-					    	{
-					    		FillSQLParameter(parameter, cmd.Parameters);
-								cmd.Prepare();
-								var result = -1;
-					    		try
-					    		{
-							    	result = cmd.ExecuteNonQuery();
-							    	affected.Add(result);
-					    		}
-					    		catch (SQLiteException sqle)
-					    		{
-					    			if (HandleSQLException(sqle))
-					    			{
-    									affected.Add(result);
-    									if (log.IsErrorEnabled)
-											log.ErrorFormat("ExecuteNonQueryImpl: Constraint Violation for raw query \"{0}\"\n{1}\n{2}", SQLCommand, sqle, Environment.StackTrace);
-					    			}
-					    			else
-					    			{
-					    				throw;
-					    			}
-					    		}
-							    current++;
-							    
-							    if (log.IsDebugEnabled && result < 1)
-							    	log.DebugFormat("ExecuteNonQueryImpl: No Change for raw query \"{0}\"", SQLCommand);
-					    	}
-						    
-						    
-						    if (log.IsDebugEnabled)
-								log.DebugFormat("ExecuteNonQueryImpl: SQL NonQuery exec time {0}ms", ((DateTime.UtcNow.Ticks / 10000) - start));
-							else if (log.IsWarnEnabled && (DateTime.UtcNow.Ticks / 10000) - start > 500)
-								log.WarnFormat("ExecuteNonQueryImpl: SQL NonQuery took {0}ms!\n{1}", ((DateTime.UtcNow.Ticks / 10000) - start), SQLCommand);
-						}
-						catch (Exception e)
-						{
-							if (!HandleException(e))
-							{
-								if(log.IsErrorEnabled)
-									log.ErrorFormat("ExecuteNonQueryImpl: UnHandled Exception for raw query \"{0}\"\n{1}", SQLCommand, e);
-								
-								throw;
-							}
-							repeat = true;
-						}
-						finally
-						{
-							conn.Close();
-						}
-					}
-				}
-			} 
-			while (repeat);
-			
-			return affected;
-		}
-
-		/// <summary>
 		/// Implementation of Scalar Query with Parameters for Prepared Query
 		/// </summary>
 		/// <param name="SQLCommand">Scalar Command</param>
@@ -866,84 +600,81 @@ namespace DOL.Database.Handlers
 
 				using (var conn = new SQLiteConnection(ConnectionString))
 				{					    
-					using (var cmd = new SQLiteCommand(SQLCommand, conn))
+					using (var cmd = conn.CreateCommand())
 					{
 						try
 						{
-						    conn.Open();
-					    	cmd.Prepare();
-						    long start = (DateTime.UtcNow.Ticks / 10000);
-					    	
-					    	foreach(var parameter in parameters.Skip(current))
-					    	{
-					    		FillSQLParameter(parameter, cmd.Parameters);
+							cmd.CommandText = SQLCommand;
+							conn.Open();
+							long start = (DateTime.UtcNow.Ticks / 10000);
+
+							foreach (var parameter in parameters.Skip(current))
+							{
+								FillSQLParameter(parameter, cmd.Parameters);
 								cmd.Prepare();
 
 								if (retrieveLastInsertID)
-					    		{
-					    			using (var tran = conn.BeginTransaction(System.Data.IsolationLevel.ReadCommitted))
-					    			{
-					    				try
-					    				{
-						    				cmd.Transaction = tran;
-						    				try
-						    				{
-							    				cmd.ExecuteNonQuery();
-							    				obj.Add(conn.LastInsertRowId);
-						    				}
-								    		catch (SQLiteException sqle)
-								    		{
-								    			if (HandleSQLException(sqle))
-								    			{
-			    									obj.Add(-1);
-			    									if (log.IsErrorEnabled)
-														log.ErrorFormat("ExecuteScalarImpl: Constraint Violation for command \"{0}\"\n{1}\n{2}", SQLCommand, sqle, Environment.StackTrace);
-								    			}
-								    			else
-								    			{
-								    				throw;
-								    			}
-								    		}
-							    			
-							    			tran.Commit();
-					    				}
-					    				catch (Exception te)
-					    				{
-					    					tran.Rollback();
-					    					if (log.IsErrorEnabled)
-					    						log.ErrorFormat("ExecuteScalarImpl: Error in Transaction (Rollback) for command : {0}\n{1}", SQLCommand, te);
-					    				}
-					    			}
-					    		}
-					    		else
-					    		{
-					    			var result = cmd.ExecuteScalar();
+								{
+									using (var tran = conn.BeginTransaction(System.Data.IsolationLevel.ReadCommitted))
+									{
+										try
+										{
+											cmd.Transaction = tran;
+											try
+											{
+												cmd.ExecuteNonQuery();
+												obj.Add(conn.LastInsertRowId);
+											}
+											catch (Exception ex)
+											{
+												if (HandleSQLException(ex))
+												{
+													obj.Add(-1);
+													if (log.IsErrorEnabled)
+														log.ErrorFormat("ExecuteScalarImpl: Constraint Violation for command \"{0}\"\n{1}\n{2}", SQLCommand, ex, Environment.StackTrace);
+												}
+												else
+												{
+													throw;
+												}
+											}
+											tran.Commit();
+										}
+										catch (Exception te)
+										{
+											tran.Rollback();
+											if (log.IsErrorEnabled)
+												log.ErrorFormat("ExecuteScalarImpl: Error in Transaction (Rollback) for command : {0}\n{1}", SQLCommand, te);
+										}
+									}
+								}
+								else
+								{
+									var result = cmd.ExecuteScalar();
 									obj.Add(result);
-					    		}
+								}
 								current++;
-					    	}
+							}
 
-					    	if (log.IsDebugEnabled)
+							if (log.IsDebugEnabled)
 								log.DebugFormat("ExecuteScalarImpl: SQL ScalarQuery exec time {0}ms", ((DateTime.UtcNow.Ticks / 10000) - start));
 							else if (log.IsWarnEnabled && (DateTime.UtcNow.Ticks / 10000) - start > 500)
 								log.WarnFormat("ExecuteScalarImpl: SQL ScalarQuery took {0}ms!\n{1}", ((DateTime.UtcNow.Ticks / 10000) - start), SQLCommand);
 						}
 						catch (Exception e)
 						{
-	
 							if (!HandleException(e))
 							{
-								if(log.IsErrorEnabled)
+								if (log.IsErrorEnabled)
 									log.ErrorFormat("ExecuteScalarImpl: UnHandled Exception for command \"{0}\"\n{1}", SQLCommand, e);
-								
+
 								throw;
 							}
-	
 							repeat = true;
 						}
 						finally
 						{
-							conn.Close();
+							CloseConnection(conn);
 						}
 					}
 				}
@@ -953,24 +684,56 @@ namespace DOL.Database.Handlers
 			return obj.ToArray();
 		}
 		#endregion
+
+		protected override DbConnection CreateConnection(string connectionsString)
+		{
+			return new SQLiteConnection(ConnectionString);
+		}
+
+		protected override void CloseConnection(DbConnection connection)
+		{
+			connection.Close();
+		}
+
+		protected override DbParameter ConvertToDBParameter(QueryParameter queryParameter)
+		{
+			var dbParam = new SQLiteParameter();
+			dbParam.ParameterName = queryParameter.Name;
+
+			if (queryParameter.Value is char)
+				dbParam.Value = Convert.ToUInt16(queryParameter.Value);
+			else if (queryParameter.Value is uint)
+				dbParam.Value = Convert.ToInt64(queryParameter.Value);
+			else if (dbParam.Value is ulong)
+				dbParam.Value = unchecked((long)Convert.ToUInt64(queryParameter.Value));
+			else
+				dbParam.Value = queryParameter.Value;
+
+			return dbParam;
+		}
+
 		/// <summary>
 		/// Handle Non Fatal SQL Query Exception
 		/// </summary>
-		/// <param name="sqle">SQL Excepiton</param>
+		/// <param name="e">SQL Excepiton</param>
 		/// <returns>True if handled, False otherwise</returns>
-		protected static bool HandleSQLException(SQLiteException sqle)
+		protected override bool HandleSQLException(Exception e)
 		{
-			switch (sqle.ResultCode)
+			if (e is SQLiteException sqle)
 			{
-				case SQLiteErrorCode.Constraint:
-				case SQLiteErrorCode.Constraint_Check:
-				case SQLiteErrorCode.Constraint_ForeignKey:
-				case SQLiteErrorCode.Constraint_Unique:
-				case SQLiteErrorCode.Constraint_NotNull:
-					return true;
-				default:
-					return false;
+				switch (sqle.ResultCode)
+				{
+					case SQLiteErrorCode.Constraint:
+					case SQLiteErrorCode.Constraint_Check:
+					case SQLiteErrorCode.Constraint_ForeignKey:
+					case SQLiteErrorCode.Constraint_Unique:
+					case SQLiteErrorCode.Constraint_NotNull:
+						return true;
+					default:
+						return false;
+				}
 			}
+			return false;
 		}
 		
 		/// <summary>

--- a/DOLDatabase/Handlers/SQLiteObjectDatabase.cs
+++ b/DOLDatabase/Handlers/SQLiteObjectDatabase.cs
@@ -153,8 +153,8 @@ namespace DOL.Database.Handlers
 			}
 			catch (Exception e)
 			{
-				if (ObjectDatabase.log.IsErrorEnabled)
-                    ObjectDatabase.log.ErrorFormat("{0}: {1} = {2} doesnt fit to {3}\n{4}", obj.TableName, bind.ColumnName, value.GetType().FullName, bind.ValueType, e);
+				if (log.IsErrorEnabled)
+                    log.ErrorFormat("{0}: {1} = {2} doesnt fit to {3}\n{4}", obj.TableName, bind.ColumnName, value.GetType().FullName, bind.ValueType, e);
 			}
 			
 			base.DatabaseSetValue(obj, bind, value);

--- a/DOLDatabase/Handlers/SQLiteObjectDatabase.cs
+++ b/DOLDatabase/Handlers/SQLiteObjectDatabase.cs
@@ -31,17 +31,11 @@ using IsolationLevel = DOL.Database.Transaction.IsolationLevel;
 
 using System.Data.SQLite;
 
-using log4net;
 
 namespace DOL.Database.Handlers
 {
 	public class SQLiteObjectDatabase : SQLObjectDatabase
 	{
-		/// <summary>
-		/// Defines a logger for this class.
-		/// </summary>
-		private static readonly ILog log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
-
 		/// <summary>
 		/// Create a new instance of <see cref="SQLiteObjectDatabase"/>
 		/// </summary>
@@ -164,8 +158,8 @@ namespace DOL.Database.Handlers
 			}
 			catch (Exception e)
 			{
-				if (Log.IsErrorEnabled)
-					Log.ErrorFormat("{0}: {1} = {2} doesnt fit to {3}\n{4}", obj.TableName, bind.ColumnName, value.GetType().FullName, bind.ValueType, e);
+				if (ObjectDatabase.log.IsErrorEnabled)
+                    ObjectDatabase.log.ErrorFormat("{0}: {1} = {2} doesnt fit to {3}\n{4}", obj.TableName, bind.ColumnName, value.GetType().FullName, bind.ValueType, e);
 			}
 			
 			base.DatabaseSetValue(obj, bind, value);

--- a/DOLDatabase/Handlers/SQLiteObjectDatabase.cs
+++ b/DOLDatabase/Handlers/SQLiteObjectDatabase.cs
@@ -211,21 +211,22 @@ namespace DOL.Database.Handlers
 			try
 			{
 				ExecuteSelectImpl(string.Format("PRAGMA TABLE_INFO(`{0}`)", table.TableName),
-				                  reader =>
-				                  {
-				                  	while (reader.Read())
-				                  	{
-				                  		var column = reader.GetString(1);
-				                  		var colType = reader.GetString(2);
-				                  		var allowNull = !reader.GetBoolean(3);
-				                  		var primary = reader.GetInt64(5) > 0;
-				                  		currentTableColumns.Add(new TableRowBindind(column, colType, allowNull, primary));
-				                  		if (log.IsDebugEnabled)
-				                  			log.DebugFormat("CheckOrCreateTable: Found Column {0} in existing table {1}", column, table.TableName);
-				                  	}
-				                  	if (log.IsDebugEnabled)
-				                  		log.DebugFormat("CheckOrCreateTable: {0} columns existing in table {1}", currentTableColumns.Count, table.TableName);
-				                  }, IsolationLevel.DEFAULT);
+					new[] { new QueryParameter[] { } },
+					reader =>
+					{
+						while (reader.Read())
+						{
+							var column = reader.GetString(1);
+							var colType = reader.GetString(2);
+							var allowNull = !reader.GetBoolean(3);
+							var primary = reader.GetInt64(5) > 0;
+							currentTableColumns.Add(new TableRowBindind(column, colType, allowNull, primary));
+							if (log.IsDebugEnabled)
+								log.DebugFormat("CheckOrCreateTable: Found Column {0} in existing table {1}", column, table.TableName);
+						}
+						if (log.IsDebugEnabled)
+							log.DebugFormat("CheckOrCreateTable: {0} columns existing in table {1}", currentTableColumns.Count, table.TableName);
+					});
 			}
 			catch (Exception e)
 			{
@@ -359,12 +360,12 @@ namespace DOL.Database.Handlers
 			try
 			{
 				ExecuteSelectImpl("SELECT name, sql FROM sqlite_master WHERE type == 'index' AND sql is not null AND tbl_name == @tableName",
-				                  new QueryParameter("@tableName", table.TableName),
+				                  new[] { new[] { new QueryParameter("@tableName", table.TableName) } },
 				                  reader =>
 				                  {
 				                  	while (reader.Read())
 				                  		currentIndexes.Add(new Tuple<string, string>(reader.GetString(0), reader.GetString(1)));
-				                  }, IsolationLevel.DEFAULT);
+				                  });
 			}
 			catch (Exception e)
 			{
@@ -457,12 +458,12 @@ namespace DOL.Database.Handlers
 			try
 			{
 				ExecuteSelectImpl("SELECT name FROM sqlite_master WHERE type == 'index' AND sql is not null AND tbl_name == @tableName",
-				                  new QueryParameter("@tableName", table.TableName),
+				                  new[] { new[] { new QueryParameter("@tableName", table.TableName) } },
 				                  reader =>
 				                  {
 				                  	while (reader.Read())
 				                  		currentIndexes.Add(reader.GetString(0));
-				                  }, IsolationLevel.DEFAULT);
+				                  });
 			}
 			catch (Exception e)
 			{

--- a/DOLDatabase/Handlers/SQLiteObjectDatabase.cs
+++ b/DOLDatabase/Handlers/SQLiteObjectDatabase.cs
@@ -146,28 +146,6 @@ namespace DOL.Database.Handlers
 		}
 		
 		/// <summary>
-		/// Fill SQL Command Parameter with Converted Values.
-		/// </summary>
-		/// <param name="parameter">Parameter collection for this Command</param>
-		/// <param name="dbParams">DbParameter Object to Fill</param>
-		protected override void FillSQLParameter(IEnumerable<QueryParameter> parameter, DbParameterCollection dbParams)
-		{
-			// Specififc Handling for Char Cast from DB Integer
-			// And Non Signed Integer Handling
-    		foreach(var param in parameter)
-    		{
-    			if (param.Value is char)
-    				dbParams[param.Name].Value = Convert.ToUInt16(param.Value);
-    			else if (param.Value is uint)
-    				dbParams[param.Name].Value = Convert.ToInt64(param.Value);
-    			else if (param.Value is ulong)
-    				dbParams[param.Name].Value = unchecked((long)Convert.ToUInt64(param.Value));
-    			else
-    				dbParams[param.Name].Value = param.Value;
-    		}
-		}
-		
-		/// <summary>
 		/// Set Value to DataObject Field according to ElementBinding
 		/// Override for SQLite to Handle some Specific Case (Unsigned Int64...)
 		/// </summary>
@@ -628,24 +606,22 @@ namespace DOL.Database.Handlers
 			{
 				repeat = false;
 
+				if (!parameters.Any()) throw new ArgumentException("No parameter list was given.");
+
 				using (var conn = new SQLiteConnection(ConnectionString))
 				{
-				    using (var cmd = new SQLiteCommand(SQLCommand, conn))
+				    using (var cmd = conn.CreateCommand())
 					{
 						try
 						{
 					    	conn.Open();
-					    	cmd.Prepare();
-					    	
 					    	long start = (DateTime.UtcNow.Ticks / 10000);
-					    	
-					    	// Register Parameter
-					    	foreach(var keys in parameters.First().Select(kv => kv.Name))
-					    		cmd.Parameters.Add(new SQLiteParameter(keys));
-					    	
-					    	foreach(var parameter in parameters.Skip(current))
-					    	{
-					    		FillSQLParameter(parameter, cmd.Parameters);
+
+							foreach (var parameter in parameters.Skip(current))
+							{
+								cmd.CommandText = SQLCommand;
+								FillSQLParameter(parameter, cmd.Parameters);
+								cmd.Prepare();
 					    	
 							    using (var reader = cmd.ExecuteReader())
 							    {
@@ -687,12 +663,29 @@ namespace DOL.Database.Handlers
 						{
 							conn.Close();
 						}
-				    }
+					}
 				}
 			}
 			while (repeat);
 		}
-		
+
+		protected override DbParameter ConvertToDBParameter(QueryParameter queryParameter)
+		{
+			var dbParam = new SQLiteParameter();
+			dbParam.ParameterName = queryParameter.Name;
+
+			if (queryParameter.Value is char)
+				dbParam.Value = Convert.ToUInt16(queryParameter.Value);
+			else if (queryParameter.Value is uint)
+				dbParam.Value = Convert.ToInt64(queryParameter.Value);
+			else if (dbParam.Value is ulong)
+				dbParam.Value = unchecked((long)Convert.ToUInt64(queryParameter.Value));
+			else
+				dbParam.Value = queryParameter.Value;
+
+			return dbParam;
+		}
+
 		/// <summary>
 		/// Implementation of Raw Non-Query with Parameters for Prepared Query
 		/// </summary>
@@ -711,6 +704,8 @@ namespace DOL.Database.Handlers
 			{
 				repeat = false;
 
+				if (!parameters.Any()) throw new ArgumentException("No parameter list was given.");
+
 				using (var conn = new SQLiteConnection(ConnectionString))
 				{
 					using (var cmd = new SQLiteCommand(SQLCommand, conn))
@@ -721,15 +716,12 @@ namespace DOL.Database.Handlers
 					    	cmd.Prepare();
 						    
 					    	long start = (DateTime.UtcNow.Ticks / 10000);
-						    
-					    	// Register Parameter
-					    	foreach(var keys in parameters.First().Select(kv => kv.Name))
-					    		cmd.Parameters.Add(new SQLiteParameter(keys));
 					    	
 					    	foreach(var parameter in parameters.Skip(current))
 					    	{
 					    		FillSQLParameter(parameter, cmd.Parameters);
-					    		var result = -1;
+								cmd.Prepare();
+								var result = -1;
 					    		try
 					    		{
 							    	result = cmd.ExecuteNonQuery();
@@ -801,7 +793,9 @@ namespace DOL.Database.Handlers
 			do
 			{
 				repeat = false;
-				
+
+				if (!parameters.Any()) throw new ArgumentException("No parameter list was given.");
+
 				using (var conn = new SQLiteConnection(ConnectionString))
 				{					    
 					using (var cmd = new SQLiteCommand(SQLCommand, conn))
@@ -811,16 +805,13 @@ namespace DOL.Database.Handlers
 						    conn.Open();
 					    	cmd.Prepare();
 						    long start = (DateTime.UtcNow.Ticks / 10000);
-
-						    // Register Parameter
-					    	foreach(var keys in parameters.First().Select(kv => kv.Name))
-					    		cmd.Parameters.Add(new SQLiteParameter(keys));
 					    	
 					    	foreach(var parameter in parameters.Skip(current))
 					    	{
 					    		FillSQLParameter(parameter, cmd.Parameters);
-					    		
-					    		if (retrieveLastInsertID)
+								cmd.Prepare();
+
+								if (retrieveLastInsertID)
 					    		{
 					    			using (var tran = conn.BeginTransaction(System.Data.IsolationLevel.ReadCommitted))
 					    			{

--- a/DOLDatabase/Handlers/SQLiteObjectDatabase.cs
+++ b/DOLDatabase/Handlers/SQLiteObjectDatabase.cs
@@ -669,6 +669,80 @@ namespace DOL.Database.Handlers
 			while (repeat);
 		}
 
+		protected override void ExecuteSelectImpl(string selectFromExpression, IEnumerable<WhereExpression> whereExpressionBatch, Action<IDataReader> Reader, IsolationLevel Isolation)
+		{
+			if (!whereExpressionBatch.Any()) throw new ArgumentException("No parameter list was given.");
+
+			if (log.IsDebugEnabled)
+				log.DebugFormat("ExecuteSelectImpl: {0}", selectFromExpression);
+
+			bool repeat;
+			var current = 0;
+			do
+			{
+				repeat = false;
+
+				using (var conn = new SQLiteConnection(ConnectionString))
+				{
+					using (var cmd = conn.CreateCommand())
+					{
+						try
+						{
+							conn.Open();
+							long start = (DateTime.UtcNow.Ticks / 10000);
+
+							foreach (var whereExpression in whereExpressionBatch.Skip(current))
+							{
+								cmd.CommandText = selectFromExpression + whereExpression.WhereClause;
+								FillSQLParameter(whereExpression.QueryParameters, cmd.Parameters);
+								cmd.Prepare();
+
+								using (var reader = cmd.ExecuteReader())
+								{
+									try
+									{
+										Reader(reader);
+									}
+									catch (Exception es)
+									{
+										if (log.IsWarnEnabled)
+											log.WarnFormat("ExecuteSelectImpl: Exception in Select Callback : {2}{0}{2}{1}", es, Environment.StackTrace, Environment.NewLine);
+									}
+									finally
+									{
+										reader.Close();
+									}
+								}
+								current++;
+							}
+
+							if (log.IsDebugEnabled)
+								log.DebugFormat("ExecuteSelectImpl: SQL Select ({0}) exec time {1}ms", Isolation, ((DateTime.UtcNow.Ticks / 10000) - start));
+							else if (log.IsWarnEnabled && (DateTime.UtcNow.Ticks / 10000) - start > 500)
+								log.WarnFormat("ExecuteSelectImpl: SQL Select ({0}) took {1}ms!\n{2}", Isolation, ((DateTime.UtcNow.Ticks / 10000) - start), selectFromExpression);
+
+						}
+						catch (Exception e)
+						{
+							if (!HandleException(e))
+							{
+								if (log.IsErrorEnabled)
+									log.ErrorFormat("ExecuteSelectImpl: UnHandled Exception in Select Query \"{0}\"\n{1}", selectFromExpression, e);
+
+								throw;
+							}
+							repeat = true;
+						}
+						finally
+						{
+							conn.Close();
+						}
+					}
+				}
+			}
+			while (repeat);
+		}
+
 		protected override DbParameter ConvertToDBParameter(QueryParameter queryParameter)
 		{
 			var dbParam = new SQLiteParameter();

--- a/DOLDatabase/IObjectDatabase.cs
+++ b/DOLDatabase/IObjectDatabase.cs
@@ -98,7 +98,7 @@ namespace DOL.Database
 		/// <typeparam name="TObject"></typeparam>
 		/// <param name="whereExpression">WhereExpression object with implied parameters</param>
 		/// <returns></returns>
-		TObject SelectObject<TObject>(WhereExpression whereExpression)
+		TObject SelectObject<TObject>(WhereClause whereExpression)
 			where TObject : DataObject;
 
 		/// <summary>
@@ -106,7 +106,7 @@ namespace DOL.Database
 		/// </summary>
 		/// <param name="whereExpression">WhereExpression object with implied parameters</param>
 		/// <returns>Collection of matching DataObjects</returns>
-		IList<TObject> SelectObjects<TObject>(WhereExpression whereExpression)
+		IList<TObject> SelectObjects<TObject>(WhereClause whereExpression)
 			where TObject : DataObject;
 
 		/// <summary>
@@ -114,7 +114,7 @@ namespace DOL.Database
 		/// </summary>
 		/// <param name="whereExpressionBatch">Batch of WhereExpressions with implied parameters</param>
 		/// <returns>Collection of matching DataObjects</returns
-		IList<IList<TObject>> MultipleSelectObjects<TObject>(IEnumerable<WhereExpression> whereExpressionBatch)
+		IList<IList<TObject>> MultipleSelectObjects<TObject>(IEnumerable<WhereClause> whereExpressionBatch)
 			where TObject : DataObject;
 
 		/// <summary>

--- a/DOLDatabase/IObjectDatabase.cs
+++ b/DOLDatabase/IObjectDatabase.cs
@@ -116,17 +116,19 @@ namespace DOL.Database
 		/// <param name="whereExpression"></param>
 		/// <param name="parameters"></param>
 		/// <returns></returns>
+		[Obsolete("Use Select Queries with WhereExpression object instead.")]
 		TObject SelectObject<TObject>(string whereExpression, IEnumerable<IEnumerable<QueryParameter>> parameters)
  			where TObject : DataObject;
- 
- 		/// <summary>
- 		/// Retrieve a Single DataObject from database based on Where Expression and Parameters
- 		/// </summary>
- 		/// <typeparam name="TObject"></typeparam>
- 		/// <param name="whereExpression"></param>
- 		/// <param name="parameter"></param>
- 		/// <returns></returns>
- 		TObject SelectObject<TObject>(string whereExpression, IEnumerable<QueryParameter> parameter)
+
+		/// <summary>
+		/// Retrieve a Single DataObject from database based on Where Expression and Parameters
+		/// </summary>
+		/// <typeparam name="TObject"></typeparam>
+		/// <param name="whereExpression"></param>
+		/// <param name="parameter"></param>
+		/// <returns></returns>
+		[Obsolete("Use Select Queries with WhereExpression object instead.")]
+		TObject SelectObject<TObject>(string whereExpression, IEnumerable<QueryParameter> parameter)
  			where TObject : DataObject;
  
  		/// <summary>
@@ -136,6 +138,7 @@ namespace DOL.Database
  		/// <param name="whereExpression"></param>
  		/// <param name="param"></param>
  		/// <returns></returns>
+		[Obsolete("Use Select Queries with WhereExpression object instead.")]
  		TObject SelectObject<TObject>(string whereExpression, QueryParameter param)
  			where TObject : DataObject;
 
@@ -145,6 +148,7 @@ namespace DOL.Database
 		/// <param name="whereExpression">Parametrized Where Expression</param>
 		/// <param name="parameters">Collection of Parameters</param>
 		/// <returns>Collection of Objects Sets for each matching Parametrized Query</returns>
+		[Obsolete("Use Select Queries with WhereExpression object instead.")]
 		IList<IList<TObject>> SelectObjects<TObject>(string whereExpression, IEnumerable<IEnumerable<QueryParameter>> parameters)
 			where TObject : DataObject;
 		/// <summary>
@@ -153,6 +157,7 @@ namespace DOL.Database
 		/// <param name="whereExpression">Parametrized Where Expression</param>
 		/// <param name="parameter">Collection of Parameter</param>
 		/// <returns>Collection of Objects matching Parametrized Query</returns>
+		[Obsolete("Use Select Queries with WhereExpression object instead.")]
 		IList<TObject> SelectObjects<TObject>(string whereExpression, IEnumerable<QueryParameter> parameter)
 			where TObject : DataObject;
 		/// <summary>
@@ -161,17 +166,18 @@ namespace DOL.Database
 		/// <param name="whereExpression">Parametrized Where Expression</param>
 		/// <param name="param">Single Parameter</param>
 		/// <returns>Collection of Objects matching Parametrized Query</returns>
+		[Obsolete("Use Select Queries with WhereExpression object instead.")]
 		IList<TObject> SelectObjects<TObject>(string whereExpression, QueryParameter param)
 			where TObject : DataObject;
 		#endregion
-		
+
 		#region Select Where Clause Without Parameter
 		/// <summary>
 		/// Retrieve a Single DataObject from database based on Where Expression
 		/// </summary>
 		/// <param name="whereExpression">Where Expression Filter</param>
 		/// <returns>Single Object or First Object if multiple matches</returns>
-		[Obsolete("Use Parametrized Select Queries for best perfomances")]
+		[Obsolete("Use Select Queries with WhereExpression object instead.")]
 		TObject SelectObject<TObject>(string whereExpression)
 			where TObject : DataObject;
 		/// <summary>
@@ -180,7 +186,7 @@ namespace DOL.Database
 		/// <param name="whereExpression">Where Expression Filter</param>
 		/// <param name="isolation">Isolation Level</param>
 		/// <returns>Single Object or First Object if multiple matches</returns>
-		[Obsolete("Use Parametrized Select Queries for best perfomances")]
+		[Obsolete("Use Select Queries with WhereExpression object instead.")]
 		TObject SelectObject<TObject>(string whereExpression, Transaction.IsolationLevel isolation)
 			where TObject : DataObject;
 		/// <summary>
@@ -188,7 +194,7 @@ namespace DOL.Database
 		/// </summary>
 		/// <param name="whereExpression">Where Expression Filter</param>
 		/// <returns>Collection of DataObjects matching filter</returns>
-		[Obsolete("Use Parametrized Select Queries for best perfomances")]
+		[Obsolete("Use Select Queries with WhereExpression object instead.")]
 		IList<TObject> SelectObjects<TObject>(string whereExpression)
 			where TObject : DataObject;
 		/// <summary>
@@ -197,7 +203,7 @@ namespace DOL.Database
 		/// <param name="whereExpression">Where Expression Filter</param>
 		/// <param name="isolation">Isolation Level</param>
 		/// <returns>Collection of DataObjects matching filter</returns>
-		[Obsolete("Use Parametrized Select Queries for best perfomances")]
+		[Obsolete("Use Select Queries with WhereExpression object instead.")]
 		IList<TObject> SelectObjects<TObject>(string whereExpression, Transaction.IsolationLevel isolation)
 			where TObject : DataObject;
 		#endregion

--- a/DOLDatabase/IObjectDatabase.cs
+++ b/DOLDatabase/IObjectDatabase.cs
@@ -110,6 +110,14 @@ namespace DOL.Database
 			where TObject : DataObject;
 
 		/// <summary>
+		/// Retrieve a Two-Dimensional Collection of DataObjects from database based on the WhereExpressionBatch with implied parameters
+		/// </summary>
+		/// <param name="whereExpressionBatch">Batch of WhereExpressions with implied parameters</param>
+		/// <returns>Collection of matching DataObjects</returns
+		IList<IList<TObject>> MultipleSelectObjects<TObject>(IEnumerable<WhereExpression> whereExpressionBatch)
+			where TObject : DataObject;
+
+		/// <summary>
 		/// Retrieve a Single DataObject from the database based on the Where Expression and Parameters Collection
 		/// </summary>
 		/// <typeparam name="TObject"></typeparam>

--- a/DOLDatabase/IObjectDatabase.cs
+++ b/DOLDatabase/IObjectDatabase.cs
@@ -230,6 +230,7 @@ namespace DOL.Database
 		/// <typeparam name="TObject">DataObject Type to Select</typeparam>
 		/// <param name="isolation">Isolation Level</param>
 		/// <returns>Collection of all DataObject for this Type</returns>
+		[Obsolete("Use SelectAllObjects() instead.")]
 		IList<TObject> SelectAllObjects<TObject>(Transaction.IsolationLevel isolation)
 			where TObject : DataObject;
 		#endregion

--- a/DOLDatabase/IObjectDatabase.cs
+++ b/DOLDatabase/IObjectDatabase.cs
@@ -93,28 +93,28 @@ namespace DOL.Database
 
 		#region Select Where Clause With Parameters
 		/// <summary>
-		/// Retrieve a Single DataObject from the database based on the WhereExpression with implied parameters
+		/// Retrieve a Single DataObject from the database based on the WhereClause with implied parameters
 		/// </summary>
 		/// <typeparam name="TObject"></typeparam>
-		/// <param name="whereExpression">WhereExpression object with implied parameters</param>
+		/// <param name="whereClause">WhereClause object with implied parameters</param>
 		/// <returns></returns>
-		TObject SelectObject<TObject>(WhereClause whereExpression)
+		TObject SelectObject<TObject>(WhereClause whereClause)
 			where TObject : DataObject;
 
 		/// <summary>
-		/// Retrieve a Collection of DataObjects from database based on the WhereExpression with implied parameters
+		/// Retrieve a Collection of DataObjects from database based on the WhereClause with implied parameters
 		/// </summary>
-		/// <param name="whereExpression">WhereExpression object with implied parameters</param>
+		/// <param name="whereClause">WhereClause object with implied parameters</param>
 		/// <returns>Collection of matching DataObjects</returns>
-		IList<TObject> SelectObjects<TObject>(WhereClause whereExpression)
+		IList<TObject> SelectObjects<TObject>(WhereClause whereClause)
 			where TObject : DataObject;
 
 		/// <summary>
-		/// Retrieve a Two-Dimensional Collection of DataObjects from database based on the WhereExpressionBatch with implied parameters
+		/// Retrieve a Two-Dimensional Collection of DataObjects from database based on the WhereClauseBatch with implied parameters
 		/// </summary>
-		/// <param name="whereExpressionBatch">Batch of WhereExpressions with implied parameters</param>
-		/// <returns>Collection of matching DataObjects</returns
-		IList<IList<TObject>> MultipleSelectObjects<TObject>(IEnumerable<WhereClause> whereExpressionBatch)
+		/// <param name="whereClauseBatch">Batch of WhereClauses with implied parameters</param>
+		/// <returns>Collection of matching DataObjects</returns>
+		IList<IList<TObject>> MultipleSelectObjects<TObject>(IEnumerable<WhereClause> whereClauseBatch)
 			where TObject : DataObject;
 
 		/// <summary>
@@ -124,7 +124,7 @@ namespace DOL.Database
 		/// <param name="whereExpression"></param>
 		/// <param name="parameters"></param>
 		/// <returns></returns>
-		[Obsolete("Use Select Queries with WhereExpression object instead.")]
+		[Obsolete("Use Select Queries with WhereClause object instead.")]
 		TObject SelectObject<TObject>(string whereExpression, IEnumerable<IEnumerable<QueryParameter>> parameters)
  			where TObject : DataObject;
 
@@ -135,7 +135,7 @@ namespace DOL.Database
 		/// <param name="whereExpression"></param>
 		/// <param name="parameter"></param>
 		/// <returns></returns>
-		[Obsolete("Use Select Queries with WhereExpression object instead.")]
+		[Obsolete("Use Select Queries with WhereClause object instead.")]
 		TObject SelectObject<TObject>(string whereExpression, IEnumerable<QueryParameter> parameter)
  			where TObject : DataObject;
  
@@ -146,7 +146,7 @@ namespace DOL.Database
  		/// <param name="whereExpression"></param>
  		/// <param name="param"></param>
  		/// <returns></returns>
-		[Obsolete("Use Select Queries with WhereExpression object instead.")]
+		[Obsolete("Use Select Queries with WhereClause object instead.")]
  		TObject SelectObject<TObject>(string whereExpression, QueryParameter param)
  			where TObject : DataObject;
 
@@ -156,7 +156,7 @@ namespace DOL.Database
 		/// <param name="whereExpression">Parametrized Where Expression</param>
 		/// <param name="parameters">Collection of Parameters</param>
 		/// <returns>Collection of Objects Sets for each matching Parametrized Query</returns>
-		[Obsolete("Use Select Queries with WhereExpression object instead.")]
+		[Obsolete("Use Select Queries with WhereClause object instead.")]
 		IList<IList<TObject>> SelectObjects<TObject>(string whereExpression, IEnumerable<IEnumerable<QueryParameter>> parameters)
 			where TObject : DataObject;
 		/// <summary>
@@ -165,7 +165,7 @@ namespace DOL.Database
 		/// <param name="whereExpression">Parametrized Where Expression</param>
 		/// <param name="parameter">Collection of Parameter</param>
 		/// <returns>Collection of Objects matching Parametrized Query</returns>
-		[Obsolete("Use Select Queries with WhereExpression object instead.")]
+		[Obsolete("Use Select Queries with WhereClause object instead.")]
 		IList<TObject> SelectObjects<TObject>(string whereExpression, IEnumerable<QueryParameter> parameter)
 			where TObject : DataObject;
 		/// <summary>
@@ -174,7 +174,7 @@ namespace DOL.Database
 		/// <param name="whereExpression">Parametrized Where Expression</param>
 		/// <param name="param">Single Parameter</param>
 		/// <returns>Collection of Objects matching Parametrized Query</returns>
-		[Obsolete("Use Select Queries with WhereExpression object instead.")]
+		[Obsolete("Use Select Queries with WhereClause object instead.")]
 		IList<TObject> SelectObjects<TObject>(string whereExpression, QueryParameter param)
 			where TObject : DataObject;
 		#endregion
@@ -185,7 +185,7 @@ namespace DOL.Database
 		/// </summary>
 		/// <param name="whereExpression">Where Expression Filter</param>
 		/// <returns>Single Object or First Object if multiple matches</returns>
-		[Obsolete("Use Select Queries with WhereExpression object instead.")]
+		[Obsolete("Use Select Queries with WhereClause object instead.")]
 		TObject SelectObject<TObject>(string whereExpression)
 			where TObject : DataObject;
 		/// <summary>
@@ -194,7 +194,7 @@ namespace DOL.Database
 		/// <param name="whereExpression">Where Expression Filter</param>
 		/// <param name="isolation">Isolation Level</param>
 		/// <returns>Single Object or First Object if multiple matches</returns>
-		[Obsolete("Use Select Queries with WhereExpression object instead.")]
+		[Obsolete("Use Select Queries with WhereClause object instead.")]
 		TObject SelectObject<TObject>(string whereExpression, Transaction.IsolationLevel isolation)
 			where TObject : DataObject;
 		/// <summary>
@@ -202,7 +202,7 @@ namespace DOL.Database
 		/// </summary>
 		/// <param name="whereExpression">Where Expression Filter</param>
 		/// <returns>Collection of DataObjects matching filter</returns>
-		[Obsolete("Use Select Queries with WhereExpression object instead.")]
+		[Obsolete("Use Select Queries with WhereClause object instead.")]
 		IList<TObject> SelectObjects<TObject>(string whereExpression)
 			where TObject : DataObject;
 		/// <summary>
@@ -211,7 +211,7 @@ namespace DOL.Database
 		/// <param name="whereExpression">Where Expression Filter</param>
 		/// <param name="isolation">Isolation Level</param>
 		/// <returns>Collection of DataObjects matching filter</returns>
-		[Obsolete("Use Select Queries with WhereExpression object instead.")]
+		[Obsolete("Use Select Queries with WhereClause object instead.")]
 		IList<TObject> SelectObjects<TObject>(string whereExpression, Transaction.IsolationLevel isolation)
 			where TObject : DataObject;
 		#endregion

--- a/DOLDatabase/ObjectDatabase.cs
+++ b/DOLDatabase/ObjectDatabase.cs
@@ -40,7 +40,7 @@ namespace DOL.Database
 		/// <summary>
 		/// Defines a logger for this class.
 		/// </summary>
-		protected static readonly ILog Log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+		protected static readonly ILog log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
 
 		/// <summary>
 		/// Number Format Info to Use for Database
@@ -117,8 +117,8 @@ namespace DOL.Database
 				
 				if (tableHandler == null)
 				{
-					if (Log.IsErrorEnabled)
-						Log.ErrorFormat("AddObject: DataObject Type ({0}) not registered !", grp.Key.FullName);
+					if (log.IsErrorEnabled)
+						log.ErrorFormat("AddObject: DataObject Type ({0}) not registered !", grp.Key.FullName);
 					success = false;
 					continue;
 				}
@@ -154,10 +154,10 @@ namespace DOL.Database
 							}
 							else
 							{
-								if (Log.IsErrorEnabled)
+								if (log.IsErrorEnabled)
 								{
 									foreach(var obj in resultGrp)
-										Log.ErrorFormat("AddObjects: DataObject ({0}) could not be inserted into database...", obj.DataObject);
+										log.ErrorFormat("AddObjects: DataObject ({0}) could not be inserted into database...", obj.DataObject);
 								}
 								success = false;
 							}
@@ -165,10 +165,10 @@ namespace DOL.Database
 					}
 					else
 					{
-						if (Log.IsWarnEnabled)
+						if (log.IsWarnEnabled)
 						{
 							foreach (var obj in allowed)
-								Log.WarnFormat("AddObject: DataObject ({0}) not allowed to be added to Database", obj);
+								log.WarnFormat("AddObject: DataObject ({0}) not allowed to be added to Database", obj);
 						}
 						success = false;
 					}
@@ -202,8 +202,8 @@ namespace DOL.Database
 				
 				if (tableHandler == null)
 				{
-					if (Log.IsErrorEnabled)
-						Log.ErrorFormat("SaveObject: DataObject Type ({0}) not registered !", grp.Key.FullName);
+					if (log.IsErrorEnabled)
+						log.ErrorFormat("SaveObject: DataObject Type ({0}) not registered !", grp.Key.FullName);
 					success = false;
 					continue;
 				}
@@ -230,10 +230,10 @@ namespace DOL.Database
 					}
 					else
 					{
-						if (Log.IsErrorEnabled)
+						if (log.IsErrorEnabled)
 						{
 							foreach(var obj in resultGrp)
-								Log.ErrorFormat("SaveObject: DataObject ({0}) could not be saved into database...", obj.DataObject);
+								log.ErrorFormat("SaveObject: DataObject ({0}) could not be saved into database...", obj.DataObject);
 						}
 						success = false;
 					}
@@ -270,8 +270,8 @@ namespace DOL.Database
 				
 				if (tableHandler == null)
 				{
-					if (Log.IsErrorEnabled)
-						Log.ErrorFormat("DeleteObject: DataObject Type ({0}) not registered !", grp.Key.FullName);
+					if (log.IsErrorEnabled)
+						log.ErrorFormat("DeleteObject: DataObject Type ({0}) not registered !", grp.Key.FullName);
 					success = false;
 					continue;
 				}
@@ -307,10 +307,10 @@ namespace DOL.Database
 							}
 							else
 							{
-								if (Log.IsErrorEnabled)
+								if (log.IsErrorEnabled)
 								{
 									foreach(var obj in resultGrp)
-										Log.ErrorFormat("DeleteObject: DataObject ({0}) could not be deleted from database...", obj.DataObject);
+										log.ErrorFormat("DeleteObject: DataObject ({0}) could not be deleted from database...", obj.DataObject);
 								}
 								success = false;
 							}
@@ -318,10 +318,10 @@ namespace DOL.Database
 					}
 					else
 					{
-						if (Log.IsWarnEnabled)
+						if (log.IsWarnEnabled)
 						{
 							foreach (var obj in allowed)
-								Log.WarnFormat("DeleteObject: DataObject ({0}) not allowed to be deleted from Database", obj);
+								log.WarnFormat("DeleteObject: DataObject ({0}) not allowed to be deleted from Database", obj);
 						}
 						success = false;
 					}
@@ -346,8 +346,8 @@ namespace DOL.Database
 				var remoteHandler = GetTableHandler(relation.ValueType);
 				if (remoteHandler == null)
 				{
-					if (Log.IsErrorEnabled)
-						Log.ErrorFormat("SaveObjectRelations: Remote Table for Type ({0}) is not registered !", relation.ValueType.FullName);
+					if (log.IsErrorEnabled)
+						log.ErrorFormat("SaveObjectRelations: Remote Table for Type ({0}) is not registered !", relation.ValueType.FullName);
 					success = false;
 					continue;
 				}
@@ -388,10 +388,10 @@ namespace DOL.Database
 								}
 								else
 								{
-									if (Log.IsErrorEnabled)
+									if (log.IsErrorEnabled)
 									{
 										foreach (var result in resultGrp)
-											Log.ErrorFormat("SaveObjectRelations: {0} Relation ({1}) of DataObject ({2}) failed for Object ({3})", grp.Key ? "Saving" : "Adding",
+											log.ErrorFormat("SaveObjectRelations: {0} Relation ({1}) of DataObject ({2}) failed for Object ({3})", grp.Key ? "Saving" : "Adding",
 											                relation.ValueType, result.RelObject.Local, result.RelObject.Remote);
 									}
 									success = false;
@@ -403,10 +403,10 @@ namespace DOL.Database
 							// Objects that could not be added can lead to failure
 							if (!grp.Key)
 							{
-								if (Log.IsWarnEnabled)
+								if (log.IsWarnEnabled)
 								{
 									foreach (var obj in allowed)
-										Log.WarnFormat("SaveObjectRelations: DataObject ({0}) not allowed to be added to Database", obj);
+										log.WarnFormat("SaveObjectRelations: DataObject ({0}) not allowed to be added to Database", obj);
 								}
 								success = false;
 							}
@@ -432,8 +432,8 @@ namespace DOL.Database
 				var remoteHandler = GetTableHandler(relation.ValueType);
 				if (remoteHandler == null)
 				{
-					if (Log.IsErrorEnabled)
-						Log.ErrorFormat("DeleteObjectRelations: Remote Table for Type ({0}) is not registered !", relation.ValueType.FullName);
+					if (log.IsErrorEnabled)
+						log.ErrorFormat("DeleteObjectRelations: Remote Table for Type ({0}) is not registered !", relation.ValueType.FullName);
 					success = false;
 					continue;
 				}
@@ -473,8 +473,8 @@ namespace DOL.Database
 							{
 								foreach (var result in resultGrp)
 								{
-									if (Log.IsErrorEnabled)
-										Log.ErrorFormat("DeleteObjectRelations: Deleting Relation ({0}) of DataObject ({1}) failed for Object ({2})",
+									if (log.IsErrorEnabled)
+										log.ErrorFormat("DeleteObjectRelations: Deleting Relation ({0}) of DataObject ({1}) failed for Object ({2})",
 										                relation.ValueType, result.RelObject.Local, result.RelObject.Remote);
 								}
 								success = false;
@@ -484,10 +484,10 @@ namespace DOL.Database
 					else
 					{
 						// Objects that could not be deleted can lead to failure
-						if (Log.IsWarnEnabled)
+						if (log.IsWarnEnabled)
 						{
 							foreach (var obj in grp)
-								Log.WarnFormat("DeleteObjectRelations: DataObject ({0}) not allowed to be deleted from Database", obj);
+								log.WarnFormat("DeleteObjectRelations: DataObject ({0}) not allowed to be deleted from Database", obj);
 						}
 						success = false;
 					}
@@ -563,16 +563,16 @@ namespace DOL.Database
 						}
 						catch (Exception re)
 						{
-							if (Log.IsErrorEnabled)
-								Log.ErrorFormat("Could not Retrieve Objects from Relation (Table {0}, Local {1}, Remote Table {2}, Remote {3})\n{4}", tableName,
+							if (log.IsErrorEnabled)
+								log.ErrorFormat("Could not Retrieve Objects from Relation (Table {0}, Local {1}, Remote Table {2}, Remote {3})\n{4}", tableName,
 								                relation.Relation.LocalField, AttributesUtils.GetTableOrViewName(relation.ValueType), relation.Relation.RemoteField, re);
 						}
 					}
 				}
 				catch (Exception e)
 				{
-					if (Log.IsErrorEnabled)
-						Log.ErrorFormat("Could not Resolve Relations for Table {0}\n{1}", tableName, e);
+					if (log.IsErrorEnabled)
+						log.ErrorFormat("Could not Resolve Relations for Table {0}\n{1}", tableName, e);
 				}
 			}
 		}
@@ -693,8 +693,8 @@ namespace DOL.Database
 			var tableHandler = GetTableOrViewHandler(typeof(TObject));
 			if (tableHandler == null)
 			{
-				if (Log.IsErrorEnabled)
-					Log.ErrorFormat("FindObjectByKey: DataObject Type ({0}) not registered !", typeof(TObject).FullName);
+				if (log.IsErrorEnabled)
+					log.ErrorFormat("FindObjectByKey: DataObject Type ({0}) not registered !", typeof(TObject).FullName);
 				
 				throw new DatabaseException(string.Format("Table {0} is not registered for Database Connection...", typeof(TObject).FullName));
 			}
@@ -739,8 +739,8 @@ namespace DOL.Database
 			var tableHandler = GetTableOrViewHandler(typeof(TObject));
 			if (tableHandler == null)
 			{
-				if (Log.IsErrorEnabled)
-					Log.ErrorFormat("SelectObjects: DataObject Type ({0}) not registered !", typeof(TObject).FullName);
+				if (log.IsErrorEnabled)
+					log.ErrorFormat("SelectObjects: DataObject Type ({0}) not registered !", typeof(TObject).FullName);
 
 				throw new DatabaseException(string.Format("Table {0} is not registered for Database Connection...", typeof(TObject).FullName));
 			}
@@ -811,8 +811,8 @@ namespace DOL.Database
 			var tableHandler = GetTableOrViewHandler(typeof(TObject));
 			if (tableHandler == null)
 			{
-				if (Log.IsErrorEnabled)
-					Log.ErrorFormat("SelectObjects: DataObject Type ({0}) not registered !", typeof(TObject).FullName);
+				if (log.IsErrorEnabled)
+					log.ErrorFormat("SelectObjects: DataObject Type ({0}) not registered !", typeof(TObject).FullName);
 				
 				throw new DatabaseException(string.Format("Table {0} is not registered for Database Connection...", typeof(TObject).FullName));
 			}
@@ -924,8 +924,8 @@ namespace DOL.Database
 			var tableHandler = GetTableOrViewHandler(typeof(TObject));
 			if (tableHandler == null)
 			{
-				if (Log.IsErrorEnabled)
-					Log.ErrorFormat("SelectAllObjects: DataObject Type ({0}) not registered !", typeof(TObject).FullName);
+				if (log.IsErrorEnabled)
+					log.ErrorFormat("SelectAllObjects: DataObject Type ({0}) not registered !", typeof(TObject).FullName);
 				
 				throw new DatabaseException(string.Format("Table {0} is not registered for Database Connection...", typeof(TObject).FullName));
 			}
@@ -1070,8 +1070,8 @@ namespace DOL.Database
 			var tableHandler = GetTableOrViewHandler(typeof(TObject));
 			if (tableHandler == null)
 			{
-				if (Log.IsErrorEnabled)
-					Log.ErrorFormat("UpdateInCache: DataObject Type ({0}) not registered !", typeof(TObject).FullName);
+				if (log.IsErrorEnabled)
+					log.ErrorFormat("UpdateInCache: DataObject Type ({0}) not registered !", typeof(TObject).FullName);
 				
 				throw new DatabaseException(string.Format("Table {0} is not registered for Database Connection...", typeof(TObject).FullName));
 			}

--- a/DOLDatabase/ObjectDatabase.cs
+++ b/DOLDatabase/ObjectDatabase.cs
@@ -633,12 +633,8 @@ namespace DOL.Database
 			}
 			else
 			{
-				
-				var whereClause = string.Format("`{0}` = @{0}", remoteBind.ColumnName);
-				
-				var parameters = objects.Select(obj => new [] { new QueryParameter(string.Format("@{0}", remoteBind.ColumnName), localBind.GetValue(obj), localBind.ValueType) });
-				
-				objsResults = SelectObjectsImpl(remoteHandler, whereClause, parameters, Transaction.IsolationLevel.DEFAULT);
+				var whereExpressions = objects.Select(obj => DB.Column(remoteBind.ColumnName).IsEqualTo(localBind.GetValue(obj)));
+				objsResults = MultipleSelectObjectsImpl(remoteHandler, whereExpressions);
 			}
 			
 			var resultByObjs = objsResults.Select((obj, index) => new { DataObject = objects[index], Results = obj }).ToArray();
@@ -753,13 +749,6 @@ namespace DOL.Database
 		#endregion
 
 		#region Public Object Select API With Parameters
-		/// <summary>
-		/// Retrieve a Single DataObject from the database based on the Where Expression and Parameters Collection
-		/// </summary>
-		/// <typeparam name="TObject"></typeparam>
-		/// <param name="whereExpression"></param>
-		/// <param name="parameters"></param>
-		/// <returns>DataObject or null</returns>
 		public TObject SelectObject<TObject>(string whereExpression, IEnumerable<IEnumerable<QueryParameter>> parameters)
 			where TObject : DataObject
 		{
@@ -769,38 +758,18 @@ namespace DOL.Database
 			return null;
 		}
 
-		/// <summary>
-		/// Retrieve a Single DataObject from database based on Where Expression and Parameters
-		/// </summary>
-		/// <typeparam name="TObject"></typeparam>
-		/// <param name="whereExpression"></param>
-		/// <param name="parameter"></param>
-		/// <returns></returns>
 		public TObject SelectObject<TObject>(string whereExpression, IEnumerable<QueryParameter> parameter)
 			where TObject : DataObject
 		{
 			return SelectObjects<TObject>(whereExpression, parameter).FirstOrDefault();
 		}
 
-		/// <summary>
-		/// Retrieve a Single DataObject from database based on Where Expression and Parameter
-		/// </summary>
-		/// <typeparam name="TObject"></typeparam>
-		/// <param name="whereExpression"></param>
-		/// <param name="param"></param>
-		/// <returns></returns>
 		public TObject SelectObject<TObject>(string whereExpression, QueryParameter param)
 			where TObject : DataObject
 		{
 			return SelectObjects<TObject>(whereExpression, param).FirstOrDefault();
 		}
 
-		/// <summary>
-		/// Retrieve a Collection of DataObjects from database based on the Where Expression and Parameters Collection
-		/// </summary>
-		/// <param name="whereExpression">Parametrized Where Expression</param>
-		/// <param name="parameters">Collection of Parameters</param>
-		/// <returns>Collection of Objects Sets for each matching Parametrized Query</returns>
 		public IList<IList<TObject>> SelectObjects<TObject>(string whereExpression, IEnumerable<IEnumerable<QueryParameter>> parameters)
 			where TObject : DataObject
 		{
@@ -822,12 +791,7 @@ namespace DOL.Database
 			
 			return objs;
 		}
-		/// <summary>
-		/// Retrieve a Collection of DataObjects from database based on the Where Expression and Parameter Collection
-		/// </summary>
-		/// <param name="whereExpression">Parametrized Where Expression</param>
-		/// <param name="parameter">Collection of Parameter</param>
-		/// <returns>Collection of Objects matching Parametrized Query</returns>
+		
 		public IList<TObject> SelectObjects<TObject>(string whereExpression, IEnumerable<QueryParameter> parameter)
 			where TObject : DataObject
 		{
@@ -836,12 +800,7 @@ namespace DOL.Database
 			
 			return SelectObjects<TObject>(whereExpression, new [] { parameter }).First();
 		}
-		/// <summary>
-		/// Retrieve a Collection of DataObjects from database based on the Where Expression and Parameter
-		/// </summary>
-		/// <param name="whereExpression">Parametrized Where Expression</param>
-		/// <param name="param">Single Parameter</param>
-		/// <returns>Collection of Objects matching Parametrized Query</returns>
+
 		public IList<TObject> SelectObjects<TObject>(string whereExpression, QueryParameter param)
 			where TObject : DataObject
 		{
@@ -853,46 +812,24 @@ namespace DOL.Database
 		#endregion
 		
 		#region Public Object Select API Without Parameters
-		/// <summary>
-		/// Retrieve a Single DataObject from database based on Where Expression
-		/// </summary>
-		/// <param name="whereExpression">Where Expression Filter</param>
-		/// <returns>Single Object or First Object if multiple matches</returns>
 		public TObject SelectObject<TObject>(string whereExpression)
 			where TObject : DataObject
 		{
 			return SelectObject<TObject>(whereExpression, Transaction.IsolationLevel.DEFAULT);
 		}
 
-		/// <summary>
-		/// Retrieve a Single DataObject from database based on Where Expression
-		/// </summary>
-		/// <param name="whereExpression">Where Expression Filter</param>
-		/// <param name="isolation">Isolation Level</param>
-		/// <returns>Single Object or First Object if multiple matches</returns>
 		public TObject SelectObject<TObject>(string whereExpression, Transaction.IsolationLevel isolation)
 			where TObject : DataObject
 		{
 			return SelectObjects<TObject>(whereExpression, isolation).FirstOrDefault();
 		}
 
-		/// <summary>
-		/// Retrieve a Collection of DataObjects from database based on Where Expression
-		/// </summary>
-		/// <param name="whereExpression">Where Expression Filter</param>
-		/// <returns>Collection of DataObjects matching filter</returns>
 		public IList<TObject> SelectObjects<TObject>(string whereExpression)
 			where TObject : DataObject
 		{
 			return SelectObjects<TObject>(whereExpression, Transaction.IsolationLevel.DEFAULT);
 		}
 
-		/// <summary>
-		/// Retrieve a Collection of DataObjects from database based on Where Expression
-		/// </summary>
-		/// <param name="whereExpression">Where Expression Filter</param>
-		/// <param name="isolation">Isolation Level</param>
-		/// <returns>Collection of DataObjects matching filter</returns>
 		public IList<TObject> SelectObjects<TObject>(string whereExpression, Transaction.IsolationLevel isolation)
 			where TObject : DataObject
 		{
@@ -901,23 +838,7 @@ namespace DOL.Database
 		#endregion
 		
 		#region Public Object Select All API
-		/// <summary>
-		/// Select all Objects From Table holding TObject Type
-		/// </summary>
-		/// <typeparam name="TObject">DataObject Type to Select</typeparam>
-		/// <returns>Collection of all DataObject for this Type</returns>
 		public IList<TObject> SelectAllObjects<TObject>()
-			where TObject : DataObject
-		{
-			return SelectAllObjects<TObject>(Transaction.IsolationLevel.DEFAULT);
-		}
-		/// <summary>
-		/// Select all Objects From Table holding TObject Type
-		/// </summary>
-		/// <typeparam name="TObject">DataObject Type to Select</typeparam>
-		/// <param name="isolation">Isolation Level</param>
-		/// <returns>Collection of all DataObject for this Type</returns>
-		public IList<TObject> SelectAllObjects<TObject>(Transaction.IsolationLevel isolation)
 			where TObject : DataObject
 		{
 			var tableHandler = GetTableOrViewHandler(typeof(TObject));
@@ -925,18 +846,24 @@ namespace DOL.Database
 			{
 				if (log.IsErrorEnabled)
 					log.ErrorFormat("SelectAllObjects: DataObject Type ({0}) not registered !", typeof(TObject).FullName);
-				
+
 				throw new DatabaseException(string.Format("Table {0} is not registered for Database Connection...", typeof(TObject).FullName));
 			}
-			
+
 			if (tableHandler.UsesPreCaching)
 				return tableHandler.SearchPreCachedObjects(obj => obj != null).OfType<TObject>().ToArray();
-			
+
 			var dataObjects = MultipleSelectObjectsImpl(tableHandler, new[] { WhereExpression.Empty }).Single().OfType<TObject>().ToArray();
-			
+
 			FillObjectRelations(dataObjects, false);
-			
+
 			return dataObjects;
+		}
+
+		public IList<TObject> SelectAllObjects<TObject>(Transaction.IsolationLevel isolation)
+			where TObject : DataObject
+		{
+			return SelectAllObjects<TObject>();
 		}
 		#endregion
 		

--- a/DOLDatabase/ObjectDatabase.cs
+++ b/DOLDatabase/ObjectDatabase.cs
@@ -714,19 +714,19 @@ namespace DOL.Database
 		#endregion
 
 		#region Public Parameterized Query Abstraction
-		public TObject SelectObject<TObject>(WhereExpression whereExpression)
+		public TObject SelectObject<TObject>(WhereClause whereExpression)
 			where TObject : DataObject
 		{
 			return SelectObjects<TObject>(whereExpression).FirstOrDefault();
 		}
 
-		public IList<TObject> SelectObjects<TObject>(WhereExpression whereExpression)
+		public IList<TObject> SelectObjects<TObject>(WhereClause whereExpression)
 			where TObject : DataObject
 		{
 			return MultipleSelectObjects<TObject>(new[] { whereExpression }).First();
 		}
 
-		public IList<IList<TObject>> MultipleSelectObjects<TObject>(IEnumerable<WhereExpression> whereExpressionBatch)
+		public IList<IList<TObject>> MultipleSelectObjects<TObject>(IEnumerable<WhereClause> whereExpressionBatch)
 			where TObject : DataObject
 		{
 			if (whereExpressionBatch == null) throw new ArgumentNullException("Parameter whereExpressionBatch may not be null.");
@@ -853,7 +853,7 @@ namespace DOL.Database
 			if (tableHandler.UsesPreCaching)
 				return tableHandler.SearchPreCachedObjects(obj => obj != null).OfType<TObject>().ToArray();
 
-			var dataObjects = MultipleSelectObjectsImpl(tableHandler, new[] { WhereExpression.Empty }).Single().OfType<TObject>().ToArray();
+			var dataObjects = MultipleSelectObjectsImpl(tableHandler, new[] { WhereClause.Empty }).Single().OfType<TObject>().ToArray();
 
 			FillObjectRelations(dataObjects, false);
 
@@ -959,7 +959,7 @@ namespace DOL.Database
 		/// <returns>Collection of DataObjects Sets matching Parametrized Where Expression</returns>
 		protected abstract IList<IList<DataObject>> SelectObjectsImpl(DataTableHandler tableHandler, string whereExpression, IEnumerable<IEnumerable<QueryParameter>> parameters, Transaction.IsolationLevel isolation);
 
-		protected abstract IList<IList<DataObject>> MultipleSelectObjectsImpl(DataTableHandler tableHandler, IEnumerable<WhereExpression> whereExpressionBatch);
+		protected abstract IList<IList<DataObject>> MultipleSelectObjectsImpl(DataTableHandler tableHandler, IEnumerable<WhereClause> whereExpressionBatch);
 
 		/// <summary>
 		/// Gets the number of objects in a given table in the database based on a given set of criteria. (where clause)

--- a/DOLDatabase/ObjectDatabase.cs
+++ b/DOLDatabase/ObjectDatabase.cs
@@ -22,7 +22,6 @@ using System.Linq;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Reflection;
-using DataTable = System.Data.DataTable;
 
 using DOL.Database.Attributes;
 using DOL.Database.Connection;

--- a/DOLDatabase/ObjectDatabase.cs
+++ b/DOLDatabase/ObjectDatabase.cs
@@ -744,7 +744,7 @@ namespace DOL.Database
 				throw new DatabaseException(string.Format("Table {0} is not registered for Database Connection...", typeof(TObject).FullName));
 			}
 
-			var objs = MultipleSelectObjectsImpl(tableHandler, whereExpressionBatch, Transaction.IsolationLevel.DEFAULT).Select(res => res.OfType<TObject>().ToArray()).ToArray();
+			var objs = MultipleSelectObjectsImpl(tableHandler, whereExpressionBatch).Select(res => res.OfType<TObject>().ToArray()).ToArray();
 
 			FillObjectRelations(objs.SelectMany(obj => obj), false);
 
@@ -932,7 +932,7 @@ namespace DOL.Database
 			if (tableHandler.UsesPreCaching)
 				return tableHandler.SearchPreCachedObjects(obj => obj != null).OfType<TObject>().ToArray();
 			
-			var dataObjects = SelectObjectsImpl(tableHandler, null, new [] { new QueryParameter[] { } }, isolation).Single().OfType<TObject>().ToArray();
+			var dataObjects = MultipleSelectObjectsImpl(tableHandler, new[] { WhereExpression.Empty }).Single().OfType<TObject>().ToArray();
 			
 			FillObjectRelations(dataObjects, false);
 			
@@ -1032,7 +1032,7 @@ namespace DOL.Database
 		/// <returns>Collection of DataObjects Sets matching Parametrized Where Expression</returns>
 		protected abstract IList<IList<DataObject>> SelectObjectsImpl(DataTableHandler tableHandler, string whereExpression, IEnumerable<IEnumerable<QueryParameter>> parameters, Transaction.IsolationLevel isolation);
 
-		protected abstract IList<IList<DataObject>> MultipleSelectObjectsImpl(DataTableHandler tableHandler, IEnumerable<WhereExpression> whereExpressionBatch, Transaction.IsolationLevel isolation);
+		protected abstract IList<IList<DataObject>> MultipleSelectObjectsImpl(DataTableHandler tableHandler, IEnumerable<WhereExpression> whereExpressionBatch);
 
 		/// <summary>
 		/// Gets the number of objects in a given table in the database based on a given set of criteria. (where clause)

--- a/DOLDatabase/ObjectDatabase.cs
+++ b/DOLDatabase/ObjectDatabase.cs
@@ -633,8 +633,8 @@ namespace DOL.Database
 			}
 			else
 			{
-				var whereExpressions = objects.Select(obj => DB.Column(remoteBind.ColumnName).IsEqualTo(localBind.GetValue(obj)));
-				objsResults = MultipleSelectObjectsImpl(remoteHandler, whereExpressions);
+				var whereClauses = objects.Select(obj => DB.Column(remoteBind.ColumnName).IsEqualTo(localBind.GetValue(obj)));
+				objsResults = MultipleSelectObjectsImpl(remoteHandler, whereClauses);
 			}
 			
 			var resultByObjs = objsResults.Select((obj, index) => new { DataObject = objects[index], Results = obj }).ToArray();
@@ -714,22 +714,22 @@ namespace DOL.Database
 		#endregion
 
 		#region Public Parameterized Query Abstraction
-		public TObject SelectObject<TObject>(WhereClause whereExpression)
+		public TObject SelectObject<TObject>(WhereClause whereClause)
 			where TObject : DataObject
 		{
-			return SelectObjects<TObject>(whereExpression).FirstOrDefault();
+			return SelectObjects<TObject>(whereClause).FirstOrDefault();
 		}
 
-		public IList<TObject> SelectObjects<TObject>(WhereClause whereExpression)
+		public IList<TObject> SelectObjects<TObject>(WhereClause whereClause)
 			where TObject : DataObject
 		{
-			return MultipleSelectObjects<TObject>(new[] { whereExpression }).First();
+			return MultipleSelectObjects<TObject>(new[] { whereClause }).First();
 		}
 
-		public IList<IList<TObject>> MultipleSelectObjects<TObject>(IEnumerable<WhereClause> whereExpressionBatch)
+		public IList<IList<TObject>> MultipleSelectObjects<TObject>(IEnumerable<WhereClause> whereClauseBatch)
 			where TObject : DataObject
 		{
-			if (whereExpressionBatch == null) throw new ArgumentNullException("Parameter whereExpressionBatch may not be null.");
+			if (whereClauseBatch == null) throw new ArgumentNullException("Parameter whereClauseBatch may not be null.");
 
 			var tableHandler = GetTableOrViewHandler(typeof(TObject));
 			if (tableHandler == null)
@@ -740,7 +740,7 @@ namespace DOL.Database
 				throw new DatabaseException(string.Format("Table {0} is not registered for Database Connection...", typeof(TObject).FullName));
 			}
 
-			var objs = MultipleSelectObjectsImpl(tableHandler, whereExpressionBatch).Select(res => res.OfType<TObject>().ToArray()).ToArray();
+			var objs = MultipleSelectObjectsImpl(tableHandler, whereClauseBatch).Select(res => res.OfType<TObject>().ToArray()).ToArray();
 
 			FillObjectRelations(objs.SelectMany(obj => obj), false);
 
@@ -959,7 +959,7 @@ namespace DOL.Database
 		/// <returns>Collection of DataObjects Sets matching Parametrized Where Expression</returns>
 		protected abstract IList<IList<DataObject>> SelectObjectsImpl(DataTableHandler tableHandler, string whereExpression, IEnumerable<IEnumerable<QueryParameter>> parameters, Transaction.IsolationLevel isolation);
 
-		protected abstract IList<IList<DataObject>> MultipleSelectObjectsImpl(DataTableHandler tableHandler, IEnumerable<WhereClause> whereExpressionBatch);
+		protected abstract IList<IList<DataObject>> MultipleSelectObjectsImpl(DataTableHandler tableHandler, IEnumerable<WhereClause> whereClauseBatch);
 
 		/// <summary>
 		/// Gets the number of objects in a given table in the database based on a given set of criteria. (where clause)

--- a/DOLDatabase/ObjectDatabase.cs
+++ b/DOLDatabase/ObjectDatabase.cs
@@ -722,9 +722,7 @@ namespace DOL.Database
 		public TObject SelectObject<TObject>(WhereExpression whereExpression)
 			where TObject : DataObject
 		{
-			var whereClause = whereExpression.WhereClause;
-			var parameters = whereExpression.QueryParameters;
-			return SelectObject<TObject>(whereClause, parameters);
+			return SelectObjects<TObject>(whereExpression).FirstOrDefault();
 		}
 
 		public IList<TObject> SelectObjects<TObject>(WhereExpression whereExpression)

--- a/DOLDatabase/SQLObjectDatabase.cs
+++ b/DOLDatabase/SQLObjectDatabase.cs
@@ -417,7 +417,7 @@ namespace DOL.Database
 			
 			var primary = columns.FirstOrDefault(col => col.PrimaryKey != null);
 			var dataObjects = new List<IList<DataObject>>();
-			ExecuteSelectImpl(command, parameters, reader => FillQueryResultList(reader, tableHandler, columns, primary, dataObjects), isolation);
+			ExecuteSelectImpl(command, parameters, reader => FillQueryResultList(reader, tableHandler, columns, primary, dataObjects));
 			
 			return dataObjects.ToArray();
 		}
@@ -549,56 +549,30 @@ namespace DOL.Database
 		/// <param name="table">Table Handler</param>
 		public abstract void CheckOrCreateTableImpl(DataTableHandler table);
 		#endregion
-		
-		#region Select Implementation
-		/// <summary>
-		/// Raw SQL Select Implementation
-		/// </summary>
-		/// <param name="SQLCommand">Command for reading</param>
-		/// <param name="Reader">Reader Method</param>
-		/// <param name="Isolation">Transaction Isolation</param>
-		protected void ExecuteSelectImpl(string SQLCommand, Action<IDataReader> Reader, Transaction.IsolationLevel Isolation)
-		{
-			ExecuteSelectImpl(SQLCommand, new [] { new QueryParameter[] { } }, Reader, Isolation);
-		}
 
-		/// <summary>
-		/// Raw SQL Select Implementation with Single Parameter for Prepared Query
-		/// </summary>
-		/// <param name="SQLCommand">Command for reading</param>
-		/// <param name="param">Parameter for Single Read</param>
-		/// <param name="Reader">Reader Method</param>
-		/// <param name="Isolation">Transaction Isolation</param>
+		#region Select Implementation
+		[Obsolete("Use ExecuteSelectImpl(string,IEnumerable<IEnumerable<QueryParameter>>,Action<IDataReader>) instead.")]
+		protected void ExecuteSelectImpl(string SQLCommand, Action<IDataReader> Reader, Transaction.IsolationLevel Isolation)
+			=> ExecuteSelectImpl(SQLCommand, new [] { new QueryParameter[] { } }, Reader);
+
+		[Obsolete("Use ExecuteSelectImpl(string,IEnumerable<IEnumerable<QueryParameter>>,Action<IDataReader>) instead.")]
 		protected void ExecuteSelectImpl(string SQLCommand, QueryParameter param, Action<IDataReader> Reader, Transaction.IsolationLevel Isolation)
-		{
-			ExecuteSelectImpl(SQLCommand, new [] { new [] { param } }, Reader, Isolation);
-		}
-		
-		/// <summary>
-		/// Raw SQL Select Implementation with Parameters for Single Prepared Query
-		/// </summary>
-		/// <param name="SQLCommand">Command for reading</param>
-		/// <param name="parameter">Collection of Parameters for Single Read</param>
-		/// <param name="Reader">Reader Method</param>
-		/// <param name="Isolation">Transaction Isolation</param>
+			=> ExecuteSelectImpl(SQLCommand, new [] { new [] { param } }, Reader);
+
+		[Obsolete("Use ExecuteSelectImpl(string,IEnumerable<IEnumerable<QueryParameter>>,Action<IDataReader>) instead.")]
 		protected void ExecuteSelectImpl(string SQLCommand, IEnumerable<QueryParameter> parameter, Action<IDataReader> Reader, Transaction.IsolationLevel Isolation)
-		{
-			ExecuteSelectImpl(SQLCommand, new [] { parameter }, Reader, Isolation);
-		}
-		
-		/// <summary>
-		/// Raw SQL Select Implementation with Parameters for Prepared Query
-		/// </summary>
-		/// <param name="SQLCommand">Command for reading</param>
-		/// <param name="parameters">Collection of Parameters for Single/Multiple Read</param>
-		/// <param name="Reader">Reader Method</param>
-		/// <param name="Isolation">Transaction Isolation</param>
+			=> ExecuteSelectImpl(SQLCommand, new [] { parameter }, Reader);
+
+		[Obsolete("Use ExecuteSelectImpl(string,IEnumerable<IEnumerable<QueryParameter>>,Action<IDataReader>) instead.")]
 		protected virtual void ExecuteSelectImpl(string SQLCommand, IEnumerable<IEnumerable<QueryParameter>> parameters, Action<IDataReader> Reader, Transaction.IsolationLevel Isolation)
+			=> ExecuteSelectImpl(SQLCommand, parameters, Reader);
+
+		protected virtual void ExecuteSelectImpl(string SQLCommand, IEnumerable<IEnumerable<QueryParameter>> parameters, Action<IDataReader> Reader)
 		{
 			if (log.IsDebugEnabled)
 				log.DebugFormat("ExecuteSelectImpl: {0}", SQLCommand);
 
-			var repeat = false;
+			bool repeat;
 			var current = 0;
 			do
 			{
@@ -641,9 +615,9 @@ namespace DOL.Database
 							}
 
 							if (log.IsDebugEnabled)
-								log.DebugFormat("ExecuteSelectImpl: SQL Select ({0}) exec time {1}ms", Isolation, ((DateTime.UtcNow.Ticks / 10000) - start));
+								log.DebugFormat("ExecuteSelectImpl: SQL Select exec time {0}ms", ((DateTime.UtcNow.Ticks / 10000) - start));
 							else if (log.IsWarnEnabled && (DateTime.UtcNow.Ticks / 10000) - start > 500)
-								log.WarnFormat("ExecuteSelectImpl: SQL Select ({0}) took {1}ms!\n{2}", Isolation, ((DateTime.UtcNow.Ticks / 10000) - start), SQLCommand);
+								log.WarnFormat("ExecuteSelectImpl: SQL Select took {0}ms!\n{1}", ((DateTime.UtcNow.Ticks / 10000) - start), SQLCommand);
 
 						}
 						catch (Exception e)

--- a/DOLDatabase/SQLObjectDatabase.cs
+++ b/DOLDatabase/SQLObjectDatabase.cs
@@ -92,7 +92,7 @@ namespace DOL.Database
 				if (dataTableHandler.UsesPreCaching)
 				{
 					var primary = dataTableHandler.PrimaryKeys.Single();
-					var objects = MultipleSelectObjectsImpl(dataTableHandler, new [] { WhereExpression.Empty }).First();
+					var objects = MultipleSelectObjectsImpl(dataTableHandler, new [] { WhereClause.Empty }).First();
 
 					foreach (var obj in objects)
 						dataTableHandler.SetPreCachedObject(primary.GetValue(obj), obj);
@@ -352,10 +352,10 @@ namespace DOL.Database
 			if (!primary.Any())
 				throw new DatabaseException(string.Format("Table {0} has no primary key for finding by key...", tableHandler.TableName));
 
-			var whereExpressions = new List<WhereExpression>();
+			var whereExpressions = new List<WhereClause>();
 			foreach (var key in keys)
 			{
-				var whereExpression = WhereExpression.Empty;
+				var whereExpression = WhereClause.Empty;
 				foreach (var column in primary)
 				{
 					whereExpression = whereExpression.And(DB.Column(column.ColumnName).IsEqualTo(key));
@@ -422,7 +422,7 @@ namespace DOL.Database
 			return dataObjects.ToArray();
 		}
 
-		protected override IList<IList<DataObject>> MultipleSelectObjectsImpl(DataTableHandler tableHandler, IEnumerable<WhereExpression> whereExpressionBatch)
+		protected override IList<IList<DataObject>> MultipleSelectObjectsImpl(DataTableHandler tableHandler, IEnumerable<WhereClause> whereExpressionBatch)
 		{
 			var columns = tableHandler.FieldElementBindings.ToArray();
 
@@ -641,7 +641,7 @@ namespace DOL.Database
 			while (repeat);
 		}
 
-		protected virtual void ExecuteSelectImpl(string selectFromExpression, IEnumerable<WhereExpression> whereExpressionBatch, Action<IDataReader> Reader)
+		protected virtual void ExecuteSelectImpl(string selectFromExpression, IEnumerable<WhereClause> whereExpressionBatch, Action<IDataReader> Reader)
 		{
 			if (!whereExpressionBatch.Any()) throw new ArgumentException("No parameter list was given.");
 
@@ -665,8 +665,8 @@ namespace DOL.Database
 
 							foreach (var whereExpression in whereExpressionBatch.Skip(current))
 							{
-								cmd.CommandText = selectFromExpression + whereExpression.WhereClause;
-								FillSQLParameter(whereExpression.QueryParameters, cmd.Parameters);
+								cmd.CommandText = selectFromExpression + whereExpression.ParameterizedText;
+								FillSQLParameter(whereExpression.Parameters, cmd.Parameters);
 								cmd.Prepare();
 
 								using (var reader = cmd.ExecuteReader())

--- a/DOLDatabase/SQLObjectDatabase.cs
+++ b/DOLDatabase/SQLObjectDatabase.cs
@@ -503,15 +503,14 @@ namespace DOL.Database
 		/// <param name="dbParams">DbParameter Object to Fill</param>
 		protected virtual void FillSQLParameter(IEnumerable<QueryParameter> parameter, DbParameterCollection dbParams)
 		{
-			// Specififc Handling for Char Cast from DB Integer
-			foreach(var param in parameter.Where(param => param.Name != null))
+			dbParams.Clear();
+			foreach(var param in parameter)
     		{
-    			if (param.Value is char)
-    				dbParams[param.Name].Value = Convert.ToUInt16(param.Value);
-    			else
-    				dbParams[param.Name].Value = param.Value;
+				dbParams.Add(ConvertToDBParameter(param));
     		}
 		}
+
+		protected abstract DbParameter ConvertToDBParameter(QueryParameter queryParameter);
 		#endregion
 		
 		#region Abstract Properties		

--- a/DOLDatabase/SQLObjectDatabase.cs
+++ b/DOLDatabase/SQLObjectDatabase.cs
@@ -414,33 +414,7 @@ namespace DOL.Database
 			
 			var primary = columns.FirstOrDefault(col => col.PrimaryKey != null);
 			var dataObjects = new List<IList<DataObject>>();
-			ExecuteSelectImpl(command, parameters, reader => {
-			                  	var list = new List<DataObject>();
-			                  	
-			                  	var data = new object[reader.FieldCount];
-			                  	while(reader.Read())
-			                  	{
-			                  		reader.GetValues(data);
-			                  		var obj = Activator.CreateInstance(tableHandler.ObjectType) as DataObject;
-			                  		
-			                  		// Fill Object
-			                  		var current = 0;
-			                  		foreach(var column in columns)
-			                  		{
-			                  			DatabaseSetValue(obj, column, data[current]);
-			                  			current++;
-			                  		}
-			                  		
-			                  		// Set Primary Key
-			                  		if (primary != null)
-			                  			obj.ObjectId = primary.GetValue(obj).ToString();
-			                  		
-									list.Add(obj);
-									obj.Dirty = false;
-									obj.IsPersisted = true;
-			                  	}
-			                  	dataObjects.Add(list.ToArray());
-			                  }, isolation);
+			ExecuteSelectImpl(command, parameters, reader => FillQueryResultList(reader, tableHandler, columns, primary, dataObjects), isolation);
 			
 			return dataObjects.ToArray();
 		}
@@ -455,44 +429,48 @@ namespace DOL.Database
 
 			var primary = columns.FirstOrDefault(col => col.PrimaryKey != null);
 			var dataObjects = new List<IList<DataObject>>();
-			ExecuteSelectImpl(selectFromExpression, whereExpressionBatch, reader => {
-				var list = new List<DataObject>();
 
-				var data = new object[reader.FieldCount];
-				while (reader.Read())
-				{
-					reader.GetValues(data);
-					var obj = Activator.CreateInstance(tableHandler.ObjectType) as DataObject;
-
-					// Fill Object
-					var current = 0;
-					foreach (var column in columns)
-					{
-						DatabaseSetValue(obj, column, data[current]);
-						current++;
-					}
-
-					// Set Primary Key
-					if (primary != null)
-						obj.ObjectId = primary.GetValue(obj).ToString();
-
-					list.Add(obj);
-					obj.Dirty = false;
-					obj.IsPersisted = true;
-				}
-				dataObjects.Add(list.ToArray());
-			}, isolation);
+			ExecuteSelectImpl(selectFromExpression, whereExpressionBatch, reader => FillQueryResultList(reader, tableHandler, columns, primary, dataObjects), isolation);
 
 			return dataObjects.ToArray();
 		}
 
-		/// <summary>
-		/// Set Value to DataObject Field according to ElementBinding
-		/// </summary>
-		/// <param name="obj">DataObject to Fill</param>
-		/// <param name="bind">ElementBinding for the targeted Member</param>
-		/// <param name="value">Object Value to Fill</param>
-		protected virtual void DatabaseSetValue(DataObject obj, ElementBinding bind, object value)
+        private void FillQueryResultList(IDataReader reader, DataTableHandler tableHandler, ElementBinding[] columns, ElementBinding primary, List<IList<DataObject>> resultList)
+		{
+            var list = new List<DataObject>();
+
+            var data = new object[reader.FieldCount];
+            while (reader.Read())
+            {
+                reader.GetValues(data);
+                var obj = Activator.CreateInstance(tableHandler.ObjectType) as DataObject;
+
+                // Fill Object
+                var current = 0;
+                foreach (var column in columns)
+                {
+                    DatabaseSetValue(obj, column, data[current]);
+                    current++;
+                }
+
+                // Set Primary Key
+                if (primary != null)
+                    obj.ObjectId = primary.GetValue(obj).ToString();
+
+                list.Add(obj);
+                obj.Dirty = false;
+                obj.IsPersisted = true;
+            }
+            resultList.Add(list.ToArray());
+        }
+
+        /// <summary>
+        /// Set Value to DataObject Field according to ElementBinding
+        /// </summary>
+        /// <param name="obj">DataObject to Fill</param>
+        /// <param name="bind">ElementBinding for the targeted Member</param>
+        /// <param name="value">Object Value to Fill</param>
+        protected virtual void DatabaseSetValue(DataObject obj, ElementBinding bind, object value)
 		{
 			if (value == null || value.GetType().IsInstanceOfType(DBNull.Value))
 				return;

--- a/DOLDatabase/SQLObjectDatabase.cs
+++ b/DOLDatabase/SQLObjectDatabase.cs
@@ -100,8 +100,8 @@ namespace DOL.Database
 			}
 			catch (Exception e)
 			{
-				if (Log.IsErrorEnabled)
-					Log.ErrorFormat("RegisterDataObject: Error While Registering Table \"{0}\"\n{1}", tableName, e);
+				if (log.IsErrorEnabled)
+					log.ErrorFormat("RegisterDataObject: Error While Registering Table \"{0}\"\n{1}", tableName, e);
 			}
 		}
 		
@@ -176,8 +176,8 @@ namespace DOL.Database
 						}
 						else
 						{
-							if (Log.IsErrorEnabled)
-								Log.ErrorFormat("Error adding data object into {0} Object = {1}, UsePrimaryAutoInc, Query = {2}", tableHandler.TableName, result.DataObject, command);
+							if (log.IsErrorEnabled)
+								log.ErrorFormat("Error adding data object into {0} Object = {1}, UsePrimaryAutoInc, Query = {2}", tableHandler.TableName, result.DataObject, command);
 							
 							success.Add(false);
 						}
@@ -200,8 +200,8 @@ namespace DOL.Database
 						}
 						else
 						{
-							if (Log.IsErrorEnabled)
-								Log.ErrorFormat("Error adding data object into {0} Object = {1} Query = {2}", tableHandler.TableName, result.DataObject, command);
+							if (log.IsErrorEnabled)
+								log.ErrorFormat("Error adding data object into {0} Object = {1} Query = {2}", tableHandler.TableName, result.DataObject, command);
 							
 							success.Add(false);
 						}
@@ -210,8 +210,8 @@ namespace DOL.Database
 			}
 			catch (Exception e)
 			{
-				if (Log.IsErrorEnabled)
-					Log.ErrorFormat("Error while adding data objects in table: {0}\n{1}", tableHandler.TableName, e);
+				if (log.IsErrorEnabled)
+					log.ErrorFormat("Error while adding data objects in table: {0}\n{1}", tableHandler.TableName, e);
 			}
 
 			return success;
@@ -261,12 +261,12 @@ namespace DOL.Database
 					}
 					else
 					{
-						if (Log.IsErrorEnabled)
+						if (log.IsErrorEnabled)
 						{
 							if (result.Result < 0)
-								Log.ErrorFormat("Error saving data object in table {0} Object = {1} --- constraint failed? {2}", tableHandler.TableName, result.DataObject, command);
+								log.ErrorFormat("Error saving data object in table {0} Object = {1} --- constraint failed? {2}", tableHandler.TableName, result.DataObject, command);
 							else
-								Log.ErrorFormat("Error saving data object in table {0} Object = {1} --- keyvalue changed? {2}\n{3}", tableHandler.TableName, result.DataObject, command, Environment.StackTrace);
+								log.ErrorFormat("Error saving data object in table {0} Object = {1} --- keyvalue changed? {2}\n{3}", tableHandler.TableName, result.DataObject, command, Environment.StackTrace);
 						}
 						success.Add(false);
 					}
@@ -274,8 +274,8 @@ namespace DOL.Database
 			}
 			catch (Exception e)
 			{
-				if (Log.IsErrorEnabled)
-					Log.ErrorFormat("Error while saving data object in table: {0}\n{1}", tableHandler.TableName, e);
+				if (log.IsErrorEnabled)
+					log.ErrorFormat("Error while saving data object in table: {0}\n{1}", tableHandler.TableName, e);
 			}
 
 			return success;
@@ -320,16 +320,16 @@ namespace DOL.Database
 					}
 					else
 					{
-						if (Log.IsErrorEnabled)
-							Log.ErrorFormat("Error deleting data object from table {0} Object = {1} --- keyvalue changed? {2}\n{3}", tableHandler.TableName, result.DataObject, command, Environment.StackTrace);
+						if (log.IsErrorEnabled)
+							log.ErrorFormat("Error deleting data object from table {0} Object = {1} --- keyvalue changed? {2}\n{3}", tableHandler.TableName, result.DataObject, command, Environment.StackTrace);
 						success.Add(false);
 					}
 				}
 			}
 			catch (Exception e)
 			{
-				if (Log.IsErrorEnabled)
-					Log.ErrorFormat("Error while deleting data object in table: {0}\n{1}", tableHandler.TableName, e);
+				if (log.IsErrorEnabled)
+					log.ErrorFormat("Error while deleting data object in table: {0}\n{1}", tableHandler.TableName, e);
 			}
 			
 			return success;
@@ -532,8 +532,8 @@ namespace DOL.Database
 			}
 			catch (Exception e)
 			{
-				if (Log.IsErrorEnabled)
-					Log.ErrorFormat("{0}: {1} = {2} doesnt fit to {3}\n{4}", obj.TableName, bind.ColumnName, value.GetType().FullName, bind.ValueType, e);
+				if (log.IsErrorEnabled)
+					log.ErrorFormat("{0}: {1} = {2} doesnt fit to {3}\n{4}", obj.TableName, bind.ColumnName, value.GetType().FullName, bind.ValueType, e);
 			}
 		}
 		
@@ -631,8 +631,8 @@ namespace DOL.Database
 			}
 			catch (Exception e)
 			{
-				if (Log.IsErrorEnabled)
-					Log.ErrorFormat("Error while executing raw query \"{0}\"\n{1}", rawQuery, e);
+				if (log.IsErrorEnabled)
+					log.ErrorFormat("Error while executing raw query \"{0}\"\n{1}", rawQuery, e);
 			}
 			
 			return false;
@@ -753,8 +753,8 @@ namespace DOL.Database
 						break;
 				}
 
-				if (Log.IsWarnEnabled)
-					Log.WarnFormat("Socket exception: ({0}) {1}; repeat: {2}", socketException.ErrorCode, socketException.Message, ret);
+				if (log.IsWarnEnabled)
+					log.WarnFormat("Socket exception: ({0}) {1}; repeat: {2}", socketException.ErrorCode, socketException.Message, ret);
 			}
 
 			return ret;

--- a/DOLDatabase/SQLObjectDatabase.cs
+++ b/DOLDatabase/SQLObjectDatabase.cs
@@ -419,18 +419,18 @@ namespace DOL.Database
 			return dataObjects.ToArray();
 		}
 
-		protected override IList<IList<DataObject>> MultipleSelectObjectsImpl(DataTableHandler tableHandler, IEnumerable<WhereExpression> whereExpressionBatch, Transaction.IsolationLevel isolation)
+		protected override IList<IList<DataObject>> MultipleSelectObjectsImpl(DataTableHandler tableHandler, IEnumerable<WhereExpression> whereExpressionBatch)
 		{
 			var columns = tableHandler.FieldElementBindings.ToArray();
 
-			string selectFromExpression = string.Format("SELECT {0} FROM `{1}` WHERE ",
+			string selectFromExpression = string.Format("SELECT {0} FROM `{1}` ",
 										string.Join(", ", columns.Select(col => string.Format("`{0}`", col.ColumnName))),
 										tableHandler.TableName);
 
 			var primary = columns.FirstOrDefault(col => col.PrimaryKey != null);
 			var dataObjects = new List<IList<DataObject>>();
 
-			ExecuteSelectImpl(selectFromExpression, whereExpressionBatch, reader => FillQueryResultList(reader, tableHandler, columns, primary, dataObjects), isolation);
+			ExecuteSelectImpl(selectFromExpression, whereExpressionBatch, reader => FillQueryResultList(reader, tableHandler, columns, primary, dataObjects));
 
 			return dataObjects.ToArray();
 		}
@@ -664,7 +664,7 @@ namespace DOL.Database
 			while (repeat);
 		}
 
-		protected virtual void ExecuteSelectImpl(string selectFromExpression, IEnumerable<WhereExpression> whereExpressionBatch, Action<IDataReader> Reader, Transaction.IsolationLevel Isolation)
+		protected virtual void ExecuteSelectImpl(string selectFromExpression, IEnumerable<WhereExpression> whereExpressionBatch, Action<IDataReader> Reader)
 		{
 			if (!whereExpressionBatch.Any()) throw new ArgumentException("No parameter list was given.");
 
@@ -712,9 +712,9 @@ namespace DOL.Database
 							}
 
 							if (log.IsDebugEnabled)
-								log.DebugFormat("ExecuteSelectImpl: SQL Select ({0}) exec time {1}ms", Isolation, ((DateTime.UtcNow.Ticks / 10000) - start));
+								log.DebugFormat("ExecuteSelectImpl: SQL Select exec time {0}ms", ((DateTime.UtcNow.Ticks / 10000) - start));
 							else if (log.IsWarnEnabled && (DateTime.UtcNow.Ticks / 10000) - start > 500)
-								log.WarnFormat("ExecuteSelectImpl: SQL Select ({0}) took {1}ms!\n{2}", Isolation, ((DateTime.UtcNow.Ticks / 10000) - start), selectFromExpression);
+								log.WarnFormat("ExecuteSelectImpl: SQL Select took {0}ms!\n{1}", ((DateTime.UtcNow.Ticks / 10000) - start), selectFromExpression);
 
 						}
 						catch (Exception e)

--- a/DOLDatabase/WhereClause.cs
+++ b/DOLDatabase/WhereClause.cs
@@ -22,7 +22,7 @@ using System.Linq;
 
 namespace DOL.Database
 {
-    public abstract class WhereExpression
+    public abstract class WhereClause
     {
         private static string alphabet = "abcdefghijklmnopqrstuvwxyz";
 
@@ -40,7 +40,7 @@ namespace DOL.Database
             return prefix + result;
         }
 
-        public virtual string WhereClause
+        public virtual string ParameterizedText
         {
             get
             {
@@ -63,7 +63,7 @@ namespace DOL.Database
             }
         }
 
-        public virtual QueryParameter[] QueryParameters
+        public virtual QueryParameter[] Parameters
         {
             get
             {
@@ -83,12 +83,12 @@ namespace DOL.Database
 
         internal abstract List<TextAtom> IntermediateRepresentation { get; }
 
-        public virtual WhereExpression And(WhereExpression rightExpression)
+        public virtual WhereClause And(WhereClause rightExpression)
             => rightExpression.Equals(Empty) ? this : new ChainingExpression(this, "AND", rightExpression);
-        public virtual WhereExpression Or(WhereExpression rightExpression) 
+        public virtual WhereClause Or(WhereClause rightExpression) 
             => rightExpression.Equals(Empty) ? this : new ChainingExpression(this, "OR", rightExpression);
 
-        public static WhereExpression Empty => new EmptyWhereExpression();
+        public static WhereClause Empty => new EmptyWhereClause();
 
         public override int GetHashCode() => base.GetHashCode();
     }
@@ -109,19 +109,19 @@ namespace DOL.Database
         public override bool IsParameterized => true;
     }
 
-    internal class EmptyWhereExpression : WhereExpression
+    internal class EmptyWhereClause : WhereClause
     {
         internal override List<TextAtom> IntermediateRepresentation => new List<TextAtom>();
 
-        public override WhereExpression And(WhereExpression rightExpression) => rightExpression;
-        public override WhereExpression Or(WhereExpression rightExpression) => rightExpression;
-        public override string WhereClause => string.Empty;
+        public override WhereClause And(WhereClause rightExpression) => rightExpression;
+        public override WhereClause Or(WhereClause rightExpression) => rightExpression;
+        public override string ParameterizedText => string.Empty;
 
-        public override bool Equals(object obj) => obj is EmptyWhereExpression;
+        public override bool Equals(object obj) => obj is EmptyWhereClause;
         public override int GetHashCode() => base.GetHashCode();
     }
 
-    internal class FilterExpression : WhereExpression
+    internal class FilterExpression : WhereClause
     {
         private string columnName;
         private string op;
@@ -168,7 +168,7 @@ namespace DOL.Database
         public override int GetHashCode() => base.GetHashCode();
     }
 
-    internal class PlainTextExpression : WhereExpression
+    internal class PlainTextExpression : WhereClause
     {
         private string columnName;
         private string op;
@@ -195,13 +195,13 @@ namespace DOL.Database
         public override int GetHashCode() => base.GetHashCode();
     }
 
-    internal class ChainingExpression : WhereExpression
+    internal class ChainingExpression : WhereClause
     {
-        private WhereExpression left;
-        private WhereExpression right;
+        private WhereClause left;
+        private WhereClause right;
         private string chainingOperator;
 
-        internal ChainingExpression(WhereExpression left, string chainingOperator, WhereExpression right)
+        internal ChainingExpression(WhereClause left, string chainingOperator, WhereClause right)
         {
             this.left = left;
             this.right = right;
@@ -251,15 +251,15 @@ namespace DOL.Database
             Name = columnName;
         }
 
-        public WhereExpression IsEqualTo(object val) => new FilterExpression(Name, "=", val);
-        public WhereExpression IsNotEqualTo(object val) => new FilterExpression(Name, "!=", val);
-        public WhereExpression IsGreatherThan(object val) => new FilterExpression(Name, ">", val);
-        public WhereExpression IsGreaterOrEqualTo(object val) => new FilterExpression(Name, ">=", val);
-        public WhereExpression IsLessThan(object val) => new FilterExpression(Name, "<", val);
-        public WhereExpression IsLessOrEqualTo(object val) => new FilterExpression(Name, "<=", val);
-        public WhereExpression IsLike(object val) => new FilterExpression(Name, "LIKE", val);
-        public WhereExpression IsNull() => new PlainTextExpression(Name, "IS NULL");
-        public WhereExpression IsNotNull() => new PlainTextExpression(Name, "IS NOT NULL");
-        public WhereExpression IsIn<T>(IEnumerable<T> values) => new FilterExpression(Name, "IN", values.Cast<object>());
+        public WhereClause IsEqualTo(object val) => new FilterExpression(Name, "=", val);
+        public WhereClause IsNotEqualTo(object val) => new FilterExpression(Name, "!=", val);
+        public WhereClause IsGreatherThan(object val) => new FilterExpression(Name, ">", val);
+        public WhereClause IsGreaterOrEqualTo(object val) => new FilterExpression(Name, ">=", val);
+        public WhereClause IsLessThan(object val) => new FilterExpression(Name, "<", val);
+        public WhereClause IsLessOrEqualTo(object val) => new FilterExpression(Name, "<=", val);
+        public WhereClause IsLike(object val) => new FilterExpression(Name, "LIKE", val);
+        public WhereClause IsNull() => new PlainTextExpression(Name, "IS NULL");
+        public WhereClause IsNotNull() => new PlainTextExpression(Name, "IS NOT NULL");
+        public WhereClause IsIn<T>(IEnumerable<T> values) => new FilterExpression(Name, "IN", values.Cast<object>());
     }
 }

--- a/DOLDatabase/WhereExpression.cs
+++ b/DOLDatabase/WhereExpression.cs
@@ -44,7 +44,7 @@ namespace DOL.Database
         {
             get
             {
-                var clause = "";
+                var clause = "WHERE ";
                 uint parameterID = 0;
                 foreach (var atom in IntermediateRepresentation)
                 {
@@ -115,6 +115,7 @@ namespace DOL.Database
 
         public override WhereExpression And(WhereExpression rightExpression) => rightExpression;
         public override WhereExpression Or(WhereExpression rightExpression) => rightExpression;
+        public override string WhereClause => string.Empty;
 
         public override bool Equals(object obj) => obj is EmptyWhereExpression;
         public override int GetHashCode() => base.GetHashCode();

--- a/DOLDatabase/WhereExpression.cs
+++ b/DOLDatabase/WhereExpression.cs
@@ -24,72 +24,9 @@ namespace DOL.Database
 {
     public abstract class WhereExpression
     {
-        public abstract string WhereClause { get; }
-        public abstract QueryParameter[] QueryParameters { get; }
-
-        public virtual WhereExpression And(WhereExpression rightExpression) => new ChainingExpression(this, "AND", rightExpression);
-        public virtual WhereExpression Or(WhereExpression rightExpression) => new ChainingExpression(this, "OR", rightExpression);
-
-        public static WhereExpression Empty => new EmptyWhereExpression();
-
-        public override int GetHashCode() => base.GetHashCode();
-    }
-
-    internal class EmptyWhereExpression : WhereExpression
-    {
-        public override string WhereClause => "";
-        public override QueryParameter[] QueryParameters => new QueryParameter[0];
-
-        public override WhereExpression And(WhereExpression rightExpression) => rightExpression;
-        public override WhereExpression Or(WhereExpression rightExpression) => rightExpression;
-
-        public override bool Equals(object obj) => obj is EmptyWhereExpression;
-        public override int GetHashCode() => base.GetHashCode();
-    }
-
-    internal class FilterExpression : WhereExpression
-    {
         private static string alphabet = "abcdefghijklmnopqrstuvwxyz";
-        private static uint placeHolderIndex = 0;
 
-        private string columnName;
-        private string op;
-        private object val;
-        private uint id;
-
-        internal FilterExpression(string columnName, string op, object val)
-        {
-            this.columnName = columnName;
-            this.op = op;
-            this.val = val;
-            id = GetID();
-        }
-
-        public override string WhereClause
-        {
-            get
-            {
-                if (op != "IN")
-                    return $"{columnName} {op} {GetPlaceHolder(id)}";
-                var values = (IEnumerable<object>)val;
-                var prefix = GetPlaceHolder(id);
-                var ids = string.Join(",", values.Select((_, i) => $"{prefix}{i}"));
-                return $"{columnName} IN ({ids})";
-            }
-        }
-        public override QueryParameter[] QueryParameters
-        {
-            get
-            {
-                if (op != "IN")
-                    return new QueryParameter[] { new QueryParameter(GetPlaceHolder(id), val) };
-                var values = (IEnumerable<object>)val;
-                var prefix = GetPlaceHolder(id);
-                return values.Select((v, i) => new QueryParameter($"{prefix}{i}", v)).ToArray();
-            }
-        }
-
-        protected static string GetPlaceHolder(uint id)
+        private string GetPlaceHolder(uint id)
         {
             var prefix = "@";
             uint radix = (uint)alphabet.Length;
@@ -103,14 +40,125 @@ namespace DOL.Database
             return prefix + result;
         }
 
-        private uint GetID() => ++placeHolderIndex - 1;
+        public virtual string WhereClause
+        {
+            get
+            {
+                var clause = "";
+                uint parameterID = 0;
+                foreach (var atom in IntermediateRepresentation)
+                {
+                    if (atom.IsParameterized)
+                    {
+                        clause += GetPlaceHolder(parameterID);
+                        parameterID++;
+                    }
+                    else
+                    {
+                        clause += atom.Val;
+                    }
+                    clause += " ";
+                }
+                return clause.Trim();
+            }
+        }
+
+        public virtual QueryParameter[] QueryParameters
+        {
+            get
+            {
+                var result = new List<QueryParameter>();
+                uint parameterID = 0;
+                foreach (var atom in IntermediateRepresentation)
+                {
+                    if (atom.IsParameterized)
+                    {
+                        result.Add(new QueryParameter(GetPlaceHolder(parameterID), atom.Val));
+                        parameterID++;
+                    }
+                }
+                return result.ToArray();
+            }
+        }
+
+        internal abstract List<TextAtom> IntermediateRepresentation { get; }
+
+        public virtual WhereExpression And(WhereExpression rightExpression)
+            => rightExpression.Equals(Empty) ? this : new ChainingExpression(this, "AND", rightExpression);
+        public virtual WhereExpression Or(WhereExpression rightExpression) 
+            => rightExpression.Equals(Empty) ? this : new ChainingExpression(this, "OR", rightExpression);
+
+        public static WhereExpression Empty => new EmptyWhereExpression();
+
+        public override int GetHashCode() => base.GetHashCode();
+    }
+
+    internal class TextAtom
+    {
+        public object Val { get; }
+
+        public TextAtom(object val) { Val = val; }
+
+        public virtual bool IsParameterized => false;
+    }
+
+    internal class ValueAtom : TextAtom
+    {
+        public ValueAtom(object val) : base(val) { }
+
+        public override bool IsParameterized => true;
+    }
+
+    internal class EmptyWhereExpression : WhereExpression
+    {
+        internal override List<TextAtom> IntermediateRepresentation => new List<TextAtom>();
+
+        public override WhereExpression And(WhereExpression rightExpression) => rightExpression;
+        public override WhereExpression Or(WhereExpression rightExpression) => rightExpression;
+
+        public override bool Equals(object obj) => obj is EmptyWhereExpression;
+        public override int GetHashCode() => base.GetHashCode();
+    }
+
+    internal class FilterExpression : WhereExpression
+    {
+        private string columnName;
+        private string op;
+        private object val;
+
+        internal FilterExpression(string columnName, string op, object val)
+        {
+            this.columnName = columnName;
+            this.op = op;
+            this.val = val;
+        }
+
+        internal override List<TextAtom> IntermediateRepresentation
+        {
+            get
+            {
+                if (val is IEnumerable<object> valueCollection && valueCollection.Any())
+                {
+                    var result = new List<TextAtom>() { new TextAtom(columnName), new TextAtom(op), new TextAtom("(") };
+                    result.Add(new ValueAtom(valueCollection.ElementAt(0)));
+                    foreach(var element in valueCollection.Skip(1))
+                    {
+                        result.Add(new TextAtom(","));
+                        result.Add(new ValueAtom(element));
+                    }
+                    result.Add(new TextAtom(")"));
+                    return result;
+                }
+                return new List<TextAtom>() { new TextAtom(columnName), new TextAtom(op), new ValueAtom(val) };
+            }
+        }
 
         public override bool Equals(object obj)
         {
             if (obj is FilterExpression filterExpression)
             {
-                return filterExpression.op.Equals(op) 
-                    && filterExpression.columnName.Equals(columnName) 
+                return filterExpression.op.Equals(op)
+                    && filterExpression.columnName.Equals(columnName)
                     && filterExpression.val.Equals(val);
             }
             return false;
@@ -130,8 +178,20 @@ namespace DOL.Database
             this.op = op;
         }
 
-        public override string WhereClause => $"{columnName} {op}";
-        public override QueryParameter[] QueryParameters => new QueryParameter[] { };
+        internal override List<TextAtom> IntermediateRepresentation
+            => new List<TextAtom>() { new TextAtom(columnName), new TextAtom(op) };
+
+        public override bool Equals(object obj)
+        {
+            if (obj is PlainTextExpression expression)
+            {
+                return expression.op.Equals(op)
+                    && expression.columnName.Equals(columnName);
+            }
+            return false;
+        }
+
+        public override int GetHashCode() => base.GetHashCode();
     }
 
     internal class ChainingExpression : WhereExpression
@@ -147,37 +207,31 @@ namespace DOL.Database
             this.chainingOperator = chainingOperator;
         }
 
-        public override string WhereClause
+        internal override List<TextAtom> IntermediateRepresentation
         {
             get
             {
-                if (right is EmptyWhereExpression) return left.WhereClause;
-                return $"({left.WhereClause} {chainingOperator} {right.WhereClause})";
-            }
-        }
+                if (right.Equals(Empty)) return left.IntermediateRepresentation;
 
-        public override QueryParameter[] QueryParameters
-        {
-            get
-            {
-                var list = new List<QueryParameter>();
-                list.AddRange(left.QueryParameters);
-                list.AddRange(right.QueryParameters);
-                return list.ToArray();
+                var result = new List<TextAtom>() { new TextAtom("(") };
+                result.AddRange(left.IntermediateRepresentation);
+                result.Add(new TextAtom(chainingOperator));
+                result.AddRange(right.IntermediateRepresentation);
+                result.Add(new TextAtom(")"));
+                return result;
             }
         }
 
         public override bool Equals(object obj)
         {
-            if (obj is ChainingExpression chainingExpression)
+            if (obj is ChainingExpression expr)
             {
-                return chainingExpression.left.Equals(left)
-                    && chainingExpression.chainingOperator.Equals(chainingOperator)
-                    && chainingExpression.right.Equals(right);
+                return expr.left.Equals(left)
+                    && expr.chainingOperator.Equals(chainingOperator)
+                    && expr.right.Equals(right);
             }
             return false;
         }
-
         public override int GetHashCode() => base.GetHashCode();
     }
 

--- a/GameServer/commands/admincommands/Account.cs
+++ b/GameServer/commands/admincommands/Account.cs
@@ -309,7 +309,7 @@ namespace DOL.GS.Commands
 							return;
 						}
 
-						var banacc = GameServer.Database.SelectObjects<DBBannedAccount>("(`Type` = @TypeA OR `Type` = @TypeB) AND `Account` = @Account", new[] { new QueryParameter("@TypeA", "A"), new QueryParameter("@TypeB", "B"), new QueryParameter("@Account", accountname) });
+						var banacc = DOLDB<DBBannedAccount>.SelectObjects(DB.Column("Type").IsEqualTo("A").Or(DB.Column("Type").IsEqualTo("B")).And(DB.Column("Account").IsEqualTo(accountname)));
 						if (banacc.Count == 0)
 						{
 							DisplayMessage(client, LanguageMgr.GetTranslation(client.Account.Language, "AdminCommands.Account.AccountNotFound", accountname));
@@ -375,7 +375,7 @@ namespace DOL.GS.Commands
 			GameClient client = WorldMgr.GetClientByPlayerName(charname, true, false);
 			if (client != null)
 				return client.Player.DBCharacter;
-			return GameServer.Database.SelectObjects<DOLCharacters>("`Name` = @Name", new QueryParameter("@Name", charname)).FirstOrDefault();
+			return DOLDB<DOLCharacters>.SelectObject(DB.Column("Name").IsEqualTo(charname));
 		}
 
 		/// <summary>
@@ -417,7 +417,7 @@ namespace DOL.GS.Commands
 			if (client != null)
 				return client.Account.Name;
 
-			DOLCharacters ch = GameServer.Database.SelectObjects<DOLCharacters>("`Name` = @Name", new QueryParameter("@Name", charname)).FirstOrDefault();
+			var ch = DOLDB<DOLCharacters>.SelectObject(DB.Column("Name").IsEqualTo(charname));
 			if (ch != null)
 				return ch.AccountName;
 			else

--- a/GameServer/commands/gmcommands/Ban.cs
+++ b/GameServer/commands/gmcommands/Ban.cs
@@ -68,7 +68,7 @@ namespace DOL.GS.Commands
 				gc = WorldMgr.GetClientByPlayerName(args[2], false, false);
 			}
 
-			Account acc = gc != null ? gc.Account : GameServer.Database.SelectObjects<Account>("`Name` LIKE @Name", new QueryParameter("@Name", args[2])).FirstOrDefault();
+			var acc = gc != null ? gc.Account : DOLDB<Account>.SelectObject(DB.Column("Name").IsLike(args[2]));
 			if (acc == null)
 			{
 				client.Out.SendMessage(LanguageMgr.GetTranslation(client.Account.Language, "GMCommands.Ban.UnableToFindPlayer"), eChatType.CT_System, eChatLoc.CL_SystemWindow);
@@ -106,7 +106,7 @@ namespace DOL.GS.Commands
 				{
 						#region Account
 					case "account":
-						var acctBans = GameServer.Database.SelectObjects<DBBannedAccount>("(`Type` = @TypeA OR `Type` = @TypeB) AND `Account` = @Account", new[] { new QueryParameter("@TypeA", "A"), new QueryParameter("@TypeB", "B"), new QueryParameter("@Account", acc.Name) });
+						var acctBans = DOLDB<DBBannedAccount>.SelectObjects(DB.Column("Type").IsEqualTo("A").Or(DB.Column("Type").IsEqualTo("B")).And(DB.Column("Account").IsEqualTo(acc.Name)));
 						if (acctBans.Count > 0)
 						{
 							client.Out.SendMessage(LanguageMgr.GetTranslation(client.Account.Language, "GMCommands.Ban.AAlreadyBanned"), eChatType.CT_Important, eChatLoc.CL_SystemWindow);
@@ -119,7 +119,7 @@ namespace DOL.GS.Commands
 						#endregion Account
 						#region IP
 					case "ip":
-						var ipBans = GameServer.Database.SelectObjects<DBBannedAccount>("(`Type` = @TypeI OR `Type` = @TypeB) AND `Ip` = @Ip", new[] { new QueryParameter("@TypeI", "I"), new QueryParameter("@TypeB", "B"), new QueryParameter("@Ip", acc.LastLoginIP) });
+						var ipBans = DOLDB<DBBannedAccount>.SelectObjects(DB.Column("Type").IsEqualTo("I").Or(DB.Column("Type").IsEqualTo("B")).And(DB.Column("Ip").IsEqualTo(acc.LastLoginIP)));
 						if (ipBans.Count > 0)
 						{
 							client.Out.SendMessage(LanguageMgr.GetTranslation(client.Account.Language, "GMCommands.Ban.IAlreadyBanned"), eChatType.CT_Important, eChatLoc.CL_SystemWindow);
@@ -132,7 +132,7 @@ namespace DOL.GS.Commands
 						#endregion IP
 						#region Both
 					case "both":
-						var acctIpBans = GameServer.Database.SelectObjects<DBBannedAccount>("`Type` = @Type AND `Account` = @Account AND `Ip` = @Ip", new[] { new QueryParameter("@Type", "B"), new QueryParameter("@Account", acc.Name), new QueryParameter("@Ip", acc.LastLoginIP) });
+						var acctIpBans = DOLDB<DBBannedAccount>.SelectObjects(DB.Column("Type").IsEqualTo("B").And(DB.Column("Account").IsEqualTo(acc.Name)).And(DB.Column("Ip").IsEqualTo(acc.LastLoginIP)));
 						if (acctIpBans.Count > 0)
 						{
 							client.Out.SendMessage(LanguageMgr.GetTranslation(client.Account.Language, "GMCommands.Ban.BAlreadyBanned"), eChatType.CT_Important, eChatLoc.CL_SystemWindow);

--- a/GameServer/commands/gmcommands/GMinfo.cs
+++ b/GameServer/commands/gmcommands/GMinfo.cs
@@ -298,7 +298,7 @@ namespace DOL.GS.Commands
 					info.Add("");
 					info.Add(" + Loot:");
 
-					var template = GameServer.Database.SelectObjects<LootTemplate>("`TemplateName` = @TemplateName", new QueryParameter("@TemplateName", target.Name));
+					var template = DOLDB<LootTemplate>.SelectObjects(DB.Column("TemplateName").IsEqualTo(target.Name));
 					foreach (LootTemplate loot in template)
 					{
 						ItemTemplate drop = GameServer.Database.FindObjectByKey<ItemTemplate>(loot.ItemTemplateID);

--- a/GameServer/commands/gmcommands/KeepComponent.cs
+++ b/GameServer/commands/gmcommands/KeepComponent.cs
@@ -300,7 +300,7 @@ namespace DOL.GS.Commands
                             return;
                         }
 
-                        DBKeepComponent dbcomponent = GameServer.Database.SelectObjects<DBKeepComponent>("`KeepID` = @KeepID AND `ID` = @ID", new [] { new QueryParameter("@KeepID", component.Keep.KeepID), new QueryParameter("@ID", component.ID) }).FirstOrDefault();
+                        var dbcomponent = DOLDB<DBKeepComponent>.SelectObject(DB.Column("KeepID").IsEqualTo(component.Keep.KeepID).And(DB.Column("ID").IsEqualTo(component.ID)));
                         component.ComponentX = dbcomponent.X;
                         component.ComponentY = dbcomponent.Y;
                         component.ComponentHeading = dbcomponent.Heading;

--- a/GameServer/commands/gmcommands/Player.cs
+++ b/GameServer/commands/gmcommands/Player.cs
@@ -118,7 +118,7 @@ namespace DOL.GS.Commands
                         if (player == null)
                             player = client.Player;
 
-                        var character = GameServer.Database.SelectObjects<DOLCharacters>("`Name` = @Name", new QueryParameter("@Name", args[2])).FirstOrDefault();
+                        var character = DOLDB<DOLCharacters>.SelectObject(DB.Column("Name").IsEqualTo(args[2]));
 
                         if (character != null)
                         {

--- a/GameServer/commands/gmcommands/door.cs
+++ b/GameServer/commands/gmcommands/door.cs
@@ -163,7 +163,7 @@ namespace DOL.GS.Commands
 
 		private void add(GameClient client, GameDoor targetDoor)
 		{
-			var DOOR = GameServer.Database.SelectObjects<DBDoor>("`InternalID` = @InternalID", new QueryParameter("@InternalID", DoorID)).FirstOrDefault();
+			var DOOR = DOLDB<DBDoor>.SelectObject(DB.Column("InternalID").IsEqualTo(DoorID));
 
 			if (DOOR != null)
 			{
@@ -228,7 +228,7 @@ namespace DOL.GS.Commands
 
 		private void delete(GameClient client, GameDoor targetDoor)
 		{
-			var DOOR = GameServer.Database.SelectObjects<DBDoor>("`InternalID` = @InternalID", new QueryParameter("@InternalID", DoorID)).FirstOrDefault();
+			var DOOR = DOLDB<DBDoor>.SelectObject(DB.Column("InternalID").IsEqualTo(DoorID));
 
 			if (DOOR != null)
 			{

--- a/GameServer/commands/gmcommands/item.cs
+++ b/GameServer/commands/gmcommands/item.cs
@@ -1565,34 +1565,27 @@ namespace DOL.GS.Commands
 
 							SalvageYield salvageYield = null;
 							bool calculated = true;
-							string sql = "";
+							var whereClause = WhereExpression.Empty;
 
 							int salvageLevel = CraftingMgr.GetItemCraftLevel(item) / 100;
 							if (salvageLevel > 9) salvageLevel = 9; // max 9
 
-							List<QueryParameter> qp = new List<QueryParameter>();
-
 							if (item.SalvageYieldID == 0)
 							{
-								sql = "`ObjectType` = @objectype AND `SalvageLevel` = @salvagelvl";
-								qp.Add(new QueryParameter("@objectype", item.Object_Type));
-								qp.Add(new QueryParameter("@salvagelvl", salvageLevel));
+								whereClause = DB.Column("ObjectType").IsEqualTo(item.Object_Type).And(DB.Column("SalvageLevel").IsEqualTo(salvageLevel));
 							}
 							else
 							{
-								sql = "`ID` = @salvageyieldid";
-								qp.Add(new QueryParameter("@salvageyieldid", item.SalvageYieldID));
+								whereClause = DB.Column("ID").IsEqualTo(item.SalvageYieldID);
 								calculated = false;
 							}
 
 							if (ServerProperties.Properties.USE_SALVAGE_PER_REALM)
 							{
-								// Some items use realm, some do not, so allow a find of either a set realm, or 0
-								sql += " AND (`Realm` = 0 OR `Realm` = @realm )";
-								qp.Add(new QueryParameter("@realm", item.Realm));
+								whereClause = whereClause.And(DB.Column("Realm").IsEqualTo((int)eRealm.None).Or(DB.Column("Realm").IsEqualTo(item.Realm)));
 							}
 
-							salvageYield = GameServer.Database.SelectObject<SalvageYield>(sql, qp);
+							salvageYield = DOLDB<SalvageYield>.SelectObject(whereClause);
 
 							SalvageYield yield = null;
 
@@ -1879,7 +1872,7 @@ namespace DOL.GS.Commands
 							string name = string.Join(" ", args, 2, args.Length - 2);
 							if (name != "")
 							{
-								var items = GameServer.Database.SelectObjects<ItemTemplate>("`id_nb` LIKE @id_nb", new QueryParameter("@id_nb", string.Format("%{0}%", name)));
+								var items = DOLDB<ItemTemplate>.SelectObjects(DB.Column("id_nb").IsLike($"%{name}%"));
 								DisplayMessage(client, LanguageMgr.GetTranslation(client.Account.Language, "GMCommands.Item.FindID.MatchingIDsForX", name, items.Count), new object[] { });
 								foreach (ItemTemplate item in items)
 								{
@@ -1895,7 +1888,7 @@ namespace DOL.GS.Commands
 							string name = string.Join(" ", args, 2, args.Length - 2);
 							if (name != "")
 							{
-								var items = GameServer.Database.SelectObjects<ItemTemplate>("`name` LIKE @name", new QueryParameter("@name", string.Format("%{0}%", name)));
+								var items = DOLDB<ItemTemplate>.SelectObjects(DB.Column("name").IsLike($"%{name}%"));
 								DisplayMessage(client, LanguageMgr.GetTranslation(client.Account.Language, "GMCommands.Item.FindName.MatchingNamesForX", name, items.Count), new object[] { });
 								foreach (ItemTemplate item in items)
 								{
@@ -1928,7 +1921,7 @@ namespace DOL.GS.Commands
 							{
 								if (args[2] == "**all**") args[2] = String.Empty;
 
-								var packageItems = GameServer.Database.SelectObjects<ItemTemplate>("`PackageID` = @PackageID", new QueryParameter("@PackageID", args[2]));
+								var packageItems = DOLDB<ItemTemplate>.SelectObjects(DB.Column("PackageID").IsEqualTo(args[2]));
 
 								if (packageItems != null)
 								{

--- a/GameServer/commands/gmcommands/item.cs
+++ b/GameServer/commands/gmcommands/item.cs
@@ -1565,7 +1565,7 @@ namespace DOL.GS.Commands
 
 							SalvageYield salvageYield = null;
 							bool calculated = true;
-							var whereClause = WhereExpression.Empty;
+							var whereClause = WhereClause.Empty;
 
 							int salvageLevel = CraftingMgr.GetItemCraftLevel(item) / 100;
 							if (salvageLevel > 9) salvageLevel = 9; // max 9

--- a/GameServer/commands/gmcommands/merchant.cs
+++ b/GameServer/commands/gmcommands/merchant.cs
@@ -146,7 +146,7 @@ namespace DOL.GS.Commands
 					{
 						string currentID = targetMerchant.TradeItems.ItemsListID;
 
-						var itemList = GameServer.Database.SelectObjects<MerchantItem>("`ItemListID` = @ItemListID", new QueryParameter("@ItemListID", currentID));
+						var itemList = DOLDB<MerchantItem>.SelectObjects(DB.Column("ItemListID").IsEqualTo(currentID));
 						foreach (MerchantItem merchantItem in itemList)
 						{
 							MerchantItem item = new MerchantItem();
@@ -267,8 +267,7 @@ namespace DOL.GS.Commands
 												return;
 											}
 
-											MerchantItem item = GameServer.Database.SelectObjects<MerchantItem>("`ItemListID` = @ItemListID AND `PageNumber` = @PageNumber AND `SlotPosition` = @SlotPosition",
-											                                                                   new [] { new QueryParameter("@ItemListID", targetMerchant.TradeItems.ItemsListID), new QueryParameter("@PageNumber", page), new QueryParameter("@SlotPosition", slot) } ).FirstOrDefault();
+											var item = DOLDB<MerchantItem>.SelectObject(DB.Column("ItemListID").IsEqualTo(targetMerchant.TradeItems.ItemsListID).And(DB.Column("PageNumber").IsEqualTo(page)).And(DB.Column("SlotPosition").IsEqualTo(slot)));
 											if (item == null)
 											{
 												item = new MerchantItem();
@@ -327,8 +326,7 @@ namespace DOL.GS.Commands
 												return;
 											}
 
-											MerchantItem item = GameServer.Database.SelectObjects<MerchantItem>("`ItemListID` = @ItemListID AND `PageNumber` = @PageNumber AND `SlotPosition` = @SlotPosition",
-											                                                                   new [] { new QueryParameter("@ItemListID", targetMerchant.TradeItems.ItemsListID), new QueryParameter("@PageNumber", page), new QueryParameter("@SlotPosition", slot) } ).FirstOrDefault();
+											MerchantItem item = DOLDB<MerchantItem>.SelectObject(DB.Column("ItemListID").IsEqualTo(targetMerchant.TradeItems.ItemsListID).And(DB.Column("PageNumber").IsEqualTo(page)).And(DB.Column("SlotPosition").IsEqualTo(slot)));
 											if (item == null)
 											{
 												DisplayMessage(client, LanguageMgr.GetTranslation(client.Account.Language, "GMCommands.Merchant.Articles.Remove.SlotInPageIsAEmpty", slot, page));
@@ -365,7 +363,7 @@ namespace DOL.GS.Commands
 											}
 											DisplayMessage(client, LanguageMgr.GetTranslation(client.Account.Language, "GMCommands.Merchant.Articles.Delete.DeletingListTemp"));
 
-											var merchantitems = GameServer.Database.SelectObjects<MerchantItem>("`ItemListID` = @ItemListID", new QueryParameter("@ItemListID", targetMerchant.TradeItems.ItemsListID));
+											var merchantitems = DOLDB<MerchantItem>.SelectObjects(DB.Column("ItemListID").IsEqualTo(targetMerchant.TradeItems.ItemsListID));
 											if (merchantitems.Count > 0)
 											{
 												GameServer.Database.DeleteObject(merchantitems);

--- a/GameServer/commands/gmcommands/mob.cs
+++ b/GameServer/commands/gmcommands/mob.cs
@@ -926,7 +926,7 @@ namespace DOL.GS.Commands
 			{
 				string raceName = string.Join(" ", args, 2, args.Length - 2);
 
-				Race npcRace = GameServer.Database.SelectObjects<Race>("`Name` = @Name", new QueryParameter("@Name", raceName)).FirstOrDefault();
+				var npcRace = DOLDB<Race>.SelectObject(DB.Column("Name").IsEqualTo(raceName));
 
 				if (npcRace == null)
 				{
@@ -1049,15 +1049,15 @@ namespace DOL.GS.Commands
 
 			if (args.Length > 2 && args[2] == "true")
 			{
-				var mobs = GameServer.Database.SelectObjects<Mob>("`Name` = @Name", new QueryParameter("@Name", mobName)).FirstOrDefault();
+				var mobs = DOLDB<Mob>.SelectObject(DB.Column("Name").IsEqualTo(mobName));
 
 				if (mobs == null)
 				{
-					var deleteLoots = GameServer.Database.SelectObjects<MobXLootTemplate>("`MobName` = @MobName", new QueryParameter("@MobName", mobName));
+					var deleteLoots = DOLDB<MobXLootTemplate>.SelectObjects(DB.Column("MobName").IsEqualTo(mobName));
 
 					GameServer.Database.DeleteObject(deleteLoots);
 
-					var deleteLootTempl = GameServer.Database.SelectObjects<LootTemplate>("`TemplateName` = @TemplateName", new QueryParameter("@TemplateName", mobName));
+					var deleteLootTempl = DOLDB<LootTemplate>.SelectObjects(DB.Column("TemplateName").IsEqualTo(mobName));
 					
 					GameServer.Database.DeleteObject(deleteLootTempl);
 
@@ -1863,7 +1863,7 @@ namespace DOL.GS.Commands
 						{
 							bool replace = (args.Length > 4 && args[4].ToLower() == "replace");
 
-							var existingTemplates = GameServer.Database.SelectObjects<NPCEquipment>("`TemplateID` = @TemplateID", new QueryParameter("@TemplateID", args[3]));
+							var existingTemplates = DOLDB<NPCEquipment>.SelectObjects(DB.Column("TemplateID").IsEqualTo(args[3]));
 
 							if (existingTemplates.Count > 0)
 							{
@@ -1949,8 +1949,7 @@ namespace DOL.GS.Commands
 
 		private void dropcount<T>(GameClient client, GameNPC targetMob, string[] args) where T : MobXLootTemplate
 		{
-			T mxlt =
-				GameServer.Database.SelectObjects<T>("`MobName` = @MobName AND `LootTemplateName` = @LootTemplateName", new [] { new QueryParameter("@MobName", targetMob.Name), new QueryParameter("@LootTemplateName", targetMob.Name) }).FirstOrDefault();
+			var mxlt = DOLDB<T>.SelectObject(DB.Column("MobName").IsEqualTo(targetMob.Name).And(DB.Column("LootTemplateName").IsEqualTo(targetMob.Name)));
 
 			if (args.Length < 3)
 			{
@@ -2010,8 +2009,7 @@ namespace DOL.GS.Commands
 					return;
 				}
 
-				var template =
-					GameServer.Database.SelectObjects<LootTemplateType>("`TemplateName` = @TemplateName AND `ItemTemplateID` = @ItemTemplateID", new[] { new QueryParameter("@TemplateName", name), new QueryParameter("@ItemTemplateID", lootTemplateID) });
+				var template = DOLDB<LootTemplateType>.SelectObjects(DB.Column("TemplateName").IsEqualTo(name).And(DB.Column("ItemTemplateID").IsEqualTo(lootTemplateID)));
 				if (template != null)
 				{
 					GameServer.Database.DeleteObject(template);
@@ -2055,8 +2053,7 @@ namespace DOL.GS.Commands
 						eChatType.CT_System, eChatLoc.CL_SystemWindow);
 				}
 
-				MobXLootType mxlt =
-					GameServer.Database.SelectObjects<MobXLootType>("`MobName` = @MobName AND `LootTemplateName` = @LootTemplateName", new [] { new QueryParameter("@MobName", targetMob.Name), new QueryParameter("@LootTemplateName", name) }).FirstOrDefault();
+				var mxlt = DOLDB<MobXLootType>.SelectObject(DB.Column("MobName").IsEqualTo(targetMob.Name).And(DB.Column("LootTemplateName").IsEqualTo(name)));
 
 				if (mxlt == null)
 				{
@@ -2091,7 +2088,7 @@ namespace DOL.GS.Commands
 					return;
 				}
 
-				LootOTD otd = GameServer.Database.SelectObjects<LootOTD>("`MobName` = @MobName AND `ItemTemplateID` = @ItemTemplateID", new [] { new QueryParameter("@MobName", mobName), new QueryParameter("@ItemTemplateID", itemTemplateID) }).FirstOrDefault();
+				var otd = DOLDB<LootOTD>.SelectObject(DB.Column("MobName").IsEqualTo(mobName).And(DB.Column("ItemTemplateID").IsEqualTo(itemTemplateID)));
 
 				if (otd != null)
 				{
@@ -2150,7 +2147,7 @@ namespace DOL.GS.Commands
 				var text = new List<string>();
 				text.Add("");
 
-				IList<LootOTD> otds = GameServer.Database.SelectObjects<LootOTD>("`MobName` = @MobName", new QueryParameter("@MobName", targetMob.Name));
+				IList<LootOTD> otds = DOLDB<LootOTD>.SelectObjects(DB.Column("MobName").IsEqualTo(targetMob.Name));
 
 				if (otds != null && otds.Count > 0)
 				{
@@ -2201,14 +2198,14 @@ namespace DOL.GS.Commands
 			if (mob.NPCTemplate != null)
 			{
 				fromNPCT = true;
-				mobXloot = GameServer.Database.SelectObjects<MobDropTemplateType>("`MobName` = @MobName", new QueryParameter("@MobName", mob.NPCTemplate.TemplateId));
+				mobXloot = DOLDB<MobDropTemplateType>.SelectObjects(DB.Column("MobName").IsEqualTo(mob.NPCTemplate.TemplateId));
 			}
-			if (mobXloot==null || (mobXloot!=null && mobXloot.Count()==0)) mobXloot = GameServer.Database.SelectObjects<MobDropTemplateType>("`MobName` = @MobName", new QueryParameter("@MobName", mobName));
+			if (mobXloot==null || (mobXloot!=null && mobXloot.Count()==0)) mobXloot = DOLDB<MobDropTemplateType>.SelectObjects(DB.Column("MobName").IsEqualTo(mobName));
 			
 			foreach (var mobXtemplate in mobXloot)
 			{
 				didDefault = didDefault || mobXtemplate.LootTemplateName == mobName;
-				var template = GameServer.Database.SelectObjects<LootTemplateType>("`TemplateName` = @TemplateName", new QueryParameter("@TemplateName", mobXtemplate.LootTemplateName));
+				var template = DOLDB<LootTemplateType>.SelectObjects(DB.Column("TemplateName").IsEqualTo(mobXtemplate.LootTemplateName));
 				if (template.Count > 0)
 					text.Add("+ Mob's template [from " + (fromNPCT?mob.NPCTemplate.TemplateId.ToString():mobName) + "]: "+ mobXtemplate.LootTemplateName + " (DropCount: " + mobXtemplate.DropCount + ")");
 				text.AddRange(
@@ -2220,7 +2217,7 @@ namespace DOL.GS.Commands
 			}
 			if (!didDefault)
 			{
-				var template = GameServer.Database.SelectObjects<LootTemplateType>("`TemplateName` = @TemplateName", new QueryParameter("@TemplateName", mobName));
+				var template = DOLDB<LootTemplateType>.SelectObjects(DB.Column("TemplateName").IsEqualTo(mobName));
 				if (template.Count > 0)
 					text.Add("+ Default: ");
 				text.AddRange(
@@ -2240,7 +2237,7 @@ namespace DOL.GS.Commands
 
 			if (lootTemplateID.ToLower() == "all items")
 			{
-				var template = GameServer.Database.SelectObjects<LootTemplateType>("`TemplateName` = @TemplateName", new QueryParameter("@TemplateName", name));
+				var template = DOLDB<LootTemplateType>.SelectObjects(DB.Column("TemplateName").IsEqualTo(name));
 
 				if (template != null && template.Count > 0)
 				{
@@ -2262,7 +2259,7 @@ namespace DOL.GS.Commands
 			}
 			else
 			{
-				IList<LootTemplateType> template = GameServer.Database.SelectObjects<LootTemplateType>("`TemplateName` = @TemplateName AND `ItemTemplateID` = @ItemTemplateID", new [] { new QueryParameter("@TemplateName", name), new QueryParameter("@ItemTemplateID", lootTemplateID) });
+				IList<LootTemplateType> template = DOLDB<LootTemplateType>.SelectObjects(DB.Column("TemplateName").IsEqualTo(name).And(DB.Column("ItemTemplateID").IsEqualTo(lootTemplateID)));
 
 				if (template != null && template.Count > 0)
 				{
@@ -2284,7 +2281,7 @@ namespace DOL.GS.Commands
 			string itemTemplateID = args[2];
 			string name = targetMob.Name;
 
-			IList<LootOTD> template = GameServer.Database.SelectObjects<LootOTD>("`MobName` = @MobName AND `ItemTemplateID` = @ItemTemplateID", new[] { new QueryParameter("@MobName", name), new QueryParameter("@ItemTemplateID", itemTemplateID) });
+			IList<LootOTD> template = DOLDB<LootOTD>.SelectObjects(DB.Column("MobName").IsEqualTo(name).And(DB.Column("ItemTemplateID").IsEqualTo(itemTemplateID)));
 
 			if (template != null)
 			{
@@ -2454,7 +2451,7 @@ namespace DOL.GS.Commands
 			{
 				string mobName = string.Join(" ", args, 2, args.Length - 2);
 
-				Mob dbMob = GameServer.Database.SelectObjects<Mob>("`Name` = @Name", new QueryParameter("@Name", mobName)).FirstOrDefault();
+				var dbMob = DOLDB<Mob>.SelectObject(DB.Column("Name").IsEqualTo(mobName));
 
 				if (dbMob != null)
 				{
@@ -3041,7 +3038,7 @@ namespace DOL.GS.Commands
 				maxreturn = 10;
 			}
 
-			var mobs = GameServer.Database.SelectObjects<Mob>("`Name` LIKE @Name", new QueryParameter("@Name", string.Format("%{0}%", args[2]))).OrderByDescending(m => m.Level).Take(maxreturn).ToArray();
+			var mobs = DOLDB<Mob>.SelectObjects(DB.Column("Name").IsLike($"%{args[2]}%")).OrderByDescending(m => m.Level).Take(maxreturn).ToArray();
 			if (mobs != null && mobs.Length > 0)
 			{
 				string mnames = "Found : \n";

--- a/GameServer/commands/gmcommands/zone.cs
+++ b/GameServer/commands/gmcommands/zone.cs
@@ -66,7 +66,7 @@ namespace DOL.GS.Commands
 					info.Add(" Zone Waterlevel: " + client.Player.CurrentZone.Waterlevel);
 
 					zone = WorldMgr.GetZone(client.Player.CurrentZone.ID);
-					Zones dbZone = GameServer.Database.SelectObjects<Zones>("`ZoneID` = @ZoneID AND `RegionID` = @RegionID", new [] { new QueryParameter("@ZoneID", zone.ID), new QueryParameter("@RegionID", zone.ZoneRegion.ID) } ).FirstOrDefault();
+					var dbZone = DOLDB<Zones>.SelectObject(DB.Column("ZoneID").IsEqualTo(zone.ID).And(DB.Column("RegionID").IsEqualTo(zone.ZoneRegion.ID)));
 
 					if (dbZone != null)
 					{
@@ -100,7 +100,7 @@ namespace DOL.GS.Commands
 					else
 						zone.IsDivingEnabled = false;
 
-					Zones dbZone = GameServer.Database.SelectObjects<Zones>("`ZoneID` = @ZoneID AND `RegionID` = @RegionID", new [] { new QueryParameter("@ZoneID", zone.ID), new QueryParameter("@RegionID", zone.ZoneRegion.ID) } ).FirstOrDefault();
+					var dbZone = DOLDB<Zones>.SelectObject(DB.Column("ZoneID").IsEqualTo(zone.ID).And(DB.Column("RegionID").IsEqualTo(zone.ZoneRegion.ID)));
 					dbZone.DivingFlag = divingFlag;
 					GameServer.Database.SaveObject(dbZone);
 
@@ -123,7 +123,7 @@ namespace DOL.GS.Commands
 					int waterlevel = Convert.ToInt32(args[2]);
 					zone.Waterlevel = waterlevel;
 
-					Zones dbZone = GameServer.Database.SelectObjects<Zones>("`ZoneID` = @ZoneID AND `RegionID` = @RegionID", new [] { new QueryParameter("@ZoneID", zone.ID), new QueryParameter("@RegionID", zone.ZoneRegion.ID) } ).FirstOrDefault();
+					var dbZone = DOLDB<Zones>.SelectObject(DB.Column("ZoneID").IsEqualTo(zone.ID).And(DB.Column("RegionID").IsEqualTo(zone.ZoneRegion.ID)));
 					dbZone.WaterLevel = waterlevel;
 					GameServer.Database.SaveObject(dbZone);
 
@@ -216,7 +216,7 @@ namespace DOL.GS.Commands
             }
 
             //find the zone.
-            Zones dbZone = GameServer.Database.SelectObjects<Zones>("`ZoneID` = @ZoneID AND `RegionID` = @RegionID", new [] { new QueryParameter("@ZoneID", zone.ID), new QueryParameter("@RegionID", zone.ZoneRegion.ID) } ).FirstOrDefault();
+            var dbZone = DOLDB<Zones>.SelectObject(DB.Column("ZoneID").IsEqualTo(zone.ID).And(DB.Column("RegionID").IsEqualTo(zone.ZoneRegion.ID)));
             //update the zone bonuses.
             dbZone.Bountypoints = zone.BonusBountypoints;
             dbZone.Realmpoints = zone.BonusRealmpoints;

--- a/GameServer/commands/playercommands/guild.cs
+++ b/GameServer/commands/playercommands/guild.cs
@@ -478,7 +478,7 @@ namespace DOL.GS.Commands
 								if (myclient == null)
 								{
 									// Patch 1.84: look for offline players
-									obj = GameServer.Database.SelectObjects<DOLCharacters>("`Name` = @Name", new QueryParameter("@Name", playername)).FirstOrDefault();
+									obj = DOLDB<DOLCharacters>.SelectObject(DB.Column("Name").IsEqualTo(playername));
 								}
 								else
 									obj = myclient.Player;
@@ -556,7 +556,7 @@ namespace DOL.GS.Commands
 
 							string playername = String.Join(" ", args, 2, args.Length - 2);
 							// Patch 1.84: look for offline players
-							var chs = GameServer.Database.SelectObjects<DOLCharacters>("`AccountName` = @AccountName AND `GuildID` = @GuildID", new[] { new QueryParameter("@AccountName", playername), new QueryParameter("@GuildID", client.Player.GuildID) });
+							var chs = DOLDB<DOLCharacters>.SelectObjects(DB.Column("AccountName").IsEqualTo(playername).And(DB.Column("GuildID").IsEqualTo(client.Player.GuildID)));
 							if (chs.Count > 0)
 							{
 								GameClient myclient = WorldMgr.GetClientByAccountName(playername, false);
@@ -1292,7 +1292,7 @@ namespace DOL.GS.Commands
 								if (onlineClient == null)
 								{
 									// Patch 1.84: look for offline players
-									obj = GameServer.Database.SelectObjects<DOLCharacters>("`Name` = @Name", new QueryParameter("@Name", playerName)).FirstOrDefault();
+									obj = DOLDB<DOLCharacters>.SelectObject(DB.Column("Name").IsEqualTo(playerName));
 									useDB = true;
 								}
 								else
@@ -1429,7 +1429,7 @@ namespace DOL.GS.Commands
 								if (myclient == null)
 								{
 									// Patch 1.84: look for offline players
-									obj = GameServer.Database.SelectObjects<DOLCharacters>("`Name` = @Name", new QueryParameter("@Name", playername)).FirstOrDefault();
+									obj = DOLDB<DOLCharacters>.SelectObject(DB.Column("Name").IsEqualTo(playername));
 								}
 								else
 									obj = myclient.Player;
@@ -1694,9 +1694,7 @@ namespace DOL.GS.Commands
 								}
 								else
 								{
-									DOLCharacters c = GameServer.Database.SelectObjects<DOLCharacters>("`Name` = @Name", new QueryParameter("@Name", playername)).FirstOrDefault();
-									//if (c == null)
-									//c = (Character)GameServer.Database.SelectObject<CharacterArchive>("Name = '" + GameServer.Database.Escape(playername) + "'");
+									DOLCharacters c = DOLDB<DOLCharacters>.SelectObject(DB.Column("Name").IsEqualTo(playername));
 
 									if (c == null)
 									{
@@ -1707,8 +1705,8 @@ namespace DOL.GS.Commands
 									accountId = c.AccountName;
 								}
 								List<DOLCharacters> chars = new List<DOLCharacters>();
-								chars.AddRange(GameServer.Database.SelectObjects<DOLCharacters>("`AccountName` = @AccountName", new QueryParameter("@AccountName", accountId)));
-								//chars.AddRange((Character[])GameServer.Database.SelectObjects<CharacterArchive>("AccountID = '" + accountId + "'"));
+								chars.AddRange(DOLDB<DOLCharacters>.SelectObjects(DB.Column("AccountName").IsEqualTo(accountId)));
+								//chars.AddRange((Character[])DOLDB<CharacterArchive>.SelectObjects("AccountID = '" + accountId + "'"));
 
 								foreach (DOLCharacters ply in chars)
 								{
@@ -1728,9 +1726,7 @@ namespace DOL.GS.Commands
 								}
 								else
 								{
-									DOLCharacters c = GameServer.Database.SelectObjects<DOLCharacters>("`Name` = @Name", new QueryParameter("@Name", args[2])).FirstOrDefault();
-									//if (c == null)
-									//    c = (Character)GameServer.Database.SelectObject<CharacterArchive>("Name = '" + GameServer.Database.Escape(args[2]) + "'");
+									var c = DOLDB<DOLCharacters>.SelectObject(DB.Column("Name").IsEqualTo(args[2]));
 									if (c == null)
 									{
 										client.Out.SendMessage(LanguageMgr.GetTranslation(client.Account.Language, "Scripts.Player.Guild.PlayerNotFound"), eChatType.CT_System, eChatLoc.CL_SystemWindow);

--- a/GameServer/commands/playercommands/train.cs
+++ b/GameServer/commands/playercommands/train.cs
@@ -92,7 +92,7 @@ namespace DOL.GS.Commands
 			string line = string.Join(" ", args, 1, args.Length - 2);
 			line = GameServer.Database.Escape(line);
 
-			var dbSpec = GameServer.Database.SelectObjects<DBSpecialization>("`KeyName` LIKE @KeyName", new QueryParameter("@KeyName", string.Format("{0}%", line))).FirstOrDefault();
+			var dbSpec = DOLDB<DBSpecialization>.SelectObject(DB.Column("KeyName").IsLike($"{line}%"));
 
 			Specialization spec = null;
 

--- a/GameServer/craft/Recipe.cs
+++ b/GameServer/craft/Recipe.cs
@@ -172,7 +172,7 @@ namespace DOL.GS
             ItemTemplate product = GameServer.Database.FindObjectByKey<ItemTemplate>(dbRecipe.Id_nb);
             if (product == null) throw new ArgumentException("Product ItemTemplate " + dbRecipe.Id_nb + " for Recipe with ID " + dbRecipe.CraftedItemID + " does not exist.");
 
-            IList<DBCraftedXItem> rawMaterials = GameServer.Database.SelectObjects<DBCraftedXItem>("`CraftedItemId_nb` = @CraftedItemId_nb", new QueryParameter("@CraftedItemId_nb", dbRecipe.Id_nb));
+            var rawMaterials = DOLDB<DBCraftedXItem>.SelectObjects(DB.Column("CraftedItemId_nb").IsEqualTo(dbRecipe.Id_nb));
             if (rawMaterials.Count == 0) throw new ArgumentException("Recipe with ID " + dbRecipe.CraftedItemID + " has no ingredients.");
 
             bool isRecipeValid = true;

--- a/GameServer/craft/Salvage.cs
+++ b/GameServer/craft/Salvage.cs
@@ -73,7 +73,7 @@ namespace DOL.GS
 			int salvageLevel = CraftingMgr.GetItemCraftLevel(item) / 100;
 			if(salvageLevel > 9) salvageLevel = 9; // max 9
 
-			var whereClause = WhereExpression.Empty;
+			var whereClause = WhereClause.Empty;
 
 			if (item.SalvageYieldID == 0)
 			{

--- a/GameServer/database/DOLDB.cs
+++ b/GameServer/database/DOLDB.cs
@@ -27,10 +27,13 @@ namespace DOL.GS
         public static IList<T> SelectAllObjects()
             => GameServer.Database.SelectAllObjects<T>();
 
-        public static IList<T> SelectObjects(WhereExpression whereExpression) 
-            => GameServer.Database.SelectObjects<T>(whereExpression);
-
         public static T SelectObject(WhereExpression whereExpression) 
             => GameServer.Database.SelectObject<T>(whereExpression);
+
+        public static IList<T> SelectObjects(WhereExpression whereExpression)
+            => GameServer.Database.SelectObjects<T>(whereExpression);
+
+        public static IList<IList<T>> MultipleSelectObjects(IEnumerable<WhereExpression> whereExpressionBatch)
+            => GameServer.Database.MultipleSelectObjects<T>(whereExpressionBatch);
     }
 }

--- a/GameServer/database/DOLDB.cs
+++ b/GameServer/database/DOLDB.cs
@@ -27,13 +27,13 @@ namespace DOL.GS
         public static IList<T> SelectAllObjects()
             => GameServer.Database.SelectAllObjects<T>();
 
-        public static T SelectObject(WhereClause whereExpression) 
-            => GameServer.Database.SelectObject<T>(whereExpression);
+        public static T SelectObject(WhereClause whereClause) 
+            => GameServer.Database.SelectObject<T>(whereClause);
 
-        public static IList<T> SelectObjects(WhereClause whereExpression)
-            => GameServer.Database.SelectObjects<T>(whereExpression);
+        public static IList<T> SelectObjects(WhereClause whereClause)
+            => GameServer.Database.SelectObjects<T>(whereClause);
 
-        public static IList<IList<T>> MultipleSelectObjects(IEnumerable<WhereClause> whereExpressionBatch)
-            => GameServer.Database.MultipleSelectObjects<T>(whereExpressionBatch);
+        public static IList<IList<T>> MultipleSelectObjects(IEnumerable<WhereClause> whereClauseBatch)
+            => GameServer.Database.MultipleSelectObjects<T>(whereClauseBatch);
     }
 }

--- a/GameServer/database/DOLDB.cs
+++ b/GameServer/database/DOLDB.cs
@@ -27,13 +27,13 @@ namespace DOL.GS
         public static IList<T> SelectAllObjects()
             => GameServer.Database.SelectAllObjects<T>();
 
-        public static T SelectObject(WhereExpression whereExpression) 
+        public static T SelectObject(WhereClause whereExpression) 
             => GameServer.Database.SelectObject<T>(whereExpression);
 
-        public static IList<T> SelectObjects(WhereExpression whereExpression)
+        public static IList<T> SelectObjects(WhereClause whereExpression)
             => GameServer.Database.SelectObjects<T>(whereExpression);
 
-        public static IList<IList<T>> MultipleSelectObjects(IEnumerable<WhereExpression> whereExpressionBatch)
+        public static IList<IList<T>> MultipleSelectObjects(IEnumerable<WhereClause> whereExpressionBatch)
             => GameServer.Database.MultipleSelectObjects<T>(whereExpressionBatch);
     }
 }

--- a/GameServer/database/converters/Version002.cs
+++ b/GameServer/database/converters/Version002.cs
@@ -52,7 +52,7 @@ namespace DOL.GS.DatabaseConverters
 			log.Info(styles.Count + " Styles Processed");
 
 			log.Info("Converting Mobs");
-			var mobs = GameServer.Database.SelectObjects<Mob>("`Realm` = @Realm", new QueryParameter("@Realm", 6));
+			var mobs = DOLDB<Mob>.SelectObjects(DB.Column("Realm").IsEqualTo(6));
 			foreach (Mob mob in mobs)
 			{
 				if ((mob.Flags & (uint)GameNPC.eFlags.PEACE) == 0)

--- a/GameServer/database/converters/Version003.cs
+++ b/GameServer/database/converters/Version003.cs
@@ -47,7 +47,7 @@ namespace DOL.GS.DatabaseConverters
 				return;
 			}
 
-			var templates = GameServer.Database.SelectObjects<ItemTemplate>("`SpellID` = @SpellID", new QueryParameter("@SpellID", 0));
+			var templates = DOLDB<ItemTemplate>.SelectObjects(DB.Column("SpellID").IsEqualTo(0));
 
 			int count = 0;
 			foreach (ItemTemplate template in templates)
@@ -79,7 +79,7 @@ namespace DOL.GS.DatabaseConverters
 
 			log.Info("Converted " + count + " templates");
 
-			var items = GameServer.Database.SelectObjects<InventoryItem>("`SpellID` = @SpellID", new QueryParameter("@SpellID", 0));
+			var items = DOLDB<InventoryItem>.SelectObjects(DB.Column("SpellID").IsEqualTo(0));
 			count = 0;
 			foreach (InventoryItem item in items)
 			{

--- a/GameServer/database/converters/Version004.cs
+++ b/GameServer/database/converters/Version004.cs
@@ -47,7 +47,7 @@ namespace DOL.GS.DatabaseConverters
 				return;
 			}
 
-			var mobs = GameServer.Database.SelectObjects<Mob>("`ClassType` = @ClassType", new QueryParameter("@ClassType", "DOL.GS.GameMob"));
+			var mobs = DOLDB<Mob>.SelectObjects(DB.Column("ClassType").IsEqualTo("DOL.GS.GameMob"));
 
 			int count = 0;
 			foreach (Mob mob in mobs)

--- a/GameServer/effects/GameEffectList.cs
+++ b/GameServer/effects/GameEffectList.cs
@@ -168,7 +168,7 @@ namespace DOL.GS.Effects
 			if (player == null || player.DBCharacter == null || GameServer.Database == null)
 				return;
 
-			var effs = GameServer.Database.SelectObjects<PlayerXEffect>("`ChardID` = @ChardID", new QueryParameter("@ChardID", player.ObjectId));
+			var effs = DOLDB<PlayerXEffect>.SelectObjects(DB.Column("ChardID").IsEqualTo(player.ObjectId));
 			if (effs == null)
 				return;
 

--- a/GameServer/gameobjects/Bonedancer/BDSubPet.cs
+++ b/GameServer/gameobjects/Bonedancer/BDSubPet.cs
@@ -67,11 +67,11 @@ namespace DOL.GS
 				if (m_PetSpecLine == null && Brain is IControlledBrain brain && brain.GetPlayerOwner() is GamePlayer player)
 				{
 					// Get the spell that summoned this pet
-					DBSpell dbSummoningSpell = GameServer.Database.SelectObject<DBSpell>("LifeDrainReturn=@TemplateId", new QueryParameter("@TemplateID", NPCTemplate.TemplateId));
+					DBSpell dbSummoningSpell = DOLDB<DBSpell>.SelectObject(DB.Column("LifeDrainReturn").IsEqualTo(NPCTemplate.TemplateId));
 					if (dbSummoningSpell != null)
 					{
 						// Figure out which spell line the summoning spell is from
-						DBLineXSpell dbLineSpell = GameServer.Database.SelectObject<DBLineXSpell>("SpellID=@SpellID", new QueryParameter("@SpellID", dbSummoningSpell.SpellID));
+						DBLineXSpell dbLineSpell = DOLDB<DBLineXSpell>.SelectObject(DB.Column("SpellID").IsEqualTo(dbSummoningSpell.SpellID));
 						if (dbLineSpell != null)
 						{
 							// Now figure out what the spec name is

--- a/GameServer/gameobjects/CustomNPC/BuffMerchant.cs
+++ b/GameServer/gameobjects/CustomNPC/BuffMerchant.cs
@@ -1985,11 +1985,11 @@ public class BuffTokensList
 	[GameServerStartedEvent]
 	public static void OnServerStartup(DOLEvent e, object sender, EventArgs args)
 	{
-		ItemTemplate[] buffMerch = GameServer.Database.SelectObjects<ItemTemplate>("`PackageID` LIKE @PackageID", new QueryParameter("@PackageID", "BuffTokens")).OrderBy(it => it.Item_Type).ToArray();
+		ItemTemplate[] buffMerch = DOLDB<ItemTemplate>.SelectObjects(DB.Column("PackageID").IsLike("BuffTokens")).OrderBy(it => it.Item_Type).ToArray();
 		MerchantItem m_item = null;
 		int pagenumber = 0;
 		int slotposition = 0;
-		m_item = GameServer.Database.SelectObjects<MerchantItem>("`ItemListID` = @ItemListID", new QueryParameter("@ItemListID", "BuffTokens")).FirstOrDefault();
+		m_item = DOLDB<MerchantItem>.SelectObject(DB.Column("ItemListID").IsEqualTo("BuffTokens"));
 		if (m_item == null)
 		{
 			foreach (ItemTemplate item in buffMerch)
@@ -2020,11 +2020,11 @@ public class BPBuffTokensList
 	[GameServerStartedEvent]
 	public static void OnServerStartup(DOLEvent e, object sender, EventArgs args)
 	{
-		ItemTemplate[] buffMerch = GameServer.Database.SelectObjects<ItemTemplate>("`PackageID` LIKE @PackageID", new QueryParameter("@PackageID", "BPBuffTokens")).OrderBy(it => it.Item_Type).ToArray();
+		ItemTemplate[] buffMerch = DOLDB<ItemTemplate>.SelectObjects(DB.Column("PackageID").IsLike("BPBuffTokens")).OrderBy(it => it.Item_Type).ToArray();
 		MerchantItem m_item = null;
 		int pagenumber = 0;
 		int slotposition = 0;
-		m_item = GameServer.Database.SelectObjects<MerchantItem>("`ItemListID` = @ItemListID", new QueryParameter("@ItemListID", "BPBuffTokens")).FirstOrDefault();
+		m_item = DOLDB<MerchantItem>.SelectObject(DB.Column("ItemListID").IsEqualTo("BPBuffTokens"));
 		if (m_item == null)
 		{
 			foreach (ItemTemplate item in buffMerch)

--- a/GameServer/gameobjects/CustomNPC/ConsignmentMerchant.cs
+++ b/GameServer/gameobjects/CustomNPC/ConsignmentMerchant.cs
@@ -206,7 +206,7 @@ namespace DOL.GS
                 {
                     m_totalMoney = value;
 
-                    var merchant = GameServer.Database.SelectObjects<HouseConsignmentMerchant>("`HouseNumber` = @HouseNumber", new QueryParameter("@HouseNumber", HouseNumber)).FirstOrDefault();
+                    var merchant = DOLDB<HouseConsignmentMerchant>.SelectObject(DB.Column("HouseNumber").IsEqualTo(HouseNumber));
                     merchant.Money = m_totalMoney;
                     GameServer.Database.SaveObject(merchant);
                 }
@@ -750,7 +750,7 @@ namespace DOL.GS
 
 			SetInventoryTemplate();
 
-			var houseCM = GameServer.Database.SelectObjects<HouseConsignmentMerchant>("`HouseNumber` = @HouseNumber", new QueryParameter("@HouseNumber", HouseNumber)).FirstOrDefault();
+			var houseCM = DOLDB<HouseConsignmentMerchant>.SelectObject(DB.Column("HouseNumber").IsEqualTo(HouseNumber));
 			if (houseCM != null)
 			{
 				TotalMoney = houseCM.Money;
@@ -782,7 +782,7 @@ namespace DOL.GS
 
 			bool isFixed = false;
 
-			var items = GameServer.Database.SelectObjects<InventoryItem>("`OwnerID` = @OwnerID AND `SlotPosition` >= @SlotPositionMin AND `SlotPosition` <= @SlotPositionMax AND `OwnerLot` = @OwnerLot", new[] { new QueryParameter("@OwnerID", house.OwnerID), new QueryParameter("@SlotPositionMin", FirstDBSlot), new QueryParameter("@SlotPositionMax", LastDBSlot), new QueryParameter("@OwnerLot", 0) });
+			var items = DOLDB<InventoryItem>.SelectObjects(DB.Column("OwnerID").IsEqualTo(house.OwnerID).And(DB.Column("SlotPosition").IsGreaterOrEqualTo(FirstDBSlot)).And(DB.Column("SlotPosition").IsLessOrEqualTo(LastDBSlot)).And(DB.Column("OwnerLot").IsEqualTo(0)));
 
 			foreach (InventoryItem item in items)
 			{
@@ -879,7 +879,7 @@ namespace DOL.GS
 
             if (house.DatabaseItem.GuildHouse)
             {
-            	var guild = GameServer.Database.SelectObjects<DBGuild>("`GuildName` = @GuildName",new QueryParameter("@GuildName", house.DatabaseItem.GuildName)).FirstOrDefault();
+            	var guild = DOLDB<DBGuild>.SelectObject(DB.Column("GuildName").IsEqualTo(house.DatabaseItem.GuildName));
                 int emblem = guild.Emblem;
 
                 InventoryItem cloak = Inventory.GetItem(eInventorySlot.Cloak);

--- a/GameServer/gameobjects/CustomNPC/Doppelganger.cs
+++ b/GameServer/gameobjects/CustomNPC/Doppelganger.cs
@@ -48,7 +48,7 @@ namespace DOL.GS
 
         static Doppelganger()
         {
-           DBNpcTemplate chthonian = GameServer.Database.SelectObject<DBNpcTemplate>("Name=@Name", new QueryParameter("@Name", "chthonian crawler"));
+           DBNpcTemplate chthonian = DOLDB<DBNpcTemplate>.SelectObject(DB.Column("Name").IsEqualTo("chthonian crawler"));
             if (chthonian != null)
                 m_petTemplate = new NpcTemplate(chthonian);
         }

--- a/GameServer/gameobjects/CustomNPC/Teleporters/SimpleTeleporter.cs
+++ b/GameServer/gameobjects/CustomNPC/Teleporters/SimpleTeleporter.cs
@@ -121,7 +121,7 @@ namespace DOL.GS
 			if (m_destinations.Count > 0 || GuildName == null || GuildName.Length == 0)
 				return;
 
-			m_destinations.AddRange(GameServer.Database.SelectObjects<Teleport>("`Type` = @Type", new QueryParameter("@Type", GuildName)));
+			m_destinations.AddRange(DOLDB<Teleport>.SelectObjects(DB.Column("Type").IsEqualTo(GuildName)));
 		}
 
 		public override bool WhisperReceive(GameLiving source, string text)

--- a/GameServer/gameobjects/CustomNPC/Teleporters/ThroneRoomTeleporter.cs
+++ b/GameServer/gameobjects/CustomNPC/Teleporters/ThroneRoomTeleporter.cs
@@ -114,7 +114,7 @@ namespace DOL.GS
 
 				if (player.CurrentRegionID == throneRegionID)
 				{
-					teleport = GameServer.Database.SelectObjects<Teleport>("`TeleportID` = @TeleportID", new QueryParameter("@TeleportID", teleportExitID)).FirstOrDefault();
+					teleport = DOLDB<Teleport>.SelectObject(DB.Column("TeleportID").IsEqualTo(teleportExitID));
 					if (teleport == null)
 					{
 						log.ErrorFormat("Can't find throne room exit TeleportID {0}!", teleportExitID);
@@ -124,7 +124,7 @@ namespace DOL.GS
 				}
 				else
 				{
-					teleport = GameServer.Database.SelectObjects<Teleport>("`TeleportID` = @TeleportID", new QueryParameter("@TeleportID", teleportThroneID)).FirstOrDefault();
+					teleport = DOLDB<Teleport>.SelectObject(DB.Column("TeleportID").IsEqualTo(teleportThroneID));
 					if (teleport == null)
 					{
 						log.ErrorFormat("Can't find throne room TeleportID {0}!", teleportThroneID);

--- a/GameServer/gameobjects/GameHouseVault.cs
+++ b/GameServer/gameobjects/GameHouseVault.cs
@@ -87,7 +87,7 @@ namespace DOL.GS
                 Index = (byte)Index
             };
 
-            var hpitem = GameServer.Database.SelectObjects<DBHouseHookpointItem>("`HouseNumber` = @HouseNumber AND `HookpointID` = @HookpointID", new[] { new QueryParameter("@HouseNumber", house.HouseNumber), new QueryParameter("@HookpointID", hookpointID) });
+            var hpitem = DOLDB<DBHouseHookpointItem>.SelectObjects(DB.Column("HouseNumber").IsEqualTo(house.HouseNumber).And(DB.Column("HookpointID").IsEqualTo(hookpointID)));
 
 			// if there isn't anything already on this hookpoint then add it to the DB
 			if (hpitem.Count == 0)

--- a/GameServer/gameobjects/GamePlayer.cs
+++ b/GameServer/gameobjects/GamePlayer.cs
@@ -12680,7 +12680,7 @@ namespace DOL.GS
 			LoadQuests();
 
 			// Load Task object of player ...
-			var tasks = GameServer.Database.SelectObjects<DBTask>("`Character_ID` = @Character_ID", new QueryParameter("@Character_ID", InternalID));
+			var tasks = DOLDB<DBTask>.SelectObjects(DB.Column("Character_ID").IsEqualTo(InternalID));
 			if (tasks.Count == 1)
 			{
 				m_task = AbstractTask.LoadFromDatabase(this, tasks[0]);
@@ -12692,7 +12692,7 @@ namespace DOL.GS
 			}
 
 			// Load ML steps of player ...
-			var mlsteps = GameServer.Database.SelectObjects<DBCharacterXMasterLevel>("`Character_ID` = @Character_ID", new QueryParameter("@Character_ID", QuestPlayerID));
+			var mlsteps = DOLDB<DBCharacterXMasterLevel>.SelectObjects(DB.Column("Character_ID").IsEqualTo(QuestPlayerID));
 			if (mlsteps.Count > 0)
 			{
 				foreach (DBCharacterXMasterLevel mlstep in mlsteps)
@@ -13397,7 +13397,7 @@ namespace DOL.GS
 			m_questListFinished.Clear();
 
 			// Scripted quests
-			var quests = GameServer.Database.SelectObjects<DBQuest>("`Character_ID` = @Character_ID", new QueryParameter("@Character_ID", QuestPlayerID));
+			var quests = DOLDB<DBQuest>.SelectObjects(DB.Column("Character_ID").IsEqualTo(QuestPlayerID));
 			foreach (DBQuest dbquest in quests)
 			{
 				AbstractQuest quest = AbstractQuest.LoadFromDatabase(this, dbquest);
@@ -13411,7 +13411,7 @@ namespace DOL.GS
 			}
 
 			// Data driven quests for this player
-			var dataQuests = GameServer.Database.SelectObjects<CharacterXDataQuest>("`Character_ID` = @Character_ID", new QueryParameter("@Character_ID", QuestPlayerID));
+			var dataQuests = DOLDB<CharacterXDataQuest>.SelectObjects(DB.Column("Character_ID").IsEqualTo(QuestPlayerID));
 			foreach (CharacterXDataQuest quest in dataQuests)
 			{
 				DBDataQuest dbDataQuest = GameServer.Database.FindObjectByKey<DBDataQuest>(quest.DataQuestID);

--- a/GameServer/gameobjects/GameVault.cs
+++ b/GameServer/gameobjects/GameVault.cs
@@ -182,8 +182,8 @@ namespace DOL.GS
 		/// </summary>
 		public IList<InventoryItem> DBItems(GamePlayer player = null)
 		{
-			return GameServer.Database.SelectObjects<InventoryItem>("`OwnerID` = @OwnerID and `SlotPosition` >= @FirstDBSlot and `SlotPosition` <= @LastDBSlot",
-			                                                        new [] { new QueryParameter("@OwnerID", GetOwner(player)), new QueryParameter("@FirstDBSlot", FirstDBSlot), new QueryParameter("@LastDBSlot", LastDBSlot) });
+			var filterBySlot = DB.Column("SlotPosition").IsGreaterOrEqualTo(FirstDBSlot).And(DB.Column("SlotPosition").IsLessOrEqualTo(LastDBSlot));
+			return DOLDB<InventoryItem>.SelectObjects(DB.Column("OwnerID").IsEqualTo(GetOwner(player)).And(filterBySlot));
 		}
 
 		/// <summary>

--- a/GameServer/gameutils/AppealMgr.cs
+++ b/GameServer/gameutils/AppealMgr.cs
@@ -178,13 +178,13 @@ namespace DOL.GS.Appeal
 
 		public static DBAppeal GetAppealByPlayerName(string name)
 		{
-			DBAppeal appeal = GameServer.Database.SelectObjects<DBAppeal>("`Name` = @Name", new QueryParameter("@Name", name)).FirstOrDefault();
+			DBAppeal appeal = DOLDB<DBAppeal>.SelectObject(DB.Column("Name").IsEqualTo(name));
 			return appeal;
 		}
 
 		public static DBAppeal GetAppealByAccountName(string name)
 		{
-			DBAppeal appeal = GameServer.Database.SelectObjects<DBAppeal>("`Account` = @Account", new QueryParameter("@Account", name)).FirstOrDefault();
+			DBAppeal appeal = DOLDB<DBAppeal>.SelectObject(DB.Column("Account").IsEqualTo(name));
 			return appeal;
 		}
 

--- a/GameServer/gameutils/Faction.cs
+++ b/GameServer/gameutils/Faction.cs
@@ -73,7 +73,7 @@ namespace DOL.GS
 
 		public void SaveAggroToFaction(string charID)
 		{
-			DBFactionAggroLevel dbfactionAggroLevel = GameServer.Database.SelectObjects<DBFactionAggroLevel>("`CharacterID` = @CharacterID AND `FactionID` = @FactionID", new[] { new QueryParameter("@CharacterID", charID), new QueryParameter("@FactionID", this.ID) }).FirstOrDefault();
+			var dbfactionAggroLevel = DOLDB<DBFactionAggroLevel>.SelectObject(DB.Column("CharacterID").IsEqualTo(charID).And(DB.Column("FactionID").IsEqualTo(ID)));
 			if (dbfactionAggroLevel == null)
 			{
 				dbfactionAggroLevel = new DBFactionAggroLevel();

--- a/GameServer/gameutils/GameNpcInventoryTemplate.cs
+++ b/GameServer/gameutils/GameNpcInventoryTemplate.cs
@@ -302,7 +302,7 @@ namespace DOL.GS
 				if (m_npcEquipmentCache.ContainsKey(templateID))
 					npcEquip = m_npcEquipmentCache[templateID];
 				else
-					npcEquip = GameServer.Database.SelectObjects<NPCEquipment>("`templateID` = @templateID", new QueryParameter("@templateID", templateID));
+					npcEquip = DOLDB<NPCEquipment>.SelectObjects(DB.Column("templateID").IsEqualTo(templateID));
 
 				if (npcEquip == null || npcEquip.Count == 0)
 				{
@@ -368,7 +368,7 @@ namespace DOL.GS
 					if (templateID == null)
 						throw new ArgumentNullException("templateID");
 
-					var npcEquipment = GameServer.Database.SelectObjects<NPCEquipment>("`templateID` = @templateID", new QueryParameter("@templateID", templateID));
+					var npcEquipment = DOLDB<NPCEquipment>.SelectObjects(DB.Column("templateID").IsEqualTo(templateID));
 
 					// delete removed item templates
 					foreach (NPCEquipment npcItem in npcEquipment)

--- a/GameServer/gameutils/GamePlayerInventory.cs
+++ b/GameServer/gameutils/GamePlayerInventory.cs
@@ -68,8 +68,8 @@ namespace DOL.GS
 					// If we cache ALL items them all vault code must make sure to update cache, which is not ideal
 					// in addition, a player with a housing vault may still have an item in cache that may have been
 					// removed by another player with the appropriate house permission.  - Tolakram
-					var items = GameServer.Database.SelectObjects<InventoryItem>("`OwnerID` = @OwnerID AND (`SlotPosition` <= @LastVault OR (`SlotPosition` >= @OtherMin AND `SlotPosition` < @OtherMax))",
-					                                                             new[] { new QueryParameter("@OwnerID", inventoryID), new QueryParameter("@LastVault", (int)eInventorySlot.LastVault), new QueryParameter("@OtherMin", 500), new QueryParameter("@OtherMax", 600) });
+					var filterBySlot = DB.Column("SlotPosition").IsLessOrEqualTo((int)eInventorySlot.LastVault).Or(DB.Column("SlotPosition").IsGreaterOrEqualTo(500).And(DB.Column("SlotPosition").IsLessThan(600)));
+					var items = DOLDB<InventoryItem>.SelectObjects(DB.Column("OwnerID").IsEqualTo(inventoryID).And(filterBySlot));
 
 					foreach (InventoryItem item in items)
 					{

--- a/GameServer/gameutils/GuildMgr.cs
+++ b/GameServer/gameutils/GuildMgr.cs
@@ -351,16 +351,16 @@ namespace DOL.GS
 				if (removeGuild == null)
 					return false;
 
-				var guilds = GameServer.Database.SelectObjects<DBGuild>("`GuildID` = @GuildID", new QueryParameter("@GuildID", removeGuild.GuildID));
+				var guilds = DOLDB<DBGuild>.SelectObjects(DB.Column("GuildID").IsEqualTo(removeGuild.GuildID));
 				foreach (var guild in guilds)
 				{
-					foreach (var cha in GameServer.Database.SelectObjects<DOLCharacters>("`GuildID` = @GuildID", new QueryParameter("@GuildID", guild.GuildID)))
+					foreach (var cha in DOLDB<DOLCharacters>.SelectObjects(DB.Column("GuildID").IsEqualTo(guild.GuildID)))
 						cha.GuildID = "";
 				}
 				GameServer.Database.DeleteObject(guilds);
 
 				//[StephenxPimentel] We need to delete the guild specific ranks aswell!
-				var ranks = GameServer.Database.SelectObjects<DBRank>("`GuildID` = @GuildID", new QueryParameter("@GuildID", removeGuild.GuildID));
+				var ranks = DOLDB<DBRank>.SelectObjects(DB.Column("GuildID").IsEqualTo(removeGuild.GuildID));
 				GameServer.Database.DeleteObject(ranks);
 
 				lock (removeGuild.GetListOfOnlineMembers())
@@ -465,12 +465,12 @@ namespace DOL.GS
 					RepairRanks(myguild);
 
 					// now reload the guild to fix the relations
-					myguild = new Guild(GameServer.Database.SelectObjects<DBGuild>("`GuildID` = @GuildID", new QueryParameter("@GuildID", obj.GuildID)).FirstOrDefault());
+					myguild = new Guild(DOLDB<DBGuild>.SelectObjects(DB.Column("GuildID").IsEqualTo(obj.GuildID)).FirstOrDefault());
 				}
 
 				AddGuild(myguild);
 
-				var guildCharacters = GameServer.Database.SelectObjects<DOLCharacters>("`GuildID` = @GuildID", new QueryParameter("@GuildID", myguild.GuildID));
+				var guildCharacters = DOLDB<DOLCharacters>.SelectObjects(DB.Column("GuildID").IsEqualTo(myguild.GuildID));
 				var tempList = new Dictionary<string, GuildMemberDisplay>(guildCharacters.Count);
 
 				foreach (DOLCharacters ch in guildCharacters)
@@ -565,7 +565,7 @@ namespace DOL.GS
 			{
 				player.RemoveMoney(COST_RE_EMBLEM, null);
                 InventoryLogging.LogInventoryAction(player, "(GUILD;" + player.GuildName + ")", eInventoryActionType.Other, COST_RE_EMBLEM);
-                var objs = GameServer.Database.SelectObjects<InventoryItem>("`Emblem` = @Emblem", new QueryParameter("@Emblem", oldemblem));
+                var objs = DOLDB<InventoryItem>.SelectObjects(DB.Column("Emblem").IsEqualTo(oldemblem));
 				
 				foreach (InventoryItem item in objs)
 				{

--- a/GameServer/gameutils/LootGeneratorMobTemplate.cs
+++ b/GameServer/gameutils/LootGeneratorMobTemplate.cs
@@ -177,7 +177,7 @@ namespace DOL.GS
 			bool isDefaultLootTemplateRefreshed = false;
 
 			// First see if there are any MobXLootTemplates associated with this mob
-			IList<MobDropTemplate> mxlts = GameServer.Database.SelectObjects<MobDropTemplate>("`MobName` = @MobName", new QueryParameter("@MobName", mob.Name));
+			IList<MobDropTemplate> mxlts = DOLDB<MobDropTemplate>.SelectObjects(DB.Column("MobName").IsEqualTo(mob.Name));
 
 			if (mxlts != null)
 			{
@@ -211,7 +211,7 @@ namespace DOL.GS
 
 		protected void RefreshLootTemplate(string templateName)
 		{
-			var lootTemplates = GameServer.Database.SelectObjects<DropTemplateXItemTemplate>("`TemplateName` = @TemplateName", new QueryParameter("@TemplateName", templateName));
+			var lootTemplates = DOLDB<DropTemplateXItemTemplate>.SelectObjects(DB.Column("TemplateName").IsEqualTo(templateName));
 
 			if (lootTemplates != null)
 			{

--- a/GameServer/gameutils/LootGeneratorOneTimeDrop.cs
+++ b/GameServer/gameutils/LootGeneratorOneTimeDrop.cs
@@ -75,7 +75,7 @@ namespace DOL.GS
 
 					foreach (LootOTD l in lootOTDs)
 					{
-						IList<Mob> mobs = GameServer.Database.SelectObjects<Mob>("`Name` = @Name", new QueryParameter("@Name", l.MobName));
+						IList<Mob> mobs = DOLDB<Mob>.SelectObjects(DB.Column("Name").IsEqualTo(l.MobName));
 
 						if (mobs == null || mobs.Count == 0)
 						{
@@ -132,7 +132,7 @@ namespace DOL.GS
 			if (mob == null)
 				return;
 
-			IList<LootOTD> otds = GameServer.Database.SelectObjects<LootOTD>("`MobName` = @MobName", new QueryParameter("@MobName", mob.Name));
+			IList<LootOTD> otds = DOLDB<LootOTD>.SelectObjects(DB.Column("MobName").IsEqualTo(mob.Name));
 
 			lock (m_mobOTDList)
 			{
@@ -196,7 +196,7 @@ namespace DOL.GS
 							{
 								if (drop.MinLevel <= player.Level)
 								{
-									CharacterXOneTimeDrop hasDrop = GameServer.Database.SelectObjects<CharacterXOneTimeDrop>("`CharacterID` = @CharacterID AND `ItemTemplateID` = @ItemTemplateID", new [] { new QueryParameter("@CharacterID", player.QuestPlayerID), new QueryParameter("@ItemTemplateID", drop.ItemTemplateID) } ).FirstOrDefault();
+									var hasDrop = DOLDB<CharacterXOneTimeDrop>.SelectObject(DB.Column("CharacterID").IsEqualTo(player.QuestPlayerID).And(DB.Column("ItemTemplateID").IsEqualTo(drop.ItemTemplateID)));
 
 									if (hasDrop == null)
 									{

--- a/GameServer/gameutils/LootGeneratorRandom.cs
+++ b/GameServer/gameutils/LootGeneratorRandom.cs
@@ -58,14 +58,10 @@ namespace DOL.GS
 			{
 				try
 				{
-					itemTemplates = GameServer.Database.SelectObjects<ItemTemplate>("`Level` >= @LevelMin AND `Level` <= @LevelMax AND `IsPickable` = @IsPickable AND `IsDropable` = @IsDropable AND `CanDropAsloot` = @CanDropAsloot AND `Item_Type` >= @MinSlot AND `Item_Type` <= @MaxSlot",
-							                                                        new[] { new QueryParameter("@LevelMin", (i * LEVEL_RANGE)),
-							                                                            new QueryParameter("@LevelMax", ((i + 1) * LEVEL_RANGE)),
-							                                                            new QueryParameter("@IsPickable", 1),
-							                                                            new QueryParameter("@IsDropable", 1),
-																						new QueryParameter("@CanDropAsloot", 1),
-																						new QueryParameter("@MinSlot", (int)eInventorySlot.MinEquipable),
-																						new QueryParameter("@MaxSlot", (int)eInventorySlot.MaxEquipable) });
+					var filterLevel = DB.Column("Level").IsGreaterOrEqualTo(i * LEVEL_RANGE).And(DB.Column("Level").IsLessOrEqualTo((i + 1) * LEVEL_RANGE));
+					var filterByFlags = DB.Column("IsPickable").IsEqualTo(1).And(DB.Column("IsDropable").IsEqualTo(1)).And(DB.Column("CanDropAsLoot").IsEqualTo(1));
+					var filterBySlot = DB.Column("Item_Type").IsGreaterOrEqualTo((int)eInventorySlot.MinEquipable).And(DB.Column("Item_Type").IsLessOrEqualTo((int)eInventorySlot.MaxEquipable));
+					itemTemplates = DOLDB<ItemTemplate>.SelectObjects(filterLevel.And(filterByFlags).And(filterBySlot));
 				}
 				catch (Exception e)
 				{

--- a/GameServer/gameutils/LootGeneratorTemplate.cs
+++ b/GameServer/gameutils/LootGeneratorTemplate.cs
@@ -191,7 +191,7 @@ namespace DOL.GS
 
 			// First see if there are any MobXLootTemplates associated with this mob
 
-			IList<MobXLootTemplate> mxlts = GameServer.Database.SelectObjects<MobXLootTemplate>("`MobName` = @MobName", new QueryParameter("@MobName", mob.Name));
+			var mxlts = DOLDB<MobXLootTemplate>.SelectObjects(DB.Column("MobName").IsEqualTo(mob.Name));
 
 			if (mxlts != null)
 			{
@@ -232,7 +232,7 @@ namespace DOL.GS
 				}
 			}
 
-			IList<LootTemplate> lootTemplates = GameServer.Database.SelectObjects<LootTemplate>("`TemplateName` = @TemplateName", new QueryParameter("@TemplateName", templateName));
+			var lootTemplates = DOLDB<LootTemplate>.SelectObjects(DB.Column("TemplateName").IsEqualTo(templateName));
 
 			if (lootTemplates != null)
 			{

--- a/GameServer/gameutils/MarketCache.cs
+++ b/GameServer/gameutils/MarketCache.cs
@@ -60,8 +60,8 @@ namespace DOL.GS
 			{
 				m_itemCache = new Dictionary<string, InventoryItem>();
 
-				IList<InventoryItem> list = GameServer.Database.SelectObjects<InventoryItem>("`SlotPosition` >= @SlotPositionFirst AND `SlotPosition` <= @SlotPositionLast AND `OwnerLot` > @OwnerLot",
-				                                                                             new[] { new QueryParameter("@SlotPositionFirst", (int)eInventorySlot.Consignment_First), new QueryParameter("@SlotPositionLast", (int)eInventorySlot.Consignment_Last), new QueryParameter("@OwnerLot", 0) });
+				var filterBySlot = DB.Column("SlotPosition").IsGreaterOrEqualTo((int)eInventorySlot.Consignment_First).And(DB.Column("SlotPosition").IsLessOrEqualTo((int)eInventorySlot.Consignment_Last));
+				var list = DOLDB<InventoryItem>.SelectObjects(filterBySlot.And(DB.Column("OwnerLot").IsGreatherThan(0)));
 
 				foreach (InventoryItem item in list)
 				{

--- a/GameServer/gameutils/MerchantTradeItems.cs
+++ b/GameServer/gameutils/MerchantTradeItems.cs
@@ -157,7 +157,7 @@ namespace DOL.GS
 				HybridDictionary itemsInPage = new HybridDictionary(MAX_ITEM_IN_TRADEWINDOWS);
 				if (m_itemsListID != null && m_itemsListID.Length > 0)
 				{
-					var itemList = GameServer.Database.SelectObjects<MerchantItem>("`ItemListID` = @ItemListID AND `PageNumber` = @PageNumber", new[] { new QueryParameter("@ItemListID", m_itemsListID), new QueryParameter("@PageNumber", page) });
+					var itemList = DOLDB<MerchantItem>.SelectObjects(DB.Column("ItemListID").IsEqualTo(m_itemsListID).And(DB.Column("PageNumber").IsEqualTo(page)));
 					foreach (MerchantItem merchantitem in itemList)
 					{
 						ItemTemplate item = GameServer.Database.FindObjectByKey<ItemTemplate>(merchantitem.ItemTemplateID);
@@ -220,8 +220,7 @@ namespace DOL.GS
 
 				if (m_itemsListID != null && m_itemsListID.Length > 0)
 				{
-					var itemToFind = GameServer.Database.SelectObjects<MerchantItem>("`ItemListID` = @ItemListID AND `PageNumber` = @PageNumber AND `SlotPosition` = @SlotPosition",
-					                                                                 new[] { new QueryParameter("@ItemListID", m_itemsListID), new QueryParameter("@PageNumber", page), new QueryParameter("@SlotPosition", (int)slot) }).FirstOrDefault();
+					var itemToFind = DOLDB<MerchantItem>.SelectObject(DB.Column("ItemListID").IsEqualTo(m_itemsListID).And(DB.Column("PageNumber").IsEqualTo(page)).And(DB.Column("SlotPosition").IsEqualTo((int)slot)));
 					if (itemToFind != null)
 					{
 						item = GameServer.Database.FindObjectByKey<ItemTemplate>(itemToFind.ItemTemplateID);
@@ -248,7 +247,7 @@ namespace DOL.GS
 				Hashtable allItems = new Hashtable();
 				if (m_itemsListID != null && m_itemsListID.Length > 0)
 				{
-					var itemList = GameServer.Database.SelectObjects<MerchantItem>("`ItemListID` = @ItemListID", new QueryParameter("@ItemListID", m_itemsListID));
+					var itemList = DOLDB<MerchantItem>.SelectObjects(DB.Column("ItemListID").IsEqualTo(m_itemsListID));
 					foreach (MerchantItem merchantitem in itemList)
 					{
 						ItemTemplate item = GameServer.Database.FindObjectByKey<ItemTemplate>(merchantitem.ItemTemplateID);

--- a/GameServer/gameutils/MovementMgr.cs
+++ b/GameServer/gameutils/MovementMgr.cs
@@ -82,7 +82,7 @@ namespace DOL.GS.Movement
 		{
 			log.DebugFormat("Updating path {0} in path cache.", pathID);
 
-			DBPath dbpath = GameServer.Database.SelectObjects<DBPath>("`PathID` = @PathID", new QueryParameter("@PathID", pathID)).FirstOrDefault();
+			var dbpath = DOLDB<DBPath>.SelectObject(DB.Column("PathID").IsEqualTo(pathID));
 			if (dbpath != null)
 			{
 				if (m_pathCache.ContainsKey(pathID))
@@ -95,7 +95,7 @@ namespace DOL.GS.Movement
 				}
 			}
 
-			IList<DBPathPoint> pathPoints = GameServer.Database.SelectObjects<DBPathPoint>("`PathID` = @PathID", new QueryParameter("@PathID", pathID));
+			var pathPoints = DOLDB<DBPathPoint>.SelectObjects(DB.Column("PathID").IsEqualTo(pathID));
 			SortedList<int, DBPathPoint> pList = new SortedList<int, DBPathPoint>();
 			if (m_pathpointCache.ContainsKey(pathID))
 			{
@@ -191,13 +191,13 @@ namespace DOL.GS.Movement
 
 			// First delete any path with this pathID from the database
 
-			DBPath dbpath = GameServer.Database.SelectObjects<DBPath>("`PathID` = @PathID", new QueryParameter("@PathID", pathID)).FirstOrDefault();
+			var dbpath = DOLDB<DBPath>.SelectObject(DB.Column("PathID").IsEqualTo(pathID));
 			if (dbpath != null)
 			{
 				GameServer.Database.DeleteObject(dbpath);
 			}
 
-			GameServer.Database.DeleteObject(GameServer.Database.SelectObjects<DBPathPoint>("`PathID` = @PathID", new QueryParameter("@PathID", pathID)));
+			GameServer.Database.DeleteObject(DOLDB<DBPathPoint>.SelectObjects(DB.Column("PathID").IsEqualTo(pathID)));
 
 			// Now add this path and iterate through the PathPoint linked list to add all the path points
 

--- a/GameServer/gameutils/NewsMgr.cs
+++ b/GameServer/gameutils/NewsMgr.cs
@@ -72,10 +72,9 @@ namespace DOL.GS
 				//we can see all captures
 				IList<DBNews> newsList;
 				if (type > 0)
-					newsList = GameServer.Database.SelectObjects<DBNews>("`Type` = @Type AND (`Realm` = @DefaultRealm OR `Realm` = @Realm)",
-					                                                     new[] { new QueryParameter("@Type", type), new QueryParameter("@DefaultRealm", 0), new QueryParameter("@Realm", realm) });
+					newsList = DOLDB<DBNews>.SelectObjects(DB.Column("Type").IsEqualTo(type).And(DB.Column("Realm").IsEqualTo(0).Or(DB.Column("Realm").IsEqualTo(realm))));
 				else
-					newsList = GameServer.Database.SelectObjects<DBNews>("`Type` = @Type", new QueryParameter("@Type", type));
+					newsList = DOLDB<DBNews>.SelectObjects(DB.Column("Type").IsEqualTo(type));
 
 				newsList = newsList.OrderByDescending(it => it.CreationDate).Take(5).ToArray();
 				int n = newsList.Count;

--- a/GameServer/gameutils/PlayerStatistics.cs
+++ b/GameServer/gameutils/PlayerStatistics.cs
@@ -184,7 +184,7 @@ namespace DOL.GS
             }
 
             #region /stats top
-            var chars = GameServer.Database.SelectObjects<DOLCharacters>("`RealmPoints` > @RealmPoints", new QueryParameter("@RealmPoints", 213881)).OrderByDescending(dc => dc.RealmPoints).Take(100).ToArray();
+            var chars = DOLDB<DOLCharacters>.SelectObjects(DB.Column("RealmPoints").IsGreatherThan(213881)).OrderByDescending(dc => dc.RealmPoints).Take(100).ToArray();
             // assuming we can get at least 20 players
             if (toplist.Count > 0)
             {

--- a/GameServer/gameutils/SinglePermission.cs
+++ b/GameServer/gameutils/SinglePermission.cs
@@ -33,8 +33,7 @@ namespace DOL.GS
 
 		public static bool HasPermission(GamePlayer player,string command)
 		{
-			DataObject obj = GameServer.Database.SelectObjects<DBSinglePermission>("`Command` = @Command AND (`PlayerID` = @PlayerID OR `PlayerID` = @PlayerAccount)",
-			                                                                      new[] { new QueryParameter("@Command", command), new QueryParameter("@PlayerID", player.ObjectId), new QueryParameter("@PlayerAccount", player.AccountName) }).FirstOrDefault();
+			var obj = DOLDB<DBSinglePermission>.SelectObject(DB.Column("Command").IsEqualTo(command).And(DB.Column("PlayerID").IsEqualTo(player.ObjectId).Or(DB.Column("PlayerID").IsEqualTo(player.AccountName))));
 			if (obj == null)
 				return false;
 			return true;
@@ -58,8 +57,7 @@ namespace DOL.GS
 
 		public static bool removePermission(GamePlayer player,string command)
 		{
-			DataObject obj = GameServer.Database.SelectObjects<DBSinglePermission>("`Command` = @Command AND `PlayerID` = @PlayerID",
-			                                                                       new[] { new QueryParameter("@Command", command), new QueryParameter("@PlayerID", player.ObjectId) }).FirstOrDefault();
+			var obj = DOLDB<DBSinglePermission>.SelectObject(DB.Column("Command").IsEqualTo(command).And(DB.Column("PlayerID").IsEqualTo(player.ObjectId)));
 			if (obj == null)
 			{
 				return false;
@@ -70,8 +68,7 @@ namespace DOL.GS
 
         public static bool removePermissionAccount(GamePlayer player, string command)
         {
-            DataObject obj = GameServer.Database.SelectObjects<DBSinglePermission>("`Command` = @Command AND `PlayerID` = @PlayerID",
-			                                                                       new[] { new QueryParameter("@Command", command), new QueryParameter("@PlayerID", player.AccountName) }).FirstOrDefault();
+            var obj = DOLDB<DBSinglePermission>.SelectObject(DB.Column("Command").IsEqualTo(command).And(DB.Column("PlayerID").IsEqualTo(player.AccountName)));
             if (obj == null)
             {
                 return false;

--- a/GameServer/gameutils/SkillBase.cs
+++ b/GameServer/gameutils/SkillBase.cs
@@ -362,7 +362,7 @@ namespace DOL.GS
 				foreach (string lineName in m_spellLineIndex.Keys)
 				{
 					// Get SpellLine X Spell relation
-					IList<DBLineXSpell> spells = GameServer.Database.SelectObjects<DBLineXSpell>("`LineName` = @LineName", new QueryParameter("@LineName", lineName));
+					var spells = DOLDB<DBLineXSpell>.SelectObjects(DB.Column("LineName").IsEqualTo(lineName));
 					
 					// Load them if any records.
 					if (spells != null)
@@ -2439,7 +2439,7 @@ namespace DOL.GS
 			m_syncLockUpdates.EnterWriteLock();
 			try
 			{
-				DBSpell dbSpell = GameServer.Database.SelectObjects<DBSpell>("`SpellID` = @SpellID", new QueryParameter("@SpellID", spellID)).FirstOrDefault();
+				var dbSpell = DOLDB<DBSpell>.SelectObject(DB.Column("SpellID").IsEqualTo(spellID));
 	
 				if (dbSpell != null)
 				{

--- a/GameServer/housing/House.cs
+++ b/GameServer/housing/House.cs
@@ -570,7 +570,7 @@ namespace DOL.GS.Housing
 		{
 			var usedVaults = new[] {false, false, false, false};
 
-			foreach (DBHouseHookpointItem housePointItem in GameServer.Database.SelectObjects<DBHouseHookpointItem>("`HouseNumber` = @HouseNumber AND `ItemTemplateID` LIKE @ItemTemplateID", new[] { new QueryParameter("@HouseNumber", HouseNumber), new QueryParameter("@ItemTemplateID", "%_vault") }))
+			foreach (var housePointItem in DOLDB<DBHouseHookpointItem>.SelectObjects(DB.Column("HouseNumber").IsEqualTo(HouseNumber).And(DB.Column("ItemTemplateID").IsLike("%_vault"))))
 			{
 				if (housePointItem.Index >= 0 && housePointItem.Index <= 3)
 				{
@@ -754,7 +754,7 @@ namespace DOL.GS.Housing
 				return;
 			}
 
-			var items = GameServer.Database.SelectObjects<DBHouseHookpointItem>("`HookpointID` = @HookpointID AND `HouseNumber` = @HouseNumber", new[] { new QueryParameter("@HookpointID", position), new QueryParameter("@HouseNumber", obj.CurrentHouse.HouseNumber) });
+			var items = DOLDB<DBHouseHookpointItem>.SelectObjects(DB.Column("HookpointID").IsEqualTo(position).And(DB.Column("HouseNumber").IsEqualTo(obj.CurrentHouse.HouseNumber)));
 			if (items.Count == 0)
 			{
 				ChatUtil.SendSystemMessage(player, "No hookpoint item found at position " + position);
@@ -825,14 +825,14 @@ namespace DOL.GS.Housing
 				return false;
 			}
 
-			var obj = GameServer.Database.SelectObjects<Mob>("`HouseNumber` = @HouseNumber", new QueryParameter("@HouseNumber", HouseNumber)).FirstOrDefault();
+			var obj = DOLDB<Mob>.SelectObject(DB.Column("HouseNumber").IsEqualTo(HouseNumber));
 			if (obj != null)
 			{
 				log.DebugFormat("Add CM: Found consignment merchant in Mob table for house {0}.", HouseNumber);
 				return false;
 			}
 
-			var houseCM = GameServer.Database.SelectObjects<HouseConsignmentMerchant>("`HouseNumber` = @HouseNumber", new QueryParameter("@HouseNumber", HouseNumber)).FirstOrDefault();
+			var houseCM = DOLDB<HouseConsignmentMerchant>.SelectObject(DB.Column("HouseNumber").IsEqualTo(HouseNumber));
 			if (houseCM != null)
 			{
 				log.DebugFormat("Add CM: Found active consignment merchant in HousingConsignmentMerchant table for house {0}.", HouseNumber);
@@ -845,7 +845,7 @@ namespace DOL.GS.Housing
 			}
 
 			// now let's try to find a CM with this owner ID and no house and if we find it, attach
-			houseCM = GameServer.Database.SelectObjects<HouseConsignmentMerchant>("`OwnerID` = @OwnerID", new QueryParameter("@OwnerID", OwnerID)).FirstOrDefault();
+			houseCM = DOLDB<HouseConsignmentMerchant>.SelectObject(DB.Column("OwnerID").IsEqualTo(OwnerID));
 
 			if (houseCM != null)
 			{
@@ -929,7 +929,7 @@ namespace DOL.GS.Housing
 					log.Warn("HOUSING: Cleared OwnerLot for " + count + " items on the consignment merchant!");
 				}
 
-				var houseCM = GameServer.Database.SelectObjects<HouseConsignmentMerchant>("`HouseNumber` = @HouseNumber", new QueryParameter("@HouseNumber", HouseNumber)).FirstOrDefault();
+				var houseCM = DOLDB<HouseConsignmentMerchant>.SelectObject(DB.Column("HouseNumber").IsEqualTo(HouseNumber));
 				if (houseCM != null)
 				{
 					houseCM.HouseNumber = 0;
@@ -1476,26 +1476,26 @@ namespace DOL.GS.Housing
 		{
 			int i = 0;
 			_indoorItems.Clear();
-			foreach (DBHouseIndoorItem dbiitem in GameServer.Database.SelectObjects<DBHouseIndoorItem>("`HouseNumber` = @HouseNumber", new QueryParameter("@HouseNumber", HouseNumber)))
+			foreach (DBHouseIndoorItem dbiitem in DOLDB<DBHouseIndoorItem>.SelectObjects(DB.Column("HouseNumber").IsEqualTo(HouseNumber)))
 			{
 				_indoorItems.Add(i++, new IndoorItem(dbiitem));
 			}
 
 			i = 0;
 			_outdoorItems.Clear();
-			foreach (DBHouseOutdoorItem dboitem in GameServer.Database.SelectObjects<DBHouseOutdoorItem>("`HouseNumber` = @HouseNumber", new QueryParameter("@HouseNumber", HouseNumber)))
+			foreach (DBHouseOutdoorItem dboitem in DOLDB<DBHouseOutdoorItem>.SelectObjects(DB.Column("HouseNumber").IsEqualTo(HouseNumber)))
 			{
 				_outdoorItems.Add(i++, new OutdoorItem(dboitem));
 			}
 
 			_housePermissions.Clear();
-			foreach (DBHouseCharsXPerms d in GameServer.Database.SelectObjects<DBHouseCharsXPerms>("`HouseNumber` = @HouseNumber", new QueryParameter("@HouseNumber", HouseNumber)))
+			foreach (DBHouseCharsXPerms d in DOLDB<DBHouseCharsXPerms>.SelectObjects(DB.Column("HouseNumber").IsEqualTo(HouseNumber)))
 			{
 				_housePermissions.Add(GetOpenPermissionSlot(), d);
 			}
 
 			_permissionLevels.Clear();
-			foreach (DBHousePermissions dbperm in GameServer.Database.SelectObjects<DBHousePermissions>("`HouseNumber` = @HouseNumber", new QueryParameter("@HouseNumber", HouseNumber)))
+			foreach (DBHousePermissions dbperm in DOLDB<DBHousePermissions>.SelectObjects(DB.Column("HouseNumber").IsEqualTo(HouseNumber)))
 			{
 				if (_permissionLevels.ContainsKey(dbperm.PermissionLevel) == false)
 				{
@@ -1508,7 +1508,7 @@ namespace DOL.GS.Housing
 			}
 
 			HousepointItems.Clear();
-			foreach (DBHouseHookpointItem item in GameServer.Database.SelectObjects<DBHouseHookpointItem>("`HouseNumber` = @HouseNumber", new QueryParameter("@HouseNumber", HouseNumber)))
+			foreach (DBHouseHookpointItem item in DOLDB<DBHouseHookpointItem>.SelectObjects(DB.Column("HouseNumber").IsEqualTo(HouseNumber)))
 			{
 				if (HousepointItems.ContainsKey(item.HookpointID) == false)
 				{

--- a/GameServer/housing/HouseMgr.cs
+++ b/GameServer/housing/HouseMgr.cs
@@ -128,7 +128,7 @@ namespace DOL.GS.Housing
 		public static string LoadHousingForRegion(ushort regionID)
 		{
 			string result = "";
-			IList<DBHouse> regionHousing = GameServer.Database.SelectObjects<DBHouse>("`RegionID` = @RegionID", new QueryParameter("@RegionID", regionID));
+			var regionHousing = DOLDB<DBHouse>.SelectObjects(DB.Column("RegionID").IsEqualTo(regionID));
 
 			if (regionHousing == null || regionHousing.Count == 0)
 				return "No housing found for region.";
@@ -406,7 +406,7 @@ namespace DOL.GS.Housing
 			}
 
 			// if there is a consignment merchant, we have to re-initialize since we changed the house
-			var merchant = GameServer.Database.SelectObjects<HouseConsignmentMerchant>("`HouseNumber` = @HouseNumber", new QueryParameter("@HouseNumber", house.HouseNumber)).FirstOrDefault();
+			var merchant = DOLDB<HouseConsignmentMerchant>.SelectObject(DB.Column("HouseNumber").IsEqualTo(house.HouseNumber));
 			long oldMerchantMoney = 0;
 			if (merchant != null)
 			{
@@ -482,15 +482,15 @@ namespace DOL.GS.Housing
 		{
 			house.RemoveConsignmentMerchant();
 
-			IList<DBHouseIndoorItem> iobjs = GameServer.Database.SelectObjects<DBHouseIndoorItem>("`HouseNumber` = @HouseNumber", new QueryParameter("@HouseNumber", house.HouseNumber));
+			IList<DBHouseIndoorItem> iobjs = DOLDB<DBHouseIndoorItem>.SelectObjects(DB.Column("HouseNumber").IsEqualTo(house.HouseNumber));
 			GameServer.Database.DeleteObject(iobjs);
 			house.IndoorItems.Clear();
 
-			IList<DBHouseOutdoorItem> oobjs = GameServer.Database.SelectObjects<DBHouseOutdoorItem>("`HouseNumber` = @HouseNumber", new QueryParameter("@HouseNumber", house.HouseNumber));
+			IList<DBHouseOutdoorItem> oobjs = DOLDB<DBHouseOutdoorItem>.SelectObjects(DB.Column("HouseNumber").IsEqualTo(house.HouseNumber));
 			GameServer.Database.DeleteObject(oobjs);
 			house.OutdoorItems.Clear();
 
-			IList<DBHouseHookpointItem> hpobjs = GameServer.Database.SelectObjects<DBHouseHookpointItem>("`HouseNumber` = @HouseNumber", new QueryParameter("@HouseNumber", house.HouseNumber));
+			IList<DBHouseHookpointItem> hpobjs = DOLDB<DBHouseHookpointItem>.SelectObjects(DB.Column("HouseNumber").IsEqualTo(house.HouseNumber));
 			GameServer.Database.DeleteObject(hpobjs);
 
 			foreach (DBHouseHookpointItem item in house.HousepointItems.Values)
@@ -518,11 +518,11 @@ namespace DOL.GS.Housing
 			house.DatabaseItem.GuildHouse = false;
 			house.DatabaseItem.GuildName = null;
 
-			IList<DBHousePermissions> pobjs = GameServer.Database.SelectObjects<DBHousePermissions>("`HouseNumber` = @HouseNumber", new QueryParameter("@HouseNumber", house.HouseNumber));
+			IList<DBHousePermissions> pobjs = DOLDB<DBHousePermissions>.SelectObjects(DB.Column("HouseNumber").IsEqualTo(house.HouseNumber));
 			GameServer.Database.DeleteObject(pobjs);
 			house.PermissionLevels.Clear();
 
-			IList<DBHouseCharsXPerms> cpobjs = GameServer.Database.SelectObjects<DBHouseCharsXPerms>("`HouseNumber` = @HouseNumber", new QueryParameter("@HouseNumber", house.HouseNumber));
+			IList<DBHouseCharsXPerms> cpobjs = DOLDB<DBHouseCharsXPerms>.SelectObjects(DB.Column("HouseNumber").IsEqualTo(house.HouseNumber));
 			GameServer.Database.DeleteObject(cpobjs);
 			house.CharXPermissions.Clear();
 		}

--- a/GameServer/housing/HouseTemplateMgr.cs
+++ b/GameServer/housing/HouseTemplateMgr.cs
@@ -260,7 +260,7 @@ namespace DOL.GS.Housing
 
         private static void CheckMerchantItems(string merchantid, ICollection<string> itemids)
         {
-            IList<MerchantItem> merchantitems = GameServer.Database.SelectObjects<MerchantItem>("`ItemListID` = @ItemListID", new QueryParameter("@ItemListID", merchantid));
+            var merchantitems = DOLDB<MerchantItem>.SelectObjects(DB.Column("ItemListID").IsEqualTo(merchantid));
 
             int slot = 0;
             foreach (string itemid in itemids)

--- a/GameServer/keeps/AbstractGameKeep.cs
+++ b/GameServer/keeps/AbstractGameKeep.cs
@@ -1166,8 +1166,7 @@ namespace DOL.GS.Keeps
 				return;
 
 			//predict Z
-			DBKeepHookPoint hp = GameServer.Database.SelectObjects<DBKeepHookPoint>("`HookPointID` = @HookPointID AND `Height` = @Height",
-			                                                                        new[] { new QueryParameter("@HookPointID", 97), new QueryParameter("@Height", Height) }).FirstOrDefault();
+			DBKeepHookPoint hp = DOLDB<DBKeepHookPoint>.SelectObject(DB.Column("HookPointID").IsEqualTo(97).And(DB.Column("Height").IsEqualTo(Height)));
 			if (hp == null)
 				return;
 			int z = component.Z + hp.Z;

--- a/GameServer/keeps/GameKeepComponent.cs
+++ b/GameServer/keeps/GameKeepComponent.cs
@@ -247,22 +247,17 @@ namespace DOL.GS.Keeps
 
 			this.Positions.Clear();
 
-			List<QueryParameter> parameters = new List<QueryParameter>(3);
-			parameters.Add(new QueryParameter("@Skin", Skin));
-			string query = "`ComponentSkin` = @Skin";
+			var whereClause = DB.Column("ComponentSkin").IsEqualTo(Skin);
 			if (Skin != (int)eComponentSkin.Keep && Skin != (int)eComponentSkin.Tower && Skin != (int)eComponentSkin.Gate)
 			{
-				parameters.Add(new QueryParameter("@Rotation", ComponentHeading));
-				query += " AND `ComponentRotation` = @Rotation";
+				whereClause = whereClause.And(DB.Column("ComponentRotation").IsEqualTo(ComponentHeading));
 			}
 			if (bg != null && GameServer.Instance.Configuration.ServerType != eGameServerType.GST_PvE)
 			{
 				// Battlegrounds, ignore all but GameKeepDoor
-				parameters.Add(new QueryParameter("@ClassType", "'DOL.GS.Keeps.GameKeepDoor'"));
-				query = query + " AND `ClassType` = @ClassType"; 
+				whereClause = whereClause.And(DB.Column("ClassType").IsEqualTo("DOL.GS.Keeps.GameKeepDoor"));
 			}
-
-			var DBPositions = GameServer.Database.SelectObjects<DBKeepPosition>(query, parameters.ToArray());
+			var DBPositions = DOLDB<DBKeepPosition>.SelectObjects(whereClause);
 
 			foreach (DBKeepPosition position in DBPositions)
 			{

--- a/GameServer/keeps/KeepHookPoint.cs
+++ b/GameServer/keeps/KeepHookPoint.cs
@@ -119,8 +119,7 @@ namespace DOL.GS.Keeps
 		{
 			m_hookpointTimer.Start(300000);//5*60*1000 = 5 min
 			GameEventMgr.RemoveHandler(m_object, GameLivingEvent.Dying, new DOLEventHandler(ObjectDie));
-			DBKeepHookPointItem item = GameServer.Database.SelectObjects<DBKeepHookPointItem>("`KeepID` = @KeepID AND `ComponentID` = @ComponentID AND `HookPointID` @HookPointID", 
-			                                                                                  new[] { new QueryParameter("@KeepID", Component.Keep.KeepID), new QueryParameter("@ComponentID", Component.ID), new QueryParameter("@HookPointID", ID) }).FirstOrDefault();
+			var item = DOLDB<DBKeepHookPointItem>.SelectObject(DB.Column("KeepID").IsEqualTo(Component.Keep.KeepID).And(DB.Column("ComponentID").IsEqualTo(Component.ID)).And(DB.Column("HookPointID").IsEqualTo(ID)));
 			if (item != null)
 				GameServer.Database.DeleteObject(item);
 		}

--- a/GameServer/keeps/KeepManager.cs
+++ b/GameServer/keeps/KeepManager.cs
@@ -144,9 +144,9 @@ namespace DOL.GS.Keeps
 				IList<DBKeepComponent> keepcomponents = null;
 
 				if (ServerProperties.Properties.USE_NEW_KEEPS == 0 || ServerProperties.Properties.USE_NEW_KEEPS == 2)
-					keepcomponents = GameServer.Database.SelectObjects<DBKeepComponent>("`Skin` < @Skin", new QueryParameter("@Skin", 20));
+					keepcomponents = DOLDB<DBKeepComponent>.SelectObjects(DB.Column("Skin").IsLessThan(20));
 				else if (ServerProperties.Properties.USE_NEW_KEEPS == 1)
-					keepcomponents = GameServer.Database.SelectObjects<DBKeepComponent>("`Skin` > @Skin", new QueryParameter("@Skin", 20));
+					keepcomponents = DOLDB<DBKeepComponent>.SelectObjects(DB.Column("Skin").IsGreatherThan(20));
 
 				if (keepcomponents != null)
 				{
@@ -838,7 +838,7 @@ namespace DOL.GS.Keeps
 
 			if (location != "")
 			{
-				Teleport t = GameServer.Database.SelectObjects<Teleport>("`TeleportID` = @TeleportID", new QueryParameter("@TeleportID", location)).FirstOrDefault();
+				Teleport t = DOLDB<Teleport>.SelectObject(DB.Column("TeleportID").IsEqualTo(location));
 				if (t != null)
 					player.MoveTo((ushort)t.RegionID, t.X, t.Y, t.Z, (ushort)t.Heading);
 			}

--- a/GameServer/keeps/Managers/Position Manager.cs
+++ b/GameServer/keeps/Managers/Position Manager.cs
@@ -41,8 +41,11 @@ namespace DOL.GS.Keeps
 		/// <returns>The position object</returns>
 		public static DBKeepPosition GetUsablePosition(GameKeepGuard guard)
 		{
-			return GameServer.Database.SelectObjects<DBKeepPosition>("`ClassType` != @ClassType AND `TemplateID` = @TemplateID AND `ComponentSkin` = @ComponentSkin AND `Height` <= @Height",
-			                                                         new [] { new QueryParameter("@ClassType", "DOL.GS.Keeps.Banner"), new QueryParameter("@TemplateID", guard.TemplateID), new QueryParameter("@ComponentSkin", guard.Component.Skin), new QueryParameter("@Height", guard.Component.Height) })
+			var filterClassType = DB.Column("ClassType").IsNotEqualTo("DOL.GS.Keeps.Banner");
+			var filterTemplateID = DB.Column("TemplateID").IsEqualTo(guard.TemplateID);
+			var filterComponentSkin = DB.Column("ComponentSkin").IsEqualTo(guard.Component.Skin);
+			var filterHeight = DB.Column("Height").IsLessOrEqualTo(guard.Component.Height);
+			return DOLDB<DBKeepPosition>.SelectObjects(filterClassType.And(filterTemplateID).And(filterComponentSkin).And(filterHeight))
 				.OrderByDescending(it => it.Height).FirstOrDefault();
 		}
 
@@ -53,8 +56,11 @@ namespace DOL.GS.Keeps
 		/// <returns>The position object</returns>
 		public static DBKeepPosition GetUsablePosition(GameKeepBanner b)
 		{
-			return GameServer.Database.SelectObjects<DBKeepPosition>("`ClassType` = @ClassType AND `TemplateID` = @TemplateID AND `ComponentSkin` = @ComponentSkin AND `Height` <= @Height",
-			                                                         new [] { new QueryParameter("@ClassType", "DOL.GS.Keeps.Banner"), new QueryParameter("@TemplateID", b.TemplateID), new QueryParameter("@ComponentSkin", b.Component.Skin), new QueryParameter("@Height", b.Component.Height) })
+			var filterClassType = DB.Column("ClassType").IsNotEqualTo("DOL.GS.Keeps.Banner");
+			var filterTemplateID = DB.Column("TemplateID").IsEqualTo(b.TemplateID);
+			var filterComponentSkin = DB.Column("ComponentSkin").IsEqualTo(b.Component.Skin);
+			var filterHeight = DB.Column("Height").IsLessOrEqualTo(b.Component.Height);
+			return DOLDB<DBKeepPosition>.SelectObjects(filterClassType.And(filterTemplateID).And(filterComponentSkin).And(filterHeight))
 				.OrderByDescending(it => it.Height).FirstOrDefault();
 		}
 
@@ -65,8 +71,10 @@ namespace DOL.GS.Keeps
 		/// <returns>The position object</returns>
 		public static DBKeepPosition GetPosition(GameKeepGuard guard)
 		{
-			return GameServer.Database.SelectObjects<DBKeepPosition>("`TemplateID` = @TemplateID AND `ComponentSkin` = @ComponentSkin AND `Height` <= @Height",
-			                                                        new [] { new QueryParameter("@TemplateID", guard.TemplateID), new QueryParameter("@ComponentSkin", guard.Component.Skin), new QueryParameter("@Height", guard.Component.Height) }).FirstOrDefault();
+			var filterTemplateID = DB.Column("TemplateID").IsEqualTo(guard.TemplateID);
+			var filterComponentSkin = DB.Column("ComponentSkin").IsEqualTo(guard.Component.Skin);
+			var filterHeight = DB.Column("Height").IsLessOrEqualTo(guard.Component.Height);
+			return DOLDB<DBKeepPosition>.SelectObject(filterTemplateID.And(filterComponentSkin).And(filterHeight));
 		}
 
 
@@ -314,7 +322,7 @@ namespace DOL.GS.Keeps
 		{
 			SortedList sorted = new SortedList();
 			pathID.Replace('\'', '/'); // we must replace the ', found no other way yet
-			DBPath dbpath = GameServer.Database.SelectObjects<DBPath>("`PathID` = @PathID", new QueryParameter("@PathID", pathID)).FirstOrDefault();
+			var dbpath = DOLDB<DBPath>.SelectObject(DB.Column("PathID").IsEqualTo(pathID));
 			IList<DBPathPoint> pathpoints = null;
 			ePathType pathType = ePathType.Once;
 
@@ -324,7 +332,7 @@ namespace DOL.GS.Keeps
 			}
 			if (pathpoints == null)
 			{
-				pathpoints = GameServer.Database.SelectObjects<DBPathPoint>("`PathID` = @PathID", new QueryParameter("@PathID", pathID));
+				pathpoints = DOLDB<DBPathPoint>.SelectObjects(DB.Column("PathID").IsEqualTo(pathID));
 			}
 
 			foreach (DBPathPoint point in pathpoints)
@@ -372,7 +380,7 @@ namespace DOL.GS.Keeps
 				return;
 
 			pathID.Replace('\'', '/'); // we must replace the ', found no other way yet
-			GameServer.Database.DeleteObject(GameServer.Database.SelectObjects<DBPath>("`PathID` = @PathID", new QueryParameter("@PathID", pathID)));
+			GameServer.Database.DeleteObject(DOLDB<DBPath>.SelectObjects(DB.Column("PathID").IsEqualTo(pathID)));
 			PathPoint root = MovementMgr.FindFirstPathPoint(path);
 
 			//Set the current pathpoint to the rootpoint!

--- a/GameServer/managers/playermanager/FriendsManager.cs
+++ b/GameServer/managers/playermanager/FriendsManager.cs
@@ -174,7 +174,7 @@ namespace DOL.GS.Friends
 				Player.Out.SendAddFriends(new[] { Friend });
 				Player.SerializedFriendsList = this[Player];
 
-				var offlineFriend = Database.SelectObjects<DOLCharacters>("`Name` = @Name", new QueryParameter("@Name", Friend)).FirstOrDefault();
+				var offlineFriend = Database.SelectObjects<DOLCharacters>(DB.Column("Name").IsEqualTo(Friend)).FirstOrDefault();
 
 				if (offlineFriend != null)
 				{

--- a/GameServer/packets/Client/168/CharacterCreateRequestHandler.cs
+++ b/GameServer/packets/Client/168/CharacterCreateRequestHandler.cs
@@ -591,7 +591,7 @@ namespace DOL.GS.PacketHandler.Client.v168
 
 							try
 							{
-								var objs = GameServer.Database.SelectObjects<InventoryItem>("`OwnerID` = @OwnerID", new QueryParameter("@OwnerID", character.ObjectId));
+								var objs = DOLDB<InventoryItem>.SelectObjects(DB.Column("OwnerID").IsEqualTo(character.ObjectId));
 								GameServer.Database.DeleteObject(objs);
 							}
 							catch (Exception e)
@@ -603,7 +603,7 @@ namespace DOL.GS.PacketHandler.Client.v168
 							// delete quests
 							try
 							{
-								var objs = GameServer.Database.SelectObjects<DBQuest>("`Character_ID` = @Character_ID", new QueryParameter("@Character_ID", character.ObjectId));
+								var objs = DOLDB<DBQuest>.SelectObjects(DB.Column("Character_ID").IsEqualTo(character.ObjectId));
 								GameServer.Database.DeleteObject(objs);
 							}
 							catch (Exception e)
@@ -615,7 +615,7 @@ namespace DOL.GS.PacketHandler.Client.v168
 							// delete ML steps
 							try
 							{
-								var objs = GameServer.Database.SelectObjects<DBCharacterXMasterLevel>("`Character_ID` = @Character_ID", new QueryParameter("@Character_ID", character.ObjectId));
+								var objs = DOLDB<DBCharacterXMasterLevel>.SelectObjects(DB.Column("Character_ID").IsEqualTo(character.ObjectId));
 								GameServer.Database.DeleteObject(objs);
 							}
 							catch (Exception e)

--- a/GameServer/packets/Client/168/DoorRequestHandler.cs
+++ b/GameServer/packets/Client/168/DoorRequestHandler.cs
@@ -100,7 +100,7 @@ namespace DOL.GS.PacketHandler.Client.v168
 				return;
 			}
 
-			var door = GameServer.Database.SelectObjects<DBDoor>("`InternalID` = @InternalID", new QueryParameter("@InternalID", doorID)).FirstOrDefault();
+			var door = DOLDB<DBDoor>.SelectObject(DB.Column("InternalID").IsEqualTo(doorID));
 			if (door != null)
 			{
 				if (doorType == 7 || doorType == 9)

--- a/GameServer/packets/Client/168/DuplicateNameCheckRequestHandler.cs
+++ b/GameServer/packets/Client/168/DuplicateNameCheckRequestHandler.cs
@@ -32,7 +32,7 @@ namespace DOL.GS.PacketHandler.Client.v168
 		{
 			string name = packet.ReadString(30);
 
-			var character = GameServer.Database.SelectObjects<DOLCharacters>("`Name` = @Name", new QueryParameter("@Name", name)).FirstOrDefault();
+			var character = DOLDB<DOLCharacters>.SelectObject(DB.Column("Name").IsEqualTo(name));
 			byte result = 0;
 			// Bad Name check.
 			if (character != null)

--- a/GameServer/packets/Client/168/HousingPlaceItemHandler.cs
+++ b/GameServer/packets/Client/168/HousingPlaceItemHandler.cs
@@ -584,7 +584,7 @@ namespace DOL.GS.PacketHandler.Client.v168
 												};
 
 								// If we already have soemthing here, do not place more
-								foreach (var hpitem in GameServer.Database.SelectObjects<DBHouseHookpointItem>("`HouseNumber` = @HouseNumber", new QueryParameter("@HouseNumber", house.HouseNumber)))
+								foreach (var hpitem in DOLDB<DBHouseHookpointItem>.SelectObjects(DB.Column("HouseNumber").IsEqualTo(house.HouseNumber)))
 								{
 									if (hpitem.HookpointID == point.HookpointID)
 									{
@@ -732,7 +732,7 @@ namespace DOL.GS.PacketHandler.Client.v168
 							}
 
 							// If we already have soemthing here, do not place more
-							foreach (var hpitem in GameServer.Database.SelectObjects<DBHouseHookpointItem>("`HouseNumber` = @HouseNumber", new QueryParameter("@HouseNumber", house.HouseNumber)))
+							foreach (var hpitem in DOLDB<DBHouseHookpointItem>.SelectObjects(DB.Column("HouseNumber").IsEqualTo(house.HouseNumber)))
 							{
 								if (hpitem.HookpointID == _position)
 								{

--- a/GameServer/packets/Client/168/LoginRequestHandler.cs
+++ b/GameServer/packets/Client/168/LoginRequestHandler.cs
@@ -311,7 +311,7 @@ namespace DOL.GS.PacketHandler.Client.v168
 
 								// check for account bombing
 								TimeSpan ts;
-								IList<Account> allAccByIp = GameServer.Database.SelectObjects<Account>("`LastLoginIP` = @LastLoginIP", new QueryParameter("@LastLoginIP", ipAddress));
+								var allAccByIp = DOLDB<Account>.SelectObjects(DB.Column("LastLoginIP").IsEqualTo(ipAddress));
 								int totalacc = 0;
 								foreach (Account ac in allAccByIp)
 								{

--- a/GameServer/packets/Client/168/RegionChangeRequestHandler.cs
+++ b/GameServer/packets/Client/168/RegionChangeRequestHandler.cs
@@ -55,14 +55,8 @@ namespace DOL.GS.PacketHandler.Client.v168
                 targetRealm = client.Player.CurrentZone.Realm;
 			}
 
-			var zonePoint =	GameServer.Database.SelectObjects<ZonePoint>(
-				"`Id` = @Id AND (`Realm` = @Realm OR `Realm` = @DefaultRealm OR `Realm` IS NULL)",
-				new [] {
-					new QueryParameter("@Id", jumpSpotId),
-					new QueryParameter("@Realm", (byte)targetRealm),
-					new QueryParameter("@DefaultRealm", 0)
-				})
-				.FirstOrDefault();
+			var filterRealm = DB.Column("Realm").IsEqualTo((byte)targetRealm).Or(DB.Column("Realm").IsEqualTo(0)).Or(DB.Column("Realm").IsNull());
+			var zonePoint = DOLDB<ZonePoint>.SelectObject(DB.Column("Id").IsEqualTo(jumpSpotId).And(filterRealm));
 
 			if (zonePoint == null || zonePoint.TargetRegion == 0)
 			{

--- a/GameServer/packets/Server/PacketLib1104.cs
+++ b/GameServer/packets/Server/PacketLib1104.cs
@@ -78,10 +78,9 @@ namespace DOL.GS.PacketHandler
 					
 					if (charsBySlot.Any())
 					{
-						var ownerIdWhere = DB.Column("OwnerID").IsIn(charsBySlot.Values.Select(c => c.ObjectId));
-						var slotWhere = DB.Column("SlotPosition").IsGreaterOrEqualTo((int)eInventorySlot.MinEquipable)
+						var filterBySlotPosition = DB.Column("SlotPosition").IsGreaterOrEqualTo((int)eInventorySlot.MinEquipable)
 							.And(DB.Column("SlotPosition").IsLessOrEqualTo((int)eInventorySlot.MaxEquipable));
-						var allItems = GameServer.Database.SelectObjects<InventoryItem>(ownerIdWhere.And(slotWhere));
+						var allItems = DOLDB<InventoryItem>.SelectObjects(DB.Column("OwnerID").IsIn(charsBySlot.Values.Select(c => c.ObjectId)).And(filterBySlotPosition));
 						
 						foreach (InventoryItem item in allItems)
 						{

--- a/GameServer/packets/Server/PacketLib1124.cs
+++ b/GameServer/packets/Server/PacketLib1124.cs
@@ -249,8 +249,9 @@ namespace DOL.GS.PacketHandler
 
 					if (charsBySlot.Any())
 					{
-						var filterBySlotPosition = DB.Column("SlotPosition").IsGreaterOrEqualTo((int)eInventorySlot.MinEquipable).And(DB.Column("SlotPosition").IsLessOrEqualTo((int)eInventorySlot.MaxEquipable));
-						var allItems = DOLDB<InventoryItem>.MultipleSelectObjects(charsBySlot.Select(kv => DB.Column("OwnerID").IsEqualTo(kv.Value.ObjectId).And(filterBySlotPosition))).SelectMany(objs => objs);
+						var filterBySlotPosition = DB.Column("SlotPosition").IsGreaterOrEqualTo((int)eInventorySlot.MinEquipable)
+							.And(DB.Column("SlotPosition").IsLessOrEqualTo((int)eInventorySlot.MaxEquipable));
+						var allItems = DOLDB<InventoryItem>.SelectObjects(DB.Column("OwnerID").IsIn(charsBySlot.Values.Select(c => c.ObjectId)).And(filterBySlotPosition));
 
 						foreach (InventoryItem item in allItems)
 						{

--- a/GameServer/packets/Server/PacketLib1124.cs
+++ b/GameServer/packets/Server/PacketLib1124.cs
@@ -249,9 +249,8 @@ namespace DOL.GS.PacketHandler
 
 					if (charsBySlot.Any())
 					{
-						var allItems = GameServer.Database.SelectObjects<InventoryItem>("`OwnerID` = @OwnerID AND `SlotPosition` >= @MinEquipable AND `SlotPosition` <= @MaxEquipable",
-																						charsBySlot.Select(kv => new[] { new QueryParameter("@OwnerID", kv.Value.ObjectId), new QueryParameter("@MinEquipable", (int)eInventorySlot.MinEquipable), new QueryParameter("@MaxEquipable", (int)eInventorySlot.MaxEquipable) }))
-							.SelectMany(objs => objs);
+						var filterBySlotPosition = DB.Column("SlotPosition").IsGreaterOrEqualTo((int)eInventorySlot.MinEquipable).And(DB.Column("SlotPosition").IsLessOrEqualTo((int)eInventorySlot.MaxEquipable));
+						var allItems = DOLDB<InventoryItem>.MultipleSelectObjects(charsBySlot.Select(kv => DB.Column("OwnerID").IsEqualTo(kv.Value.ObjectId).And(filterBySlotPosition))).SelectMany(objs => objs);
 
 						foreach (InventoryItem item in allItems)
 						{

--- a/GameServer/packets/Server/PacketLib1125.cs
+++ b/GameServer/packets/Server/PacketLib1125.cs
@@ -127,9 +127,8 @@ namespace DOL.GS.PacketHandler
 
 					if (charsBySlot.Any())
 					{
-						var allItems = GameServer.Database.SelectObjects<InventoryItem>("`OwnerID` = @OwnerID AND `SlotPosition` >= @MinEquipable AND `SlotPosition` <= @MaxEquipable",
-																						charsBySlot.Select(kv => new[] { new QueryParameter("@OwnerID", kv.Value.ObjectId), new QueryParameter("@MinEquipable", (int)eInventorySlot.MinEquipable), new QueryParameter("@MaxEquipable", (int)eInventorySlot.MaxEquipable) }))
-							.SelectMany(objs => objs);
+						var filterBySlotPosition = DB.Column("SlotPosition").IsGreaterOrEqualTo((int)eInventorySlot.MinEquipable).And(DB.Column("SlotPosition").IsLessOrEqualTo((int)eInventorySlot.MaxEquipable));
+						var allItems = DOLDB<InventoryItem>.MultipleSelectObjects(charsBySlot.Select(kv => DB.Column("OwnerID").IsEqualTo(kv.Value.ObjectId).And(filterBySlotPosition))).SelectMany(objs => objs);
 
 						foreach (InventoryItem item in allItems)
 						{

--- a/GameServer/packets/Server/PacketLib1125.cs
+++ b/GameServer/packets/Server/PacketLib1125.cs
@@ -127,8 +127,9 @@ namespace DOL.GS.PacketHandler
 
 					if (charsBySlot.Any())
 					{
-						var filterBySlotPosition = DB.Column("SlotPosition").IsGreaterOrEqualTo((int)eInventorySlot.MinEquipable).And(DB.Column("SlotPosition").IsLessOrEqualTo((int)eInventorySlot.MaxEquipable));
-						var allItems = DOLDB<InventoryItem>.MultipleSelectObjects(charsBySlot.Select(kv => DB.Column("OwnerID").IsEqualTo(kv.Value.ObjectId).And(filterBySlotPosition))).SelectMany(objs => objs);
+						var filterBySlotPosition = DB.Column("SlotPosition").IsGreaterOrEqualTo((int)eInventorySlot.MinEquipable)
+							.And(DB.Column("SlotPosition").IsLessOrEqualTo((int)eInventorySlot.MaxEquipable));
+						var allItems = DOLDB<InventoryItem>.SelectObjects(DB.Column("OwnerID").IsIn(charsBySlot.Values.Select(c => c.ObjectId)).And(filterBySlotPosition));
 
 						foreach (InventoryItem item in allItems)
 						{

--- a/GameServer/packets/Server/PacketLib1126.cs
+++ b/GameServer/packets/Server/PacketLib1126.cs
@@ -104,8 +104,9 @@ namespace DOL.GS.PacketHandler
 
 				if (charsBySlot.Any())
 				{
-					var filterBySlotPosition = DB.Column("SlotPosition").IsGreaterOrEqualTo((int)eInventorySlot.MinEquipable).And(DB.Column("SlotPosition").IsLessOrEqualTo((int)eInventorySlot.MaxEquipable));
-					var allItems = DOLDB<InventoryItem>.MultipleSelectObjects(charsBySlot.Select(kv => DB.Column("OwnerID").IsEqualTo(kv.Value.ObjectId).And(filterBySlotPosition))).SelectMany(objs => objs);
+					var filterBySlotPosition = DB.Column("SlotPosition").IsGreaterOrEqualTo((int)eInventorySlot.MinEquipable)
+						.And(DB.Column("SlotPosition").IsLessOrEqualTo((int)eInventorySlot.MaxEquipable));
+					var allItems = DOLDB<InventoryItem>.SelectObjects(DB.Column("OwnerID").IsIn(charsBySlot.Values.Select(c => c.ObjectId)).And(filterBySlotPosition));
 
 					foreach (InventoryItem item in allItems)
 					{

--- a/GameServer/packets/Server/PacketLib1126.cs
+++ b/GameServer/packets/Server/PacketLib1126.cs
@@ -104,15 +104,8 @@ namespace DOL.GS.PacketHandler
 
 				if (charsBySlot.Any())
 				{
-					var allItems = GameServer.Database.SelectObjects<InventoryItem>(
-							"`OwnerID` = @OwnerID AND `SlotPosition` >= @MinEquipable AND `SlotPosition` <= @MaxEquipable",
-							charsBySlot.Select(kv => new[] {
-								new QueryParameter("@OwnerID", kv.Value.ObjectId),
-								new QueryParameter("@MinEquipable", (int)eInventorySlot.MinEquipable),
-								new QueryParameter("@MaxEquipable", (int)eInventorySlot.MaxEquipable)
-							})
-						)
-						.SelectMany(objs => objs);
+					var filterBySlotPosition = DB.Column("SlotPosition").IsGreaterOrEqualTo((int)eInventorySlot.MinEquipable).And(DB.Column("SlotPosition").IsLessOrEqualTo((int)eInventorySlot.MaxEquipable));
+					var allItems = DOLDB<InventoryItem>.MultipleSelectObjects(charsBySlot.Select(kv => DB.Column("OwnerID").IsEqualTo(kv.Value.ObjectId).And(filterBySlotPosition))).SelectMany(objs => objs);
 
 					foreach (InventoryItem item in allItems)
 					{

--- a/GameServer/packets/Server/PacketLib168.cs
+++ b/GameServer/packets/Server/PacketLib168.cs
@@ -253,8 +253,8 @@ namespace DOL.GS.PacketHandler
 							pak.WriteByte((byte) characters[j].Empathy);
 							pak.WriteByte((byte) characters[j].Charisma);
 							
-							var items = GameServer.Database.SelectObjects<InventoryItem>("`OwnerID` = @OwnerID AND `SlotPosition` >= @SlotPositionMin AND `SlotPosition` <= @SlotPositionMax",
-								                                                         new[] { new QueryParameter("@OwnerID", characters[j].ObjectId), new QueryParameter("@SlotPositionMin", 10), new QueryParameter("@SlotPositionMax", 29) });
+							var items = DOLDB<InventoryItem>.SelectObjects(DB.Column("OwnerID").IsEqualTo(characters[j].ObjectId)
+								.And(DB.Column("SlotPosition").IsGreaterOrEqualTo(10).And(DB.Column("SlotPosition").IsLessOrEqualTo(29))));
 							int found = 0;
 							//16 bytes: armor model
 							for (int k = 0x15; k < 0x1D; k++)

--- a/GameServer/packets/Server/PacketLib173.cs
+++ b/GameServer/packets/Server/PacketLib173.cs
@@ -299,8 +299,7 @@ namespace DOL.GS.PacketHandler
 							if (characters[j].AccountSlot == i)
 							{
 								pak.FillString(characters[j].Name, 24);
-								items = GameServer.Database.SelectObjects<InventoryItem>("`OwnerID` = @OwnerID AND `SlotPosition` >= @SlotPositionMin AND `SlotPosition` <= @SlotPositionMax",
-								                                                         new[] { new QueryParameter("@OwnerID", characters[j].ObjectId), new QueryParameter("@SlotPositionMin", 10), new QueryParameter("@SlotPositionMax", 37) });
+								items = DOLDB<InventoryItem>.SelectObjects(DB.Column("OwnerID").IsEqualTo(characters[j].ObjectId).And(DB.Column("SlotPosition").IsGreaterOrEqualTo(10)).And(DB.Column("SlotPosition").IsLessOrEqualTo(37)));
 								byte ExtensionTorso = 0;
 								byte ExtensionGloves = 0;
 								byte ExtensionBoots = 0;

--- a/GameServer/packets/Server/PacketLib174.cs
+++ b/GameServer/packets/Server/PacketLib174.cs
@@ -79,8 +79,7 @@ namespace DOL.GS.PacketHandler
 							if (characters[j].AccountSlot == i)
 							{
 								pak.FillString(characters[j].Name, 24);
-								items = GameServer.Database.SelectObjects<InventoryItem>("`OwnerID` = @OwnerID AND `SlotPosition` >= @SlotPositionMin AND `SlotPosition` <= @SlotPositionMax",
-								                                                         new[] { new QueryParameter("@OwnerID", characters[j].ObjectId), new QueryParameter("@SlotPositionMin", 10), new QueryParameter("@SlotPositionMax", 37) });
+								items = DOLDB<InventoryItem>.SelectObjects(DB.Column("OwnerID").IsEqualTo(characters[j].ObjectId).And(DB.Column("SlotPosition").IsGreaterOrEqualTo(10)).And(DB.Column("SlotPosition").IsLessOrEqualTo(37)));
 								byte ExtensionTorso = 0;
 								byte ExtensionGloves = 0;
 								byte ExtensionBoots = 0;

--- a/GameServer/packets/Server/PacketLib199.cs
+++ b/GameServer/packets/Server/PacketLib199.cs
@@ -81,8 +81,7 @@ namespace DOL.GS.PacketHandler
 							if (characters[j].AccountSlot == i)
 							{
 								pak.FillString(characters[j].Name, 24);
-								items = GameServer.Database.SelectObjects<InventoryItem>("`OwnerID` = @OwnerID AND `SlotPosition` >= @SlotPositionMin AND `SlotPosition` <= @SlotPositionMax",
-								                                                         new[] { new QueryParameter("@OwnerID", characters[j].ObjectId), new QueryParameter("@SlotPositionMin", 10), new QueryParameter("@SlotPositionMax", 37) });
+								items = DOLDB<InventoryItem>.SelectObjects(DB.Column("OwnerID").IsEqualTo(characters[j].ObjectId).And(DB.Column("SlotPosition").IsGreaterOrEqualTo(10)).And(DB.Column("SlotPosition").IsLessOrEqualTo(37)));
 								byte ExtensionTorso = 0;
 								byte ExtensionGloves = 0;
 								byte ExtensionBoots = 0;

--- a/GameServer/quests/QuestsMgr/DataQuest.cs
+++ b/GameServer/quests/QuestsMgr/DataQuest.cs
@@ -982,7 +982,7 @@ namespace DOL.GS.Quests
 		/// <returns></returns>
 		public static CharacterXDataQuest GetCharacterQuest(GamePlayer player, int ID, bool create)
 		{
-			CharacterXDataQuest charQuest = GameServer.Database.SelectObjects<CharacterXDataQuest>("`Character_ID` = @Character_ID AND `DataQuestID` = @DataQuestID", new[] { new QueryParameter("@Character_ID", player.QuestPlayerID), new QueryParameter("@DataQuestID", ID) }).FirstOrDefault();
+			CharacterXDataQuest charQuest = DOLDB<CharacterXDataQuest>.SelectObject(DB.Column("Character_ID").IsEqualTo(player.QuestPlayerID).And(DB.Column("DataQuestID").IsEqualTo(ID)));
 
 			if (charQuest == null && create)
 			{

--- a/GameServer/quests/QuestsMgr/QuestMgr.cs
+++ b/GameServer/quests/QuestsMgr/QuestMgr.cs
@@ -143,7 +143,7 @@ namespace DOL.GS.Quests
 				string tempID = Convert.ToString(identifier);
 
                 // TODO: Dirty Hack this should be done better
-                Mob mob = GameServer.Database.SelectObjects<Mob>("`Mob_ID` = @MobID OR `Name` = @Name", new[] { new QueryParameter("@MobID", tempID), new QueryParameter("@Name", tempID) }).FirstOrDefault();
+                var mob = DOLDB<Mob>.SelectObject(DB.Column("Mob_ID").IsEqualTo(tempID).Or(DB.Column("Name").IsEqualTo(tempID)));
 
                 GameNPC[] livings = WorldMgr.GetNPCsByName(mob.Name,(eRealm) mob.Realm);
 
@@ -206,7 +206,7 @@ namespace DOL.GS.Quests
 			{
 				string tempID = Convert.ToString(identifier);
 
-                Mob mob = GameServer.Database.SelectObjects<Mob>("`Mob_ID` = @MobID OR `Name` = @Name", new[] { new QueryParameter("@MobID", tempID), new QueryParameter("@Name", tempID) }).FirstOrDefault();
+                var mob = DOLDB<Mob>.SelectObject(DB.Column("Mob_ID").IsEqualTo(tempID).Or(DB.Column("Name").IsEqualTo(tempID)));
 
 				GameNPC[] npcs = WorldMgr.GetNPCsByName(mob.Name,(eRealm) mob.Realm);
 

--- a/GameServer/quests/Tasks/CraftTask.cs
+++ b/GameServer/quests/Tasks/CraftTask.cs
@@ -157,7 +157,8 @@ namespace DOL.GS.Quests
 			int lowLevel = mediumCraftingLevel - 20;
 			int highLevel = mediumCraftingLevel + 20;
 
-			var craftitem = GameServer.Database.SelectObjects<DBCraftedItem>("`CraftingSkillType` = @CraftingSkillType AND `CraftingLevel` > @CraftingLevelLow AND `CraftingLevel` < @CraftingLevelHigh", new[] { new QueryParameter("@CraftingSkillType", (int)player.CraftingPrimarySkill), new QueryParameter("@CraftingLevelLow", lowLevel), new QueryParameter("@CraftingLevelHigh", highLevel) });
+			var craftitem = DOLDB<DBCraftedItem>.SelectObjects(DB.Column("CraftingSkillType").IsEqualTo((int)player.CraftingPrimarySkill)
+				.And(DB.Column("CraftingLevel").IsGreatherThan(lowLevel).And(DB.Column("CraftingLevel").IsLessThan(highLevel))));
 			int craftrnd = Util.Random(craftitem.Count);
 
 			ItemTemplate template = GameServer.Database.FindObjectByKey<ItemTemplate>(craftitem[craftrnd].Id_nb);

--- a/GameServer/serverrules/AbstractServerRules.cs
+++ b/GameServer/serverrules/AbstractServerRules.cs
@@ -72,7 +72,7 @@ namespace DOL.GS.ServerRules
 
 			// Ban account
 			IList<DBBannedAccount> objs;
-			objs = GameServer.Database.SelectObjects<DBBannedAccount>("(`Type` = @TypeA OR `Type` = @TypeB) AND `Account` = @Account", new[] { new QueryParameter("@TypeA", "A"), new QueryParameter("@TypeB", "B"), new QueryParameter("@Account", username) });
+			objs = DOLDB<DBBannedAccount>.SelectObjects(DB.Column("Type").IsEqualTo("A").Or(DB.Column("Type").IsEqualTo("B")).And(DB.Column("Account").IsEqualTo(username)));
 			if (objs.Count > 0)
 			{
 				client.IsConnected = false;
@@ -82,8 +82,8 @@ namespace DOL.GS.ServerRules
 			}
 
 			// Ban IP Address or range (example: 5.5.5.%)
-			string accip = GameServer.Database.Escape(client.TcpEndpointAddress);
-			objs = GameServer.Database.SelectObjects<DBBannedAccount>("(`Type` = @TypeI OR `Type` = @TypeB) AND @Ip LIKE `Ip`", new[] { new QueryParameter("@TypeI", "I"), new QueryParameter("@TypeB", "B"), new QueryParameter("@Ip", accip) });
+			string accip = client.TcpEndpointAddress;
+			objs = DOLDB<DBBannedAccount>.SelectObjects(DB.Column("Type").IsEqualTo("I").Or(DB.Column("Type").IsEqualTo("B")).And(DB.Column("Ip").IsLike(accip)));
 			if (objs.Count > 0)
 			{
 				client.IsConnected = false;

--- a/GameServer/skillhandler/Climbing.cs
+++ b/GameServer/skillhandler/Climbing.cs
@@ -57,7 +57,7 @@ namespace DOL.GS.SkillHandler
 			if (spellid == -1)
 			{
 				spellid=0;
-				DBSpell climbSpell = GameServer.Database.SelectObjects<DBSpell>("`Name` = @Name", new QueryParameter("@Name", Abilities.ClimbSpikes)).FirstOrDefault();
+				DBSpell climbSpell = DOLDB<DBSpell>.SelectObject(DB.Column("Name").IsEqualTo(Abilities.ClimbSpikes));
 				if (climbSpell != null)
 					spellid = climbSpell.SpellID;
 			}

--- a/GameServer/world/Instance/Instance.cs
+++ b/GameServer/world/Instance/Instance.cs
@@ -71,7 +71,7 @@ namespace DOL.GS
 		/// <param name="instanceName"></param>
 		public virtual void LoadFromDatabase(string instanceName)
 		{
-			var objects = GameServer.Database.SelectObjects<DBInstanceXElement>("`InstanceID` = @InstanceID", new QueryParameter("@InstanceID", instanceName));
+			var objects = DOLDB<DBInstanceXElement>.SelectObjects(DB.Column("InstanceID").IsEqualTo(instanceName));
 
 			if (objects.Count == 0)
 				return;

--- a/GameServer/world/Instance/RegionInstance.cs
+++ b/GameServer/world/Instance/RegionInstance.cs
@@ -112,8 +112,8 @@ namespace DOL.GS
                 return;
 
             Assembly gasm = Assembly.GetAssembly(typeof(GameServer));
-            var staticObjs = GameServer.Database.SelectObjects<WorldObject>("`Region` = @Region", new QueryParameter("@Region", Skin));
-            var areaObjs = GameServer.Database.SelectObjects<DBArea>("`Region` = @Region", new QueryParameter("@Region", Skin));            
+            var staticObjs = DOLDB<WorldObject>.SelectObjects(DB.Column("Region").IsEqualTo(Skin));
+            var areaObjs = DOLDB<DBArea>.SelectObjects(DB.Column("Region").IsEqualTo(Skin));            
             
             int count = mobObjs.Length + staticObjs.Count;
             if (count > 0) PreAllocateRegionSpace(count + 100);

--- a/GameServer/world/Region.cs
+++ b/GameServer/world/Region.cs
@@ -790,8 +790,8 @@ namespace DOL.GS
                 return;
 
             Assembly gasm = Assembly.GetAssembly(typeof(GameServer));
-            var staticObjs = GameServer.Database.SelectObjects<WorldObject>("`Region` = @Region", new QueryParameter("@Region", ID));
-            var bindPoints = GameServer.Database.SelectObjects<BindPoint>("`Region` = @Region", new QueryParameter("@Region", ID));
+            var staticObjs = DOLDB<WorldObject>.SelectObjects(DB.Column("Region").IsEqualTo(ID));
+            var bindPoints = DOLDB<BindPoint>.SelectObjects(DB.Column("Region").IsEqualTo(ID));
             int count = mobObjs.Length + staticObjs.Count;
             if (count > 0) PreAllocateRegionSpace(count + 100);
             int myItemCount = staticObjs.Count;

--- a/GameServer/world/WorldMgr.cs
+++ b/GameServer/world/WorldMgr.cs
@@ -346,7 +346,7 @@ namespace DOL.GS
 			{
 				foreach (string loadRegion in Util.SplitCSV(ServerProperties.Properties.DEBUG_LOAD_REGIONS, true))
 				{
-					mobList.AddRange(GameServer.Database.SelectObjects<Mob>("`Region` = @Region", new QueryParameter("@Region", loadRegion)));
+					mobList.AddRange(DOLDB<Mob>.SelectObjects(DB.Column("Region").IsEqualTo(loadRegion)));
 				}
 			}
 			else

--- a/GameServer/world/ZonePointEffects.cs
+++ b/GameServer/world/ZonePointEffects.cs
@@ -38,7 +38,7 @@ namespace DOL.GS.GameEvents
 			NpcTemplate zp;
 			try{
 				model = (ushort)ServerProperties.Properties.ZONEPOINT_NPCTEMPLATE;
-				zp = new NpcTemplate(GameServer.Database.SelectObjects<DBNpcTemplate>("`TemplateId` = @TemplateId", new QueryParameter("@TemplateId", model)).FirstOrDefault());
+				zp = new NpcTemplate(DOLDB<DBNpcTemplate>.SelectObjects(DB.Column("TemplateId").IsEqualTo(model)).FirstOrDefault());
 				if (model <= 0 || zp == null) throw new ArgumentNullException();
 			}
 			catch {

--- a/GameServerScripts/dbupdater/GuildAndAllianceUpdate.cs
+++ b/GameServerScripts/dbupdater/GuildAndAllianceUpdate.cs
@@ -42,13 +42,12 @@ namespace DOL.GS.DatabaseUpdate
 				log.Info("Start Searching for records that need update...");
 			
 			// Change the Leader Relation if Missing
-			var alliances = GameServer.Database.SelectObjects<DBAlliance>("LeaderGuildID = @LeaderGuildID OR LeaderGuildID IS NULL", new QueryParameter("@LeaderGuildID", string.Empty));
+			var alliances = DOLDB<DBAlliance>.SelectObjects(DB.Column("LeaderGuildID").IsEqualTo(string.Empty).Or(DB.Column("LeaderGuildID").IsNull()));
 			
 			if (alliances.Any())
 			{
 				
-				var leadingGuilds = GameServer.Database.SelectObjects<DBGuild>("AllianceID = @AllianceID AND GuildName = @GuildName",
-				                                                               alliances.Select(al => new [] { new QueryParameter("@AllianceID", al.ObjectId), new QueryParameter("@GuildName", al.AllianceName) }));
+				var leadingGuilds = DOLDB<DBGuild>.MultipleSelectObjects(alliances.Select(al => DB.Column("AllianceID").IsEqualTo(al.ObjectId).And(DB.Column("GuildName").IsEqualTo(al.AllianceName))));
 				
 				var alliancesWithLeader = leadingGuilds.Select((gd, i) => {
 				                                               	var al = alliances[i];

--- a/Tests/IntegrationTests/Database/InterfaceTests.cs
+++ b/Tests/IntegrationTests/Database/InterfaceTests.cs
@@ -980,11 +980,10 @@ namespace DOL.Integration.Database
 			CollectionAssert.AreEqual(orderedObjs.Select(obj => obj.TestField.ToLower()), resultsMany.Select(obj => obj.TestField.ToLower()),
 			                          "Retrieve Sets from Select Objects should be Equal to Parameter Set Field Value...");
 
-			var parameterManyWithMissing = new [] { new [] { new QueryParameter("@TestField", "No Known Value"), new QueryParameter("@ObjectId", "Probably Nothing") },
-			new [] { new QueryParameter("@TestField", "Absolutely None"), new QueryParameter("@ObjectId", "Nothing for Sure") } }
-			.Concat(orderedObjs.Select(obj => new [] { new QueryParameter("@Testfield", obj.TestField), new QueryParameter("@ObjectId", obj.ObjectId) }));
-			
-			var retrieveManyWithMissing = Database.SelectObjects<TestTable>("`TestField` = @TestField AND `Test_Table_ID` = @ObjectId", parameterManyWithMissing);
+			var parameterManyWithMissing = new [] { ("No Known Value", "Probably Nothing"),("Absolutely None","Nothing for Sure")}
+			.Concat(orderedObjs.Select(obj => (obj.TestField, obj.ObjectId)));
+			var manyQueriesWithMissing = parameterManyWithMissing.Select(tuple => DB.Column("TestField").IsEqualTo(tuple.Item1).And(DB.Column("Test_Table_ID").IsEqualTo(tuple.Item2)));
+			var retrieveManyWithMissing = Database.MultipleSelectObjects<TestTable>(manyQueriesWithMissing);
 			
 			Assert.IsNotNull(retrieveManyWithMissing, "Retrieve Sets from Select Objects should not return null value...");
 			Assert.IsNotEmpty(retrieveManyWithMissing, "Retrieve Set from Select Objects should not be Empty...");

--- a/Tests/IntegrationTests/Database/InterfaceTests.cs
+++ b/Tests/IntegrationTests/Database/InterfaceTests.cs
@@ -921,7 +921,19 @@ namespace DOL.Integration.Database
 
 			Assert.AreEqual(1, resultsWithTestfieldNull.Count);
 		}
-		
+
+		[Test]
+		public void SelectObjects_KeywordAsColumnName_SameAsAddedObjects()
+		{
+			Database.RegisterDataObject(typeof(SqlKeywordTable));
+			var firstEntry = new SqlKeywordTable { Type = "SomeText" };
+			Database.AddObject(firstEntry);
+
+			var result = Database.SelectObjects<SqlKeywordTable>(DB.Column("Type").IsEqualTo(firstEntry.Type));
+
+			CollectionAssert.Contains(result.Select(obj => obj.ObjectId), firstEntry.ObjectId, "Select Objects with Simple Where clause should retrieve Object similar to Created one...");
+		}
+
 		/// <summary>
 		/// Test IObjectDatabase.SelectObjects`TObject(string, IEnumerable`IEnumerable`KeyValuePair`string, object)
 		/// </summary>
@@ -1105,7 +1117,7 @@ namespace DOL.Integration.Database
 			
 			Assert.AreEqual(1, filterCount, "Test Table should return same object count as filtered collection...");
 		}
-		
+
 		/// <summary>
 		/// Test IObjectDatabase.GetObjectCount`TObject
 		/// with null where clause

--- a/Tests/IntegrationTests/Database/InterfaceTests.cs
+++ b/Tests/IntegrationTests/Database/InterfaceTests.cs
@@ -1071,7 +1071,6 @@ namespace DOL.Integration.Database
 		public void TestSelectAllNonRegistered()
 		{
 			Assert.Throws(typeof(DatabaseException), () => Database.SelectAllObjects<TableNotRegistered>(), "Trying to Query a Non Registered Table should throw a DatabaseException...");
-			Assert.Throws(typeof(DatabaseException), () => Database.SelectAllObjects<TableNotRegistered>(DOL.Database.Transaction.IsolationLevel.DEFAULT), "Trying to Query a Non Registered Table should throw a DatabaseException...");
 		}
 		#endregion
 		

--- a/Tests/IntegrationTests/Database/InterfaceTests.cs
+++ b/Tests/IntegrationTests/Database/InterfaceTests.cs
@@ -1023,8 +1023,8 @@ namespace DOL.Integration.Database
 			
 			Assert.IsNotEmpty(allobjects, "This Test Need some Data to be Accurate...");
 
-			Assert.Throws(typeof(NullReferenceException), () => Database.SelectObject<TestTable>((WhereExpression)null), "");
-			Assert.Throws(typeof(NullReferenceException), () => Database.SelectObjects<TestTable>((WhereExpression)null), "");
+			Assert.Throws(typeof(NullReferenceException), () => Database.SelectObject<TestTable>((WhereClause)null), "");
+			Assert.Throws(typeof(NullReferenceException), () => Database.SelectObjects<TestTable>((WhereClause)null), "");
 			Assert.Throws(typeof(ArgumentNullException), () => Database.MultipleSelectObjects<TestTable>(null));
 		}
 		

--- a/Tests/IntegrationTests/Database/InterfaceTests.cs
+++ b/Tests/IntegrationTests/Database/InterfaceTests.cs
@@ -950,7 +950,7 @@ namespace DOL.Integration.Database
 			Assert.IsTrue(added, "TestTable Objects should be added successfully...");
 
 			var parameters = new[] { "Test Select Group1", "Test Select Group2", "Test Select Group3", "Test Select Group4" };
-			var retrieve = parameters.Select(parameter => Database.SelectObjects<TestTable>(DB.Column("TestField").IsEqualTo(parameter)));
+			var retrieve = Database.MultipleSelectObjects<TestTable>(parameters.Select(parameter => DB.Column("TestField").IsEqualTo(parameter)));
 
 			var objectByGroup = new []{ "Test Select Group1", "Test Select Group2", "Test Select Group3", "Test Select Group4" }
 			.Select((grp, index) => new { Grp = grp, Objects = retrieve.ElementAt(index) });
@@ -969,7 +969,7 @@ namespace DOL.Integration.Database
 			}
 
 			var orderedObjs = objs.SelectMany(obj => obj.Value).ToArray();
-			var retrieveMany = orderedObjs.Select(obj => Database.SelectObjects<TestTable>(DB.Column("TestField").IsEqualTo(obj.TestField).And(DB.Column("Test_Table_ID").IsEqualTo(obj.ObjectId))));
+			var retrieveMany = Database.MultipleSelectObjects<TestTable>(orderedObjs.Select(obj => DB.Column("TestField").IsEqualTo(obj.TestField).And(DB.Column("Test_Table_ID").IsEqualTo(obj.ObjectId))));
 			
 			Assert.IsNotNull(retrieveMany, "Retrieve Sets from Select Objects should not return null value...");
 			Assert.IsNotEmpty(retrieveMany, "Retrieve Set from Select Objects should not be Empty...");

--- a/Tests/IntegrationTests/Database/InterfaceTests.cs
+++ b/Tests/IntegrationTests/Database/InterfaceTests.cs
@@ -898,14 +898,6 @@ namespace DOL.Integration.Database
 			
 			Assert.IsNotEmpty(allobjects, "Select Objects Test Need some Data to be Accurate...");
 			
-			var nullWhere = Database.SelectObjects<TestTable>("", new QueryParameter[] { });
-			
-			CollectionAssert.AreEqual(allobjects.Select(obj => obj.ObjectId), nullWhere.Select(obj => obj.ObjectId), "Select Objects with Null Where clause should retrieve Objects similar to Select All...");
-			
-			var dumbWhere = Database.SelectObjects<TestTable>("@whClause", new QueryParameter("@whClause", 1));
-			
-			CollectionAssert.AreEqual(allobjects.Select(obj => obj.ObjectId), dumbWhere.Select(obj => obj.ObjectId), "Select Objects with Dumb Where clause should retrieve Objects similar to Select All...");
-			
 			var simpleWhere = Database.SelectObjects<TestTable>(DB.Column("TestField").IsEqualTo(objInitial.TestField));
 			
 			CollectionAssert.Contains(simpleWhere.Select(obj => obj.ObjectId), objInitial.ObjectId, "Select Objects with Simple Where clause should retrieve Object similar to Created one...");
@@ -996,7 +988,7 @@ namespace DOL.Integration.Database
 			
 			
 		}
-		
+
 		/// <summary>
 		/// Test IObjectDatabase.SelectObject(s)`TObject()
 		/// With Non Registered Table
@@ -1004,14 +996,11 @@ namespace DOL.Integration.Database
 		[Test]
 		public void TestSelectObjectsNonRegistered()
 		{
-			Assert.Throws(typeof(DatabaseException), () => Database.SelectObject<TableNotRegistered>("1"), "Trying to Query a Non Registered Table should throw a DatabaseException...");
-			Assert.Throws(typeof(DatabaseException), () => Database.SelectObject<TableNotRegistered>("1", DOL.Database.Transaction.IsolationLevel.DEFAULT), "Trying to Query a Non Registered Table should throw a DatabaseException...");
-			Assert.Throws(typeof(DatabaseException), () => Database.SelectObjects<TableNotRegistered>("1"), "Trying to Query a Non Registered Table should throw a DatabaseException...");
-			Assert.Throws(typeof(DatabaseException), () => Database.SelectObjects<TableNotRegistered>("1", DOL.Database.Transaction.IsolationLevel.DEFAULT), "Trying to Query a Non Registered Table should throw a DatabaseException...");
-			Assert.Throws(typeof(DatabaseException), () => Database.SelectObjects<TableNotRegistered>("1", new QueryParameter()), "Trying to Query a Non Registered Table should throw a DatabaseException...");
-			Assert.Throws(typeof(DatabaseException), () => Database.SelectObjects<TableNotRegistered>("1", new [] { new QueryParameter() }), "Trying to Query a Non Registered Table should throw a DatabaseException...");
-			Assert.Throws(typeof(DatabaseException), () => Database.SelectObjects<TableNotRegistered>("1", new [] { new [] { new QueryParameter() } }), "Trying to Query a Non Registered Table should throw a DatabaseException...");
-
+			var assertFailMessage = "Trying to Query a Non Registered Table should throw a DatabaseException...";
+			Assert.Throws(typeof(DatabaseException), () => Database.SelectObject<TableNotRegistered>(DB.Column("a").IsEqualTo(null)), assertFailMessage);
+			Assert.Throws(typeof(DatabaseException), () => Database.SelectObjects<TableNotRegistered>(DB.Column("a").IsEqualTo(null)), assertFailMessage);
+			Assert.Throws(typeof(DatabaseException), () => Database.MultipleSelectObjects<TableNotRegistered>(new[] { DB.Column("a").IsEqualTo(null) }), assertFailMessage);
+			Assert.Throws(typeof(DatabaseException), () => Database.SelectAllObjects<TableNotRegistered>(), assertFailMessage);
 		}
 		
 		/// <summary>
@@ -1033,50 +1022,10 @@ namespace DOL.Integration.Database
 			var allobjects = Database.SelectAllObjects<TestTable>();
 			
 			Assert.IsNotEmpty(allobjects, "This Test Need some Data to be Accurate...");
-			
-			var retrieveNull = Database.SelectObject<TestTable>((string)null);
-			
-			CollectionAssert.Contains(allobjects.Select(obj => obj.ObjectId), retrieveNull.ObjectId, "");
-			
-			var retrieveNullWithIsolation = Database.SelectObject<TestTable>(null, DOL.Database.Transaction.IsolationLevel.SERIALIZABLE);
-			
-			CollectionAssert.Contains(allobjects.Select(obj => obj.ObjectId), retrieveNullWithIsolation.ObjectId, "");
 
-			var retrieveMultipleNull = Database.SelectObjects<TestTable>((string)null);
-
-			CollectionAssert.AreEquivalent(allobjects.Select(obj => obj.ObjectId), retrieveMultipleNull.Select(obj => obj.ObjectId), "");
-			
-			var retrieveMultipleNullWithIsolation = Database.SelectObjects<TestTable>(null, DOL.Database.Transaction.IsolationLevel.SERIALIZABLE);
-
-			CollectionAssert.AreEquivalent(allobjects.Select(obj => obj.ObjectId), retrieveMultipleNullWithIsolation.Select(obj => obj.ObjectId), "");
-			
-			var retrieveParameter = Database.SelectObjects<TestTable>(null, new QueryParameter());
-			
-			CollectionAssert.AreEquivalent(allobjects.Select(obj => obj.ObjectId), retrieveParameter.Select(obj => obj.ObjectId), "");
-			
-			var retrieveParameters = Database.SelectObjects<TestTable>(null, new QueryParameter[] { });
-			
-			CollectionAssert.AreEquivalent(allobjects.Select(obj => obj.ObjectId), retrieveParameters.Select(obj => obj.ObjectId), "");
-
-			var retrieveMultipleParameters = Database.SelectObjects<TestTable>(null, new [] { new QueryParameter[] { } });
-			
-			CollectionAssert.AreEquivalent(allobjects.Select(obj => obj.ObjectId), retrieveMultipleParameters.First().Select(obj => obj.ObjectId), "");
-			
-			Assert.Throws(typeof(ArgumentNullException), () => Database.SelectObjects<TestTable>(null, (QueryParameter)null), "");
-			
-			Assert.Throws(typeof(ArgumentNullException), () => Database.SelectObjects<TestTable>(null, (IEnumerable<QueryParameter>)null), "");
-			
-			Assert.Throws(typeof(ArgumentNullException), () => Database.SelectObjects<TestTable>(null, (IEnumerable<IEnumerable<QueryParameter>>)null), "");
-			
-			Assert.Throws(typeof(NullReferenceException), () => Database.SelectObjects<TestTable>(null, new QueryParameter[] { null }), "");
-			
-			Assert.Throws(typeof(NullReferenceException), () => Database.SelectObjects<TestTable>(null, new [] { new QueryParameter[] { null } }), "");
-			
-			Assert.Throws(typeof(NullReferenceException), () => Database.SelectObjects<TestTable>(null, new QueryParameter[][] { null }), "");
-
-			Assert.Throws(typeof(ArgumentException), () => Database.SelectObjects<TestTable>(null, new QueryParameter[][] {  }), "");
-
+			Assert.Throws(typeof(NullReferenceException), () => Database.SelectObject<TestTable>((WhereExpression)null), "");
 			Assert.Throws(typeof(NullReferenceException), () => Database.SelectObjects<TestTable>((WhereExpression)null), "");
+			Assert.Throws(typeof(ArgumentNullException), () => Database.MultipleSelectObjects<TestTable>(null));
 		}
 		
 		#endregion

--- a/Tests/IntegrationTests/Database/TestDataObjects.cs
+++ b/Tests/IntegrationTests/Database/TestDataObjects.cs
@@ -28,12 +28,23 @@ namespace DOL.Integration.Database
 	public class TestTable : DataObject
 	{
 		string m_testField;
+
 		[DataElement]
 		public string TestField { get { return m_testField; } set { Dirty = true; m_testField = value; } }
-		
+
 		public TestTable() { }
 	}
-	
+
+	[DataTable(TableName = "Keyword_Table")]
+	public class SqlKeywordTable : DataObject
+	{
+		string m_type;
+		[DataElement]
+		public string Type { get { return m_type; } set { Dirty = true; m_type = value; } }
+
+		public SqlKeywordTable() { }
+	}
+
 	/// <summary>
 	/// Basic Test Table with Auto Increment Primary Key
 	/// </summary>

--- a/Tests/IntegrationTests/GameServer/gameutils/InventoryTest.cs
+++ b/Tests/IntegrationTests/GameServer/gameutils/InventoryTest.cs
@@ -38,13 +38,13 @@ namespace DOL.Integration.Server
 		{
 			player = CreateMockGamePlayer();
 			Assert.IsNotNull(player, "Player is null !");
-			itemt = GameServer.Database.SelectObject<ItemTemplate>("`Id_nb` = @champwardenblade", new QueryParameter("@champwardenblade", "championDocharWardenBlade"));
+			itemt = DOLDB<ItemTemplate>.SelectObject(DB.Column("Id_nb").IsEqualTo("championDocharWardenBlade"));
 			Assert.IsNotNull(itemt, "ItemTemplate is null !");
 			itemu = new ItemUnique();
 			itemu.Id_nb = "tunik"+DateTime.Now.Ticks;
 			GameServer.Database.AddObject(itemu);
 			Assert.IsNotNull(itemu, "ItemUnique is created !");
-			_ = GameServer.Database.SelectObject<ItemTemplate>("`id_nb`= @ddt", new QueryParameter("@ddt","traitors_dagger_hib"));
+			_ = DOLDB<ItemTemplate>.SelectObject(DB.Column("id_nb").IsEqualTo("traitors_dagger_hib"));
 		}
 
 		/* Tests for items - 1/ IT 2/ IU 3/ Ghost

--- a/Tests/IntegrationTests/Server.cs
+++ b/Tests/IntegrationTests/Server.cs
@@ -18,9 +18,11 @@
  */
 using System;
 using System.IO;
+using System.Linq;
 using System.Net.Sockets;
 using DOL.Database;
 using DOL.GS;
+using DOL.GS.PacketHandler;
 using NUnit.Framework;
 
 namespace DOL.Integration.Server
@@ -34,22 +36,22 @@ namespace DOL.Integration.Server
 		protected GamePlayer CreateMockGamePlayer()
 		{
 			DOLCharacters character= null;
-			Account account = GameServer.Database.SelectObject<Account>("", new QueryParameter());
+			var account = GameServer.Database.SelectAllObjects<Account>().FirstOrDefault();
 			Assert.IsNotNull(account);
 
-			foreach (DOLCharacters charact in account.Characters)
+			foreach (var charact in account.Characters)
 			{
 				if (charact!=null)
 					character = charact;
 			}
 			Assert.IsNotNull(character);
 			
-			GameClient client = new GameClient(GameServer.Instance);
+			var client = new GameClient(GameServer.Instance);
 			client.Version = GameClient.eClientVersion.Version1105;
 			client.Socket = new Socket(AddressFamily.InterNetwork,SocketType.Stream,ProtocolType.Tcp);
 			client.Account = account;
-			client.PacketProcessor = new DOL.GS.PacketHandler.PacketProcessor(client);
-			client.Out = new DOL.GS.PacketHandler.PacketLib1105(client);
+			client.PacketProcessor = new PacketProcessor(client);
+			client.Out = new PacketLib1105(client);
 			client.Player = new GamePlayer(client,character);
 			Assert.IsNotNull(client.Player,"GamePlayer instance created");
 			

--- a/Tests/UnitTests/FakeServer.cs
+++ b/Tests/UnitTests/FakeServer.cs
@@ -96,9 +96,9 @@ namespace DOL.UnitTests.Gameserver
         public IList<TObject> SelectObjects<TObject>(string whereExpression) where TObject : DataObject => throw new NotImplementedException();
         public IList<TObject> SelectObjects<TObject>(string whereExpression, IsolationLevel isolation) where TObject : DataObject => throw new NotImplementedException();
 
-        public TObject SelectObject<TObject>(WhereExpression whereExpression) where TObject : DataObject => (TObject)SelectObjectReturns.FirstOrDefault();
-        public IList<TObject> SelectObjects<TObject>(WhereExpression whereExpression) where TObject : DataObject => (IList<TObject>)SelectObjectReturns;
-        public IList<IList<TObject>> MultipleSelectObjects<TObject>(IEnumerable<WhereExpression> whereExpressionBatch) where TObject : DataObject => throw new NotImplementedException();
+        public TObject SelectObject<TObject>(WhereClause whereExpression) where TObject : DataObject => (TObject)SelectObjectReturns.FirstOrDefault();
+        public IList<TObject> SelectObjects<TObject>(WhereClause whereExpression) where TObject : DataObject => (IList<TObject>)SelectObjectReturns;
+        public IList<IList<TObject>> MultipleSelectObjects<TObject>(IEnumerable<WhereClause> whereExpressionBatch) where TObject : DataObject => throw new NotImplementedException();
 
         public bool UpdateInCache<TObject>(object key) where TObject : DataObject => false;
         public bool UpdateObjsInCache<TObject>(IEnumerable<object> keys) where TObject : DataObject => throw new NotImplementedException();

--- a/Tests/UnitTests/FakeServer.cs
+++ b/Tests/UnitTests/FakeServer.cs
@@ -96,9 +96,9 @@ namespace DOL.UnitTests.Gameserver
         public IList<TObject> SelectObjects<TObject>(string whereExpression) where TObject : DataObject => throw new NotImplementedException();
         public IList<TObject> SelectObjects<TObject>(string whereExpression, IsolationLevel isolation) where TObject : DataObject => throw new NotImplementedException();
 
-        public TObject SelectObject<TObject>(WhereClause whereExpression) where TObject : DataObject => (TObject)SelectObjectReturns.FirstOrDefault();
-        public IList<TObject> SelectObjects<TObject>(WhereClause whereExpression) where TObject : DataObject => (IList<TObject>)SelectObjectReturns;
-        public IList<IList<TObject>> MultipleSelectObjects<TObject>(IEnumerable<WhereClause> whereExpressionBatch) where TObject : DataObject => throw new NotImplementedException();
+        public TObject SelectObject<TObject>(WhereClause whereClause) where TObject : DataObject => (TObject)SelectObjectReturns.FirstOrDefault();
+        public IList<TObject> SelectObjects<TObject>(WhereClause whereClause) where TObject : DataObject => (IList<TObject>)SelectObjectReturns;
+        public IList<IList<TObject>> MultipleSelectObjects<TObject>(IEnumerable<WhereClause> whereClauseBatch) where TObject : DataObject => throw new NotImplementedException();
 
         public bool UpdateInCache<TObject>(object key) where TObject : DataObject => false;
         public bool UpdateObjsInCache<TObject>(IEnumerable<object> keys) where TObject : DataObject => throw new NotImplementedException();

--- a/Tests/UnitTests/FakeServer.cs
+++ b/Tests/UnitTests/FakeServer.cs
@@ -4,6 +4,7 @@ using DOL.GS;
 using DOL.GS.PacketHandler;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace DOL.UnitTests.Gameserver
 {
@@ -64,7 +65,7 @@ namespace DOL.UnitTests.Gameserver
 
     public class FakeDatabase : IObjectDatabase
     {
-        public IList<CharacterXDataQuest> SelectObjectReturns { get; set; } = new List<CharacterXDataQuest>();
+        public IList<DataObject> SelectObjectReturns { get; set; } = new List<DataObject>();
 
         public bool AddObject(DataObject dataObject) => throw new NotImplementedException();
         public bool AddObject(IEnumerable<DataObject> dataObjects) => throw new NotImplementedException();
@@ -89,15 +90,15 @@ namespace DOL.UnitTests.Gameserver
         public TObject SelectObject<TObject>(string whereExpression) where TObject : DataObject => throw new NotImplementedException();
         public TObject SelectObject<TObject>(string whereExpression, IsolationLevel isolation) where TObject : DataObject => throw new NotImplementedException();
 
-        public TObject SelectObject<TObject>(WhereExpression whereExpression) where TObject : DataObject => throw new NotImplementedException();
-
         public IList<IList<TObject>> SelectObjects<TObject>(string whereExpression, IEnumerable<IEnumerable<QueryParameter>> parameters) where TObject : DataObject => throw new NotImplementedException();
         public IList<TObject> SelectObjects<TObject>(string whereExpression, IEnumerable<QueryParameter> parameter) where TObject : DataObject => (IList<TObject>)SelectObjectReturns;
         public IList<TObject> SelectObjects<TObject>(string whereExpression, QueryParameter param) where TObject : DataObject => throw new NotImplementedException();
         public IList<TObject> SelectObjects<TObject>(string whereExpression) where TObject : DataObject => throw new NotImplementedException();
         public IList<TObject> SelectObjects<TObject>(string whereExpression, IsolationLevel isolation) where TObject : DataObject => throw new NotImplementedException();
 
+        public TObject SelectObject<TObject>(WhereExpression whereExpression) where TObject : DataObject => (TObject)SelectObjectReturns.FirstOrDefault();
         public IList<TObject> SelectObjects<TObject>(WhereExpression whereExpression) where TObject : DataObject => (IList<TObject>)SelectObjectReturns;
+        public IList<IList<TObject>> MultipleSelectObjects<TObject>(IEnumerable<WhereExpression> whereExpressionBatch) where TObject : DataObject => throw new NotImplementedException();
 
         public bool UpdateInCache<TObject>(object key) where TObject : DataObject => false;
         public bool UpdateObjsInCache<TObject>(IEnumerable<object> keys) where TObject : DataObject => throw new NotImplementedException();

--- a/Tests/UnitTests/UT_DataQuest.cs
+++ b/Tests/UnitTests/UT_DataQuest.cs
@@ -210,7 +210,7 @@ namespace DOL.UnitTests.Gameserver
             dataQuest.SpyCharQuest.Count = 3;
             var fakeDatabase = new FakeDatabase();
             fakeServer.SetDatabase(fakeDatabase);
-            fakeDatabase.SelectObjectReturns = new List<CharacterXDataQuest>() { dataQuest.SpyCharQuest };
+            fakeDatabase.SelectObjectReturns = new List<DataObject>() { dataQuest.SpyCharQuest };
 
             bool isQualified = dataQuest.CheckQuestQualification(player);
 

--- a/Tests/UnitTests/UT_WhereClause.cs
+++ b/Tests/UnitTests/UT_WhereClause.cs
@@ -24,96 +24,96 @@ using System;
 namespace DOL.UnitTests.Database
 {
     [TestFixture]
-    class UT_WhereExpression
+    class UT_WhereClause
     {
         [Test]
-        public void WhereClause_KeyIsEqualToOne_KeyEqualAtA()
+        public void ParameterizedText_KeyIsEqualToOne_KeyEqualAtA()
         {
             var expression = DB.Column("key").IsEqualTo(1);
 
-            Assert.AreEqual("WHERE key = @a", expression.WhereClause);
+            Assert.AreEqual("WHERE key = @a", expression.ParameterizedText);
         }
 
         [Test]
-        public void QueryParameters_KeyColumnIsEqualToOne_FirstQueryParameterValueIsOne()
+        public void Parameters_KeyColumnIsEqualToOne_FirstQueryParameterValueIsOne()
         {
             var expression = DB.Column("key").IsEqualTo(1);
 
-            var firstQueryParameter = expression.QueryParameters[0];
+            var firstQueryParameter = expression.Parameters[0];
             Assert.AreEqual(firstQueryParameter.Value, 1);
         }
 
         [Test]
-        public void WhereClause_FooIsEqualToOneAndBarIsEqualToOne_WhereFooEqualAtAAndBarEqualAtB()
+        public void ParameterizedText_FooIsEqualToOneAndBarIsEqualToOne_WhereFooEqualAtAAndBarEqualAtB()
         {
             var expression1 = DB.Column("foo").IsEqualTo(1);
             var expression2 = DB.Column("bar").IsEqualTo(1);
 
             var andExpression = expression1.And(expression2);
 
-            var actual = andExpression.WhereClause;
+            var actual = andExpression.ParameterizedText;
             var expected = $"WHERE ( foo = @a AND bar = @b )";
             Assert.AreEqual(expected, actual);
         }
 
         [Test]
-        public void InExpressionWhereClause_WithIntValues()
+        public void ParameterizedText_FooIsInOneAndTwo_FooIsInAtACommaAtB()
         {
             var expr = DB.Column("foo").IsIn(new [] { 1, 2 });
-            var placeHolder1 = expr.QueryParameters[0].Item1;
-            var placeHolder2 = expr.QueryParameters[1].Item1;
-            var actual = expr.WhereClause;
-            var expected = $"foo IN ( {placeHolder1} , {placeHolder2} )";
+            var placeHolder1 = expr.Parameters[0].Item1;
+            var placeHolder2 = expr.Parameters[1].Item1;
+            var actual = expr.ParameterizedText;
+            var expected = $"WHERE foo IN ( {placeHolder1} , {placeHolder2} )";
             Assert.AreEqual(expected, actual);
         }
 
         [Test]
-        public void InExpressionWhereClause_WithStringValues()
+        public void ParameterizedText_FooIsInAandB_FooIsInAtACommaAtB()
         {
             var expr = DB.Column("foo").IsIn(new [] { "a", "b" });
-            var placeHolder1 = expr.QueryParameters[0].Item1;
-            var placeHolder2 = expr.QueryParameters[1].Item1;
-            var actual = expr.WhereClause;
-            var expected = $"foo IN ( {placeHolder1} , {placeHolder2} )";
+            var placeHolder1 = expr.Parameters[0].Item1;
+            var placeHolder2 = expr.Parameters[1].Item1;
+            var actual = expr.ParameterizedText;
+            var expected = $"WHERE foo IN ( {placeHolder1} , {placeHolder2} )";
             Assert.AreEqual(expected, actual);
         }
 
         [Test]
-        public void QueryParameters_Expression1AndExpression2_ConcatenationOfBothQueryParameters()
+        public void Parameters_Expression1AndExpression2_ConcatenationOfBothParameters()
         {
             var expression1 = DB.Column("foo").IsEqualTo(1);
             var expression2 = DB.Column("bar").IsEqualTo(2);
 
             var andExpression = expression1.And(expression2);
 
-            var actual = andExpression.QueryParameters;
+            var actual = andExpression.Parameters;
             var expected = new[] { new QueryParameter("@a", 1), new QueryParameter("@b", 2) };
             Assert.AreEqual(expected, actual);
         }
 
         [Test]
-        public void WhereClause_EmptyWhereExpression_EmptyString()
+        public void ParameterizedText_EmptyWhereClause_EmptyString()
         {
-            var expression = WhereExpression.Empty;
+            var expression = WhereClause.Empty;
 
-            var actual = expression.QueryParameters;
-            Assert.IsEmpty(actual);
-        }
-
-        [Test]
-        public void QueryParameters_EmptyWhereExpression_Empty()
-        {
-            var expression = WhereExpression.Empty;
-
-            var actual = expression.WhereClause;
+            var actual = expression.ParameterizedText;
             var expected = string.Empty;
             Assert.AreEqual(expected, actual);
         }
 
         [Test]
+        public void Parameters_EmptyWhereClause_Empty()
+        {
+            var expression = WhereClause.Empty;
+
+            var actual = expression.Parameters;
+            Assert.IsEmpty(actual);
+        }
+
+        [Test]
         public void And_EmptyAndFilterExpression_EqualsFilterExpression()
         {
-            var emptyExpression = WhereExpression.Empty;
+            var emptyExpression = WhereClause.Empty;
             var filterExpression = DB.Column("foo").IsEqualTo(0);
 
             var andExpression = emptyExpression.And(filterExpression);
@@ -126,7 +126,7 @@ namespace DOL.UnitTests.Database
         [Test]
         public void And_FilterExpressionAndEmpty_EqualsFilterExpression()
         {
-            var emptyExpression = WhereExpression.Empty;
+            var emptyExpression = WhereClause.Empty;
             var filterExpression = DB.Column("foo").IsEqualTo(2);
 
             var andExpression = filterExpression.And(emptyExpression);
@@ -139,17 +139,17 @@ namespace DOL.UnitTests.Database
         [Test]
         public void EmptyExpression_AndEmptyExpression_OnlyFilterExpression()
         {
-            var andExpression = WhereExpression.Empty.And(WhereExpression.Empty);
+            var andExpression = WhereClause.Empty.And(WhereClause.Empty);
 
-            var actual = andExpression.WhereClause;
+            var actual = andExpression.ParameterizedText;
             var expected = string.Empty;
             Assert.AreEqual(expected, actual);
         }
 
         [Test]
-        public void WhereClause_DBColumnFooIsNull_WhereFooIsNull()
+        public void ParameterizedText_DBColumnFooIsNull_WhereFooIsNull()
         {
-            var actual = DB.Column("Foo").IsNull().WhereClause;
+            var actual = DB.Column("Foo").IsNull().ParameterizedText;
             var expected = "WHERE Foo IS NULL";
             Assert.AreEqual(expected, actual);
         }
@@ -167,9 +167,9 @@ namespace DOL.UnitTests.Database
         }
 
         [Test]
-        public void Equals_TwoFreshEmptyWhereExpressions_True()
+        public void Equals_TwoFreshEmptyWhereClauses_True()
         {
-            Assert.IsTrue(WhereExpression.Empty.Equals(WhereExpression.Empty));
+            Assert.IsTrue(WhereClause.Empty.Equals(WhereClause.Empty));
         }
 
         [Test]

--- a/Tests/UnitTests/UT_WhereExpression.cs
+++ b/Tests/UnitTests/UT_WhereExpression.cs
@@ -20,8 +20,6 @@ using NUnit.Framework;
 
 using DOL.Database;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace DOL.UnitTests.Database
 {
@@ -109,6 +107,62 @@ namespace DOL.UnitTests.Database
         }
 
         [Test]
+        public void EmptyWhereExpressionWhereClause__EmptyString()
+        {
+            var expression = WhereExpression.Empty;
+
+            var actual = expression.WhereClause;
+            var expected = string.Empty;
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void EmptyWhereExpressionWhereClause__QueryParametersEmpty()
+        {
+            var expression = WhereExpression.Empty;
+
+            var actual = expression.WhereClause;
+            var expected = string.Empty;
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void EmptyWhereExpression_AndFilterExpression_OnlyFilterExpression()
+        {
+            var emptyExpression = WhereExpression.Empty;
+            var filterExpression = DB.Column("foo").IsEqualTo(0);
+
+            var andExpression = emptyExpression.And(filterExpression);
+
+            var actual = andExpression.WhereClause;
+            var expected = $"foo = {andExpression.QueryParameters[0].Item1}";
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void FilterExpression_AndEmptyWhereExpression_OnlyFilterExpression()
+        {
+            var emptyExpression = WhereExpression.Empty;
+            var filterExpression = DB.Column("foo").IsEqualTo(0);
+
+            var andExpression = filterExpression.And(emptyExpression);
+
+            var actual = andExpression.WhereClause;
+            var expected = $"foo = {andExpression.QueryParameters[0].Item1}";
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void EmptyExpression_AndEmptyExpression_OnlyFilterExpression()
+        {
+            var andExpression = WhereExpression.Empty.And(WhereExpression.Empty);
+
+            var actual = andExpression.WhereClause;
+            var expected = string.Empty;
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
         public void DBColumn_Null_ThrowArgumentException()
         {
             Assert.Throws(typeof(ArgumentException), () => DB.Column(null));
@@ -118,6 +172,68 @@ namespace DOL.UnitTests.Database
         public void DBColumn_EmptyString_ThrowArgumentException()
         {
             Assert.Throws(typeof(ArgumentException), () => DB.Column(string.Empty));
+        }
+
+        [Test]
+        public void Equals_TwoFreshEmptyWhereExpressions_True()
+        {
+            Assert.IsTrue(WhereExpression.Empty.Equals(WhereExpression.Empty));
+        }
+
+        [Test]
+        public void Equals_TwoFilterExpressionsWithSameProperties_True()
+        {
+            var expression1 = DB.Column("foo").IsEqualTo(1);
+            var expression2 = DB.Column("foo").IsEqualTo(1);
+
+            Assert.IsTrue(expression1.Equals(expression2));
+        }
+
+        [Test]
+        public void Equals_TwoFilterExpressionsWithOnlyDifferentValue_False()
+        {
+            var expression1 = DB.Column("foo").IsEqualTo(0);
+            var expression2 = DB.Column("foo").IsEqualTo(1);
+
+            Assert.IsFalse(expression1.Equals(expression2));
+        }
+
+        [Test]
+        public void Equals_TwoFilterExpressionsWithOnlyDifferentColumnName_False()
+        {
+            var expression1 = DB.Column("foo").IsEqualTo(1);
+            var expression2 = DB.Column("bar").IsEqualTo(1);
+
+            Assert.IsFalse(expression1.Equals(expression2));
+        }
+
+        [Test]
+        public void Equals_TwoFilterExpressionsWithOnlyDifferentOperator_False()
+        {
+            var expression1 = DB.Column("foo").IsEqualTo(1);
+            var expression2 = DB.Column("foo").IsNotEqualTo(1);
+
+            Assert.IsFalse(expression1.Equals(expression2));
+        }
+
+        [Test]
+        public void Equals_TwoAndExpressionsWithSameExpressions_True()
+        {
+            var filterExpression = DB.Column("foo").IsEqualTo(1);
+            var andExpression1 = filterExpression.And(filterExpression);
+            var andExpression2 = filterExpression.And(filterExpression);
+
+            Assert.IsTrue(andExpression1.Equals(andExpression2));
+        }
+
+        [Test]
+        public void Equals_AndExpressionsAndOrExpressionWithSameExpressions_False()
+        {
+            var filterExpression = DB.Column("foo").IsEqualTo(1);
+            var andExpression = filterExpression.And(filterExpression);
+            var orExpression = filterExpression.Or(filterExpression);
+
+            Assert.IsFalse(andExpression.Equals(orExpression));
         }
     }
 }

--- a/Tests/UnitTests/UT_WhereExpression.cs
+++ b/Tests/UnitTests/UT_WhereExpression.cs
@@ -31,7 +31,7 @@ namespace DOL.UnitTests.Database
         {
             var expression = DB.Column("key").IsEqualTo(1);
 
-            Assert.AreEqual(expression.WhereClause, "key = @a");
+            Assert.AreEqual("WHERE key = @a", expression.WhereClause);
         }
 
         [Test]
@@ -44,15 +44,15 @@ namespace DOL.UnitTests.Database
         }
 
         [Test]
-        public void AndExpressionWhereClause_TwoFilterExpressions_FilterExpressionWhereClausesConnectedWithAND()
+        public void WhereClause_FooIsEqualToOneAndBarIsEqualToOne_WhereFooEqualAtAAndBarEqualAtB()
         {
             var expression1 = DB.Column("foo").IsEqualTo(1);
-            var expression2 = DB.Column("bar").IsEqualTo(2);
+            var expression2 = DB.Column("bar").IsEqualTo(1);
 
             var andExpression = expression1.And(expression2);
 
             var actual = andExpression.WhereClause;
-            var expected = $"( foo = @a AND bar = @b )";
+            var expected = $"WHERE ( foo = @a AND bar = @b )";
             Assert.AreEqual(expected, actual);
         }
 
@@ -96,9 +96,8 @@ namespace DOL.UnitTests.Database
         {
             var expression = WhereExpression.Empty;
 
-            var actual = expression.WhereClause;
-            var expected = string.Empty;
-            Assert.AreEqual(expected, actual);
+            var actual = expression.QueryParameters;
+            Assert.IsEmpty(actual);
         }
 
         [Test]
@@ -144,6 +143,14 @@ namespace DOL.UnitTests.Database
 
             var actual = andExpression.WhereClause;
             var expected = string.Empty;
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void WhereClause_DBColumnFooIsNull_WhereFooIsNull()
+        {
+            var actual = DB.Column("Foo").IsNull().WhereClause;
+            var expected = "WHERE Foo IS NULL";
             Assert.AreEqual(expected, actual);
         }
 

--- a/Tests/UnitTests/UT_WhereExpression.cs
+++ b/Tests/UnitTests/UT_WhereExpression.cs
@@ -27,33 +27,20 @@ namespace DOL.UnitTests.Database
     class UT_WhereExpression
     {
         [Test]
-        public void FilterExpressionWhereClause_KeyColumn_KeyEqualsPlaceHolder()
+        public void WhereClause_KeyIsEqualToOne_KeyEqualAtA()
         {
             var expression = DB.Column("key").IsEqualTo(1);
 
-            var firstQueryParameter = expression.QueryParameters[0];
-            var placeHolder = firstQueryParameter.Item1;
-            Assert.AreEqual(expression.WhereClause, "key = " + placeHolder);
+            Assert.AreEqual(expression.WhereClause, "key = @a");
         }
 
         [Test]
-        public void FilterExpressionWhereQueryParameters_KeyColumnIsEqualToOne_FirstQueryParameterValueIsOne()
+        public void QueryParameters_KeyColumnIsEqualToOne_FirstQueryParameterValueIsOne()
         {
             var expression = DB.Column("key").IsEqualTo(1);
 
             var firstQueryParameter = expression.QueryParameters[0];
             Assert.AreEqual(firstQueryParameter.Value, 1);
-        }
-
-        [Test]
-        public void FilterExpressionQueryParameters_TwoCreated_PlaceHoldersAreNotEqual()
-        {
-            var expression1 = DB.Column("foo").IsEqualTo(1);
-            var expression2 = DB.Column("foo").IsEqualTo(1);
-
-            var placeHolder1 = expression1.QueryParameters[0];
-            var placeHolder2 = expression2.QueryParameters[0];
-            Assert.AreNotEqual(placeHolder1.Item1, placeHolder2.Item1);
         }
 
         [Test]
@@ -64,10 +51,8 @@ namespace DOL.UnitTests.Database
 
             var andExpression = expression1.And(expression2);
 
-            var placeHolder1 = expression1.QueryParameters[0].Item1;
-            var placeHolder2 = expression2.QueryParameters[0].Item1;
             var actual = andExpression.WhereClause;
-            var expected = $"(foo = {placeHolder1} AND bar = {placeHolder2})";
+            var expected = $"( foo = @a AND bar = @b )";
             Assert.AreEqual(expected, actual);
         }
 
@@ -78,7 +63,7 @@ namespace DOL.UnitTests.Database
             var placeHolder1 = expr.QueryParameters[0].Item1;
             var placeHolder2 = expr.QueryParameters[1].Item1;
             var actual = expr.WhereClause;
-            var expected = $"foo IN ({placeHolder1},{placeHolder2})";
+            var expected = $"foo IN ( {placeHolder1} , {placeHolder2} )";
             Assert.AreEqual(expected, actual);
         }
 
@@ -89,12 +74,12 @@ namespace DOL.UnitTests.Database
             var placeHolder1 = expr.QueryParameters[0].Item1;
             var placeHolder2 = expr.QueryParameters[1].Item1;
             var actual = expr.WhereClause;
-            var expected = $"foo IN ({placeHolder1},{placeHolder2})";
+            var expected = $"foo IN ( {placeHolder1} , {placeHolder2} )";
             Assert.AreEqual(expected, actual);
         }
 
         [Test]
-        public void AndExpressionWhereClause_TwoFilterExpressions_FilterExpressionParametersInArray()
+        public void QueryParameters_Expression1AndExpression2_ConcatenationOfBothQueryParameters()
         {
             var expression1 = DB.Column("foo").IsEqualTo(1);
             var expression2 = DB.Column("bar").IsEqualTo(2);
@@ -102,12 +87,12 @@ namespace DOL.UnitTests.Database
             var andExpression = expression1.And(expression2);
 
             var actual = andExpression.QueryParameters;
-            var expected = new QueryParameter[] { expression1.QueryParameters[0], expression2.QueryParameters[0] };
+            var expected = new[] { new QueryParameter("@a", 1), new QueryParameter("@b", 2) };
             Assert.AreEqual(expected, actual);
         }
 
         [Test]
-        public void EmptyWhereExpressionWhereClause__EmptyString()
+        public void WhereClause_EmptyWhereExpression_EmptyString()
         {
             var expression = WhereExpression.Empty;
 
@@ -117,7 +102,7 @@ namespace DOL.UnitTests.Database
         }
 
         [Test]
-        public void EmptyWhereExpressionWhereClause__QueryParametersEmpty()
+        public void QueryParameters_EmptyWhereExpression_Empty()
         {
             var expression = WhereExpression.Empty;
 
@@ -127,28 +112,28 @@ namespace DOL.UnitTests.Database
         }
 
         [Test]
-        public void EmptyWhereExpression_AndFilterExpression_OnlyFilterExpression()
+        public void And_EmptyAndFilterExpression_EqualsFilterExpression()
         {
             var emptyExpression = WhereExpression.Empty;
             var filterExpression = DB.Column("foo").IsEqualTo(0);
 
             var andExpression = emptyExpression.And(filterExpression);
 
-            var actual = andExpression.WhereClause;
-            var expected = $"foo = {andExpression.QueryParameters[0].Item1}";
+            var actual = andExpression;
+            var expected = filterExpression;
             Assert.AreEqual(expected, actual);
         }
 
         [Test]
-        public void FilterExpression_AndEmptyWhereExpression_OnlyFilterExpression()
+        public void And_FilterExpressionAndEmpty_EqualsFilterExpression()
         {
             var emptyExpression = WhereExpression.Empty;
-            var filterExpression = DB.Column("foo").IsEqualTo(0);
+            var filterExpression = DB.Column("foo").IsEqualTo(2);
 
             var andExpression = filterExpression.And(emptyExpression);
 
-            var actual = andExpression.WhereClause;
-            var expected = $"foo = {andExpression.QueryParameters[0].Item1}";
+            var actual = andExpression;
+            var expected = filterExpression;
             Assert.AreEqual(expected, actual);
         }
 


### PR DESCRIPTION
Use implicit version instead
Rename WhereExpression to WhereClause
Replace all SelectObject(s) queries with implicit parameters (WhereClause object)
Replace many internal calls in *ObjectDatabase with implicit parameters