### PR TITLE
fix spell level in delve tooltip/popup

### DIFF
--- a/GameServer/gameutils/SkillBase.cs
+++ b/GameServer/gameutils/SkillBase.cs
@@ -87,7 +87,7 @@ namespace DOL.GS
 		protected static readonly Dictionary<int, Spell> m_spellIndex = new Dictionary<int, Spell>();
 		// Spells Tooltip Dict ToolTipID => SpellID
 		protected static readonly Dictionary<ushort, int> m_spellToolTipIndex = new Dictionary<ushort, int>();
-		
+
 		
 		// lookup table for styles, faster access when invoking a char styleID with classID
 		protected static readonly Dictionary<KeyValuePair<int, int>, Style> m_styleIndex = new Dictionary<KeyValuePair<int, int>, Style>();

--- a/GameServer/packets/Server/PacketLib1124.cs
+++ b/GameServer/packets/Server/PacketLib1124.cs
@@ -39,6 +39,7 @@ using DOL.GS.Spells;
 using DOL.GS.Styles;
 
 using log4net;
+using DOL.GS.PacketHandler.Client.v168;
 
 
 namespace DOL.GS.PacketHandler
@@ -3865,28 +3866,28 @@ namespace DOL.GS.PacketHandler
 				if (t is RealmAbility)
 				{
 					if (m_gameClient.CanSendTooltip(27, t.InternalID))
-						SendDelveInfo(DOL.GS.PacketHandler.Client.v168.DetailDisplayHandler.DelveRealmAbility(m_gameClient, t.InternalID));
+						SendDelveInfo(DetailDisplayHandler.DelveRealmAbility(m_gameClient, t.InternalID));
 				}
 				else if (t is Ability)
 				{
 					if (m_gameClient.CanSendTooltip(28, t.InternalID))
-						SendDelveInfo(DOL.GS.PacketHandler.Client.v168.DetailDisplayHandler.DelveAbility(m_gameClient, t.InternalID));
+						SendDelveInfo(DetailDisplayHandler.DelveAbility(m_gameClient, t.InternalID));
 				}
 				else if (t is Style)
 				{
 					if (m_gameClient.CanSendTooltip(25, t.InternalID))
-						SendDelveInfo(DOL.GS.PacketHandler.Client.v168.DetailDisplayHandler.DelveStyle(m_gameClient, t.InternalID));
+						SendDelveInfo(DetailDisplayHandler.DelveStyle(m_gameClient, t.InternalID));
 				}
-				else if (t is Spell)
+				else if (t is Spell spell)
 				{
-					if (t is Song || (t is Spell && ((Spell)t).NeedInstrument))
+					if (spell is Song || spell.NeedInstrument)
 					{
-						if (m_gameClient.CanSendTooltip(26, ((Spell)t).InternalID))
-							SendDelveInfo(DOL.GS.PacketHandler.Client.v168.DetailDisplayHandler.DelveSong(m_gameClient, ((Spell)t).InternalID));
+						if (m_gameClient.CanSendTooltip(26, spell.InternalID))
+							SendDelveInfo(DetailDisplayHandler.DelveSong(m_gameClient, spell.InternalID));
 					}
 
-					if (m_gameClient.CanSendTooltip(24, ((Spell)t).InternalID))
-						SendDelveInfo(DOL.GS.PacketHandler.Client.v168.DetailDisplayHandler.DelveSpell(m_gameClient, ((Spell)t).InternalID));
+					if (m_gameClient.CanSendTooltip(24, spell.InternalID))
+						SendDelveInfo(DetailDisplayHandler.DelveSpell(m_gameClient, spell));
 				}
 			}
 		}
@@ -3898,7 +3899,7 @@ namespace DOL.GS.PacketHandler
 				return;
 			}
 
-			IList<int> tooltipids = new List<int>();
+			var tooltipSpellHandlers = new List<ISpellHandler>();
 
 			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.UpdateIcons)))
 			{
@@ -3923,10 +3924,9 @@ namespace DOL.GS.PacketHandler
 						}
 
 						// store tooltip update for gamespelleffect.
-						if (ForceTooltipUpdate && (effect is GameSpellEffect))
+						if (ForceTooltipUpdate && effect is GameSpellEffect gameEffect)
 						{
-							Spell spell = ((GameSpellEffect)effect).Spell;
-							tooltipids.Add(spell.InternalID);
+							tooltipSpellHandlers.Add(gameEffect.SpellHandler);
 						}
 
 						//						log.DebugFormat("adding [{0}] '{1}'", fxcount-1, effect.Name);
@@ -3999,10 +3999,10 @@ namespace DOL.GS.PacketHandler
 			}
 
 			// force tooltips update
-			foreach (int entry in tooltipids)
+			foreach (var spellHandler in tooltipSpellHandlers)
 			{
-				if (m_gameClient.CanSendTooltip(24, entry))
-					SendDelveInfo(DOL.GS.PacketHandler.Client.v168.DetailDisplayHandler.DelveSpell(m_gameClient, entry));
+				if (m_gameClient.CanSendTooltip(24, spellHandler.Spell.InternalID))
+					SendDelveInfo(DetailDisplayHandler.DelveSpell(spellHandler));
 			}
 		}
 

--- a/GameServer/spells/ISpellHandler.cs
+++ b/GameServer/spells/ISpellHandler.cs
@@ -254,7 +254,7 @@ namespace DOL.GS.Spells
 		/// </summary>
 		/// <returns>Modified Spell Range</returns>
 		int CalculateSpellRange();
-		void TooltipDelve(ref DOL.GS.PacketHandler.MiniDelveWriter dw, int id);
+		void TooltipDelve(ref DOL.GS.PacketHandler.MiniDelveWriter dw);
 	}
 
 	/// <summary>

--- a/GameServer/spells/SpellHandler.cs
+++ b/GameServer/spells/SpellHandler.cs
@@ -4021,14 +4021,14 @@ namespace DOL.GS.Spells
 		/// </summary>
 		/// <param name="dw"></param>
 		/// <param name="id"></param>
-		public virtual void TooltipDelve(ref MiniDelveWriter dw, int id)
+		public virtual void TooltipDelve(ref MiniDelveWriter dw)
 		{
 			if (dw == null)
 				return;
 			
 			dw.AddKeyValuePair("Function", "light"); // Function of type "light" allows custom description to show with no hardcoded text.  Temporary Fix - tolakram
 			//.Value("Function", spellHandler.FunctionName ?? "0")
-			dw.AddKeyValuePair("Index", unchecked((short)id));
+			dw.AddKeyValuePair("Index", unchecked((ushort)Spell.InternalID));
 			dw.AddKeyValuePair("Name", Spell.Name);
 			
 			if (Spell.CastTime > 2000)
@@ -4043,7 +4043,11 @@ namespace DOL.GS.Spells
 				dw.AddKeyValuePair("damage_type", (int) Spell.DamageType + 1); // Damagetype not the same as dol
 			//.Value("type1", spellHandler.GetDelveValueType1, spellHandler.GetDelveValueType1 > 0)
 			if (Spell.Level > 0)
+			{
 				dw.AddKeyValuePair("level", Spell.Level);
+				dw.AddKeyValuePair("power_level", Spell.Level);
+			}
+
 			if (Spell.CostPower)
 				dw.AddKeyValuePair("power_cost", Spell.Power);
 			//.Value("round_cost",spellHandler.GetDelveValueRoundCost,spellHandler.GetDelveValueRoundCost!=0)


### PR DESCRIPTION
I think we should move the spell level in spell's table instead of having it in the spell line. I don't think a same spell is used in different spell lines with a different level and even if it's the case, the spell can be duplicated.