### PR TITLE
Whereexp isin

### DIFF
--- a/GameServer/managers/playermanager/FriendsManager.cs
+++ b/GameServer/managers/playermanager/FriendsManager.cs
@@ -102,7 +102,7 @@ namespace DOL.GS.Friends
 			var offlineFriends = new FriendStatus[0];
 			if (friends.Any())
 			{
-				offlineFriends = Database.SelectObjects<DOLCharacters>("`Name` = @Name", friends.Select(name => new[] { new QueryParameter("@Name", name) })).SelectMany(chars => chars)
+				offlineFriends = Database.SelectObjects<DOLCharacters>(DB.Column("Name").IsIn(friends))
 					.Select(chr => new FriendStatus(chr.Name, chr.Level, chr.Class, chr.LastPlayed)).ToArray();
 			}
 

--- a/GameServer/packets/Server/PacketLib1104.cs
+++ b/GameServer/packets/Server/PacketLib1104.cs
@@ -78,9 +78,10 @@ namespace DOL.GS.PacketHandler
 					
 					if (charsBySlot.Any())
 					{
-						var allItems = GameServer.Database.SelectObjects<InventoryItem>("`OwnerID` = @OwnerID AND `SlotPosition` >= @MinEquipable AND `SlotPosition` <= @MaxEquipable",
-						                                                                charsBySlot.Select(kv => new [] { new QueryParameter("@OwnerID", kv.Value.ObjectId), new QueryParameter("@MinEquipable", (int)eInventorySlot.MinEquipable), new QueryParameter("@MaxEquipable", (int)eInventorySlot.MaxEquipable) }))
-							.SelectMany(objs => objs);
+						var ownerIdWhere = DB.Column("OwnerID").IsIn(charsBySlot.Values.Select(c => c.ObjectId));
+						var slotWhere = DB.Column("SlotPosition").IsGreaterOrEqualTo((int)eInventorySlot.MinEquipable)
+							.And(DB.Column("SlotPosition").IsLessOrEqualTo((int)eInventorySlot.MaxEquipable));
+						var allItems = GameServer.Database.SelectObjects<InventoryItem>(ownerIdWhere.And(slotWhere));
 						
 						foreach (InventoryItem item in allItems)
 						{

--- a/Tests/IntegrationTests/Database/DatabaseTests.cs
+++ b/Tests/IntegrationTests/Database/DatabaseTests.cs
@@ -113,6 +113,15 @@ namespace DOL.Integration.Database
 			Assert.IsNotNull(retrieveKeyObj, "Test Table Retrieved Object by Key should not be null.");
 			Assert.AreEqual(retrieveKeyObj.ObjectId, keyObject.ObjectId, "Test Table Key Object and Retrieved Key Object should have same Object Id.");
 			Assert.AreEqual(retrieveKeyObj.TestField, keyObject.TestField, "Test Table Key Object and Retrieved Key Object should have same Values.");
+
+			// Find Objects by Key
+			var keys = retrieve.Take(2).Select(r => r.ObjectId).Append("__bad__id__").ToList();
+			var retrieveKeyObjects = Database.FindObjectsByKey<TestTable>(keys);
+			Assert.IsNotNull(retrieveKeyObjects, "Test Table Retrieved Objects by Key should not be null.");
+			Assert.IsTrue(retrieveKeyObjects.Count == 3, "Test Table Retrieved Objects by Key should contains 3 objects");
+			Assert.IsTrue(keys.Contains(retrieveKeyObjects[0].ObjectId), "Test Table first Key Object and Retrieved first Key Object should have same Object Id.");
+			Assert.IsTrue(keys.Contains(retrieveKeyObjects[1].ObjectId), "Test Table second Key Object and Retrieved second Key Object should have same Object Id.");
+			Assert.IsNull(retrieveKeyObjects[2], "Test Table third object should be null (it's an invalid id)");
 		}
 		
 		/// <summary>

--- a/Tests/UnitTests/UT_WhereExpression.cs
+++ b/Tests/UnitTests/UT_WhereExpression.cs
@@ -20,6 +20,8 @@ using NUnit.Framework;
 
 using DOL.Database;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace DOL.UnitTests.Database
 {
@@ -68,6 +70,28 @@ namespace DOL.UnitTests.Database
             var placeHolder2 = expression2.QueryParameters[0].Item1;
             var actual = andExpression.WhereClause;
             var expected = $"(foo = {placeHolder1} AND bar = {placeHolder2})";
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void InExpressionWhereClause_WithIntValues()
+        {
+            var expr = DB.Column("foo").IsIn(new [] { 1, 2 });
+            var placeHolder1 = expr.QueryParameters[0].Item1;
+            var placeHolder2 = expr.QueryParameters[1].Item1;
+            var actual = expr.WhereClause;
+            var expected = $"foo IN ({placeHolder1},{placeHolder2})";
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void InExpressionWhereClause_WithStringValues()
+        {
+            var expr = DB.Column("foo").IsIn(new [] { "a", "b" });
+            var placeHolder1 = expr.QueryParameters[0].Item1;
+            var placeHolder2 = expr.QueryParameters[1].Item1;
+            var actual = expr.WhereClause;
+            var expected = $"foo IN ({placeHolder1},{placeHolder2})";
             Assert.AreEqual(expected, actual);
         }
 


### PR DESCRIPTION
Add `DB.Column.IsIn` operator which transform to sql `IN`, it's a bit more complex than other operators but it can save many SQL queries if it's used correctly. There are 2 usages of this optimization, we can find many more in the code but it's not obvious.

Also, I added a small unit test for `FindObjectsByKey`.