### PR TITLE
fix DataQuest, give the same item 2 times in some cases

### DIFF
--- a/GameServer/quests/QuestsMgr/DataQuest.cs
+++ b/GameServer/quests/QuestsMgr/DataQuest.cs
@@ -1642,16 +1642,6 @@ namespace DOL.GS.Quests
                         stepTemplates[0] = template[0];
                     }
 
-					if (nextStepType == eStepType.Deliver || nextStepType == eStepType.DeliverFinish)
-					{
-						// Allow StepItemTemplate to be empty, assume quest player received item in a previous step or outside of the quest
-
-						if (!string.IsNullOrEmpty(m_stepItemTemplates[Step].Trim()))
-						{
-							stepTemplates.Add(m_stepItemTemplates[Step].Trim());
-						}
-					}
-
 					if (stepTemplates.Count > 0)
 					{
 						// check for inventory space


### PR DESCRIPTION
Fix a small bug in DataQuests: if the quest has an item to give at step N (seems fine) but if the next step N+1 is a deliver step, it will give the next item in advance (seems wrong, when you finish deliver step, you get the item once more).

I don't know why this code was added in the first place, I think I removed the wrong part.