### PR TITLE
Fix for Poisoned weapons trade + loot bug as a GM

### DIFF
--- a/GameServer/gameobjects/GameLiving.cs
+++ b/GameServer/gameobjects/GameLiving.cs
@@ -4406,7 +4406,12 @@ namespace DOL.GS
 			lock (Attackers)
 			{
 				m_attackers.Remove(attacker);
-			}
+                // If GM use viewloot, need remove the attacker from the xpGainers, else if he deco/reco
+                // and redo the action, he apears twice in the list and the bug is happen
+                lock (m_xpGainers)
+                    if (m_xpGainers.ContainsKey(attacker) && Health == MaxHealth)
+                        m_xpGainers.Remove(attacker);
+            }
 		}
 		/// <summary>
 		/// Called when this living dies

--- a/GameServer/gameobjects/GamePlayer.cs
+++ b/GameServer/gameobjects/GamePlayer.cs
@@ -9495,6 +9495,11 @@ namespace DOL.GS
 				Out.SendMessage(LanguageMgr.GetTranslation(Client.Account.Language, "GamePlayer.ApplyPoison.CantApplyRecentCombat"), eChatType.CT_System, eChatLoc.CL_SystemWindow);
 				return false;
 			}
+            if (toItem.PoisonCharges > 0)
+            {
+                Out.SendMessage(LanguageMgr.GetTranslation(Client.Account.Language, "GameObjects.GamePlayer.ApplyPoison.CantReapplyPoison"), eChatType.CT_System, eChatLoc.CL_SystemWindow);
+                return false;
+            }
 
 			if (toItem.PoisonSpellID != 0)
 			{
@@ -11779,6 +11784,7 @@ namespace DOL.GS
 		#endregion
 
 		#region ReceiveItem/DropItem/PickupObject
+
 		/// <summary>
 		/// Receive an item from another living
 		/// </summary>
@@ -11787,9 +11793,10 @@ namespace DOL.GS
 		/// <returns>true if player took the item</returns>
 		public override bool ReceiveItem(GameLiving source, InventoryItem item)
 		{
-			if (item == null) return false;
+            GamePlayer sourcePlayer = source as GamePlayer;
+            if (item == null) return false;
 
-			if (!Inventory.AddItem(eInventorySlot.FirstEmptyBackpack, item))
+            if (!Inventory.AddItem(eInventorySlot.FirstEmptyBackpack, item))
 				return false;
 			InventoryLogging.LogInventoryAction(source, this, eInventoryActionType.Trade, item.Template, item.Count);
 
@@ -11805,22 +11812,18 @@ namespace DOL.GS
                     Out.SendMessage(String.Format(LanguageMgr.GetTranslation(Client.Account.Language, "GamePlayer.ReceiveItem.ReceiveFrom", item.GetName(0, false), source.GetName(0, false))), eChatType.CT_Skill, eChatLoc.CL_SystemWindow);
 			}
 
-			if (source is GamePlayer)
-			{
-				GamePlayer sourcePlayer = source as GamePlayer;
-				if (sourcePlayer != null)
-				{
-					uint privLevel1 = Client.Account.PrivLevel;
-					uint privLevel2 = sourcePlayer.Client.Account.PrivLevel;
-					if (privLevel1 != privLevel2
-					    && (privLevel1 > 1 || privLevel2 > 1)
-					    && (privLevel1 == 1 || privLevel2 == 1))
-					{
-						GameServer.Instance.LogGMAction("   Item: " + source.Name + "(" + sourcePlayer.Client.Account.Name + ") -> " + Name + "(" + Client.Account.Name + ") : " + item.Name + "(" + item.Id_nb + ")");
-					}
-				}
-			}
-			return true;
+            if (sourcePlayer != null)
+            {
+                uint privLevel1 = Client.Account.PrivLevel;
+                uint privLevel2 = sourcePlayer.Client.Account.PrivLevel;
+                if (privLevel1 != privLevel2
+                    && (privLevel1 > 1 || privLevel2 > 1)
+                    && (privLevel1 == 1 || privLevel2 == 1))
+                {
+                    GameServer.Instance.LogGMAction("   Item: " + source.Name + "(" + sourcePlayer.Client.Account.Name + ") -> " + Name + "(" + Client.Account.Name + ") : " + item.Name + "(" + item.Id_nb + ")");
+                }
+            }
+            return true;
 		}
 
 		/// <summary>

--- a/GameServer/gameutils/PlayerTradeWindow.cs
+++ b/GameServer/gameutils/PlayerTradeWindow.cs
@@ -619,7 +619,7 @@ namespace DOL.GS
                         InventoryItem itemtoadd = item;
 
                         // If PLayer is not Infiltrator (9), Shadowblade (23), Nightshade (49), remove Envenom bonus before add the item in the inventory
-                        if (item.PoisonSpellID > 0 && !(partner.CharacterClass.ID == 9 || partner.CharacterClass.ID == 23 || partner.CharacterClass.ID == 49))
+                        if (item.PoisonSpellID > 0)
                         {
                             itemtoadd = GameInventoryItem.Create(itemtoadd);
                             itemtoadd.PoisonCharges = 0;

--- a/GameServer/gameutils/PlayerTradeWindow.cs
+++ b/GameServer/gameutils/PlayerTradeWindow.cs
@@ -616,13 +616,24 @@ namespace DOL.GS
 
 						bool tradeSuccess = false;
 
+                        InventoryItem itemtoadd = item;
+
+                        // If PLayer is not Infiltrator (9), Shadowblade (23), Nightshade (49), remove Envenom bonus before add the item in the inventory
+                        if (item.PoisonSpellID > 0 && !(partner.CharacterClass.ID == 9 || partner.CharacterClass.ID == 23 || partner.CharacterClass.ID == 49))
+                        {
+                            itemtoadd = GameInventoryItem.Create(itemtoadd);
+                            itemtoadd.PoisonCharges = 0;
+                            itemtoadd.PoisonMaxCharges = 0;
+                            itemtoadd.PoisonSpellID = 0;
+                        }
+
 						if (item.IsDeleted)
 						{
-							tradeSuccess = partner.Inventory.AddItem(eInventorySlot.FirstEmptyBackpack, item);
+                            tradeSuccess = partner.Inventory.AddItem(eInventorySlot.FirstEmptyBackpack, itemtoadd);
 						}
 						else
 						{
-							tradeSuccess = partner.Inventory.AddTradeItem(eInventorySlot.FirstEmptyBackpack, item);
+                            tradeSuccess = partner.Inventory.AddTradeItem(eInventorySlot.FirstEmptyBackpack, itemtoadd);
 						}
 
 						if (!tradeSuccess)
@@ -648,13 +659,24 @@ namespace DOL.GS
 
 						bool tradeSuccess = false;
 
+                        InventoryItem itemtoadd = item;
+
+                        // If PLayer is not Infiltrator (9), Shadowblade (23), Nightshade (49), remove Envenom bonus before add the item in the inventory
+                        if (item.PoisonSpellID > 0 && !(m_owner.CharacterClass.ID == 9 || m_owner.CharacterClass.ID == 23 || m_owner.CharacterClass.ID == 49))
+                        {
+                            itemtoadd = GameInventoryItem.Create(itemtoadd);
+                            itemtoadd.PoisonCharges = 0;
+                            itemtoadd.PoisonMaxCharges = 0;
+                            itemtoadd.PoisonSpellID = 0;
+                        }
+
 						if (item.IsDeleted)
 						{
-							tradeSuccess = m_owner.Inventory.AddItem(eInventorySlot.FirstEmptyBackpack, item);
+                            tradeSuccess = m_owner.Inventory.AddItem(eInventorySlot.FirstEmptyBackpack, itemtoadd);
 						}
 						else
 						{
-							tradeSuccess = m_owner.Inventory.AddTradeItem(eInventorySlot.FirstEmptyBackpack, item);
+                            tradeSuccess = m_owner.Inventory.AddTradeItem(eInventorySlot.FirstEmptyBackpack, itemtoadd);
 						}
 
 						if (!tradeSuccess)

--- a/GameServer/language/EN/GameObjects/GamePlayer.txt
+++ b/GameServer/language/EN/GameObjects/GamePlayer.txt
@@ -7,6 +7,7 @@ GamePlayer.ApplyPoison.CantPoisonWeapon:		You can't poison this weapon!
 GamePlayer.ApplyPoison.CantUsePoison:			You can't use this poison.		
 GamePlayer.ApplyPoison.CantUsePoisons:			You can't use poisons.		
 GamePlayer.ApplyPoison.PoisonsAppliedWeapons:	Poisons can be applied only to weapons.
+GamePlayer.ApplyPoison.CantReapplyPoison:	Poisons can't be re-applied on this weapon.
 GamePlayer.Attack.AlreadyDead:				{0} is already dead!
 GamePlayer.Attack.Blocked:					{0} blocks your attack!	
 GamePlayer.Attack.CantBeAttacked:			This can't be attacked!		

--- a/GameServer/language/FR/GameObjects/GamePlayer.txt
+++ b/GameServer/language/FR/GameObjects/GamePlayer.txt
@@ -10,6 +10,7 @@ GamePlayer.ApplyPoison.CantPoisonWeapon:		Vous ne pouvez pas utiliser du poison 
 GamePlayer.ApplyPoison.CantUsePoison:			Vous ne pouvez pas utiliser ce poison.
 GamePlayer.ApplyPoison.CantUsePoisons:			Vous ne pouvez pas utiliser ces poisons.
 GamePlayer.ApplyPoison.PoisonsAppliedWeapons:	Les poisons ne peuvent être appliqués que sur des armes.
+GamePlayer.ApplyPoison.CantReapplyPoison:	Vous ne pouvez pas réappliquer du poison sur cette arme.
 GamePlayer.Attack.AlreadyDead:				{0} est déjà mort(e).
 GamePlayer.Attack.Blocked:					{0} bloque votre attaque.
 GamePlayer.Attack.CantBeAttacked:			Ceci ne peut pas être attaqué.


### PR DESCRIPTION
- Players can't re-apply a poison on a weapon beeing already poisonous
- Poisoned Weapons lose their poison if traded with classes other than Infiltrator, Shadowblade, Nightshade
- Fix bug when loot items as GM with "/viewloot random inv"
