### PR TITLE
Fix day constant and avoid in-game time glitches

### DIFF
--- a/GameServer/commands/playercommands/time.cs
+++ b/GameServer/commands/playercommands/time.cs
@@ -45,7 +45,7 @@ namespace DOL.GS.Commands
 						speed = Convert.ToUInt32(args[1]);
 						time = Convert.ToUInt32(args[2]);
 	
-						WorldMgr.StartDay(speed, time * (77760000 / 1000));
+						WorldMgr.StartDay( speed, time / 1000.0 );
 						return;
 					}
 					else throw new Exception ();

--- a/GameServer/world/WorldMgr.cs
+++ b/GameServer/world/WorldMgr.cs
@@ -212,7 +212,7 @@ namespace DOL.GS
 		/// <summary>
 		/// This constant defines the day constant
 		/// </summary>
-		private const int DAY = 77760000;
+		private const int DAY = 86400000;
 
 		/// <summary>
 		/// This holds the tick when the day started
@@ -697,12 +697,13 @@ namespace DOL.GS
 		}
 
 		/// <summary>
-		/// Starts a new day with a certain increment
+		/// Starts a new day with a certain percent of the increment
 		/// </summary>
 		/// <param name="dayInc"></param>
-		/// <param name="dayStart"></param>
-		public static void StartDay(uint dayInc, uint dayStart)
+		/// <param name="percent">0..1</param>
+		public static void StartDay( uint dayInc, double percent )
 		{
+			uint dayStart = (uint)( percent * DAY );
 			m_dayIncrement = dayInc;
 
 			if (m_dayIncrement == 0)


### PR DESCRIPTION
This fixes the glitches we randomly have in-game when server decides to send a time update packet to the client to resynchronize the clocks. When that happens we used to suddenly see daytime changes.
This also allows the clock with /time to fully count towards 23:59 and not rollback halfway around ~20:00.