### PR TITLE
add spellhandler's specific TooltipDelve infos for 1.110+

### DIFF
--- a/GameServer/packets/Utils/MiniDelveWriter.cs
+++ b/GameServer/packets/Utils/MiniDelveWriter.cs
@@ -117,15 +117,36 @@ namespace DOL.GS.PacketHandler
 			{
 				case eDamageType.Natural:
 					break;
+				case eDamageType.Crush:
+					AddKeyValuePair(name, 1);
+					break;
+				case eDamageType.Slash:
+					AddKeyValuePair(name, 2);
+					break;
+				case eDamageType.Thrust:
+					AddKeyValuePair(name, 3);
+					break;
+
 				case eDamageType.Body:
 					AddKeyValuePair(name,  16);
 					break;
+				case eDamageType.Cold:
+					AddKeyValuePair(name, 12);
+					break;
+				case eDamageType.Heat:
+					AddKeyValuePair(name, 10);
+					break;
+
+				case eDamageType.Matter:
+					AddKeyValuePair(name, 13);
+					break;
 				case eDamageType.Energy:
-					AddKeyValuePair(name,  22);
+					AddKeyValuePair(name,  20);
 					break;
 				case eDamageType.Spirit:
-					AddKeyValuePair(name,  17);
+					AddKeyValuePair(name,  11);
 					break;
+
 				default:
 					AddKeyValuePair(name, (int)val + 1);
 					break;

--- a/GameServer/packets/Utils/MiniDelveWriter.cs
+++ b/GameServer/packets/Utils/MiniDelveWriter.cs
@@ -111,6 +111,27 @@ namespace DOL.GS.PacketHandler
 			m_values[name] = val;
 		}
 
+		public void AddKeyValuePair(string name, eDamageType val)
+		{
+			switch (val)
+			{
+				case eDamageType.Natural:
+					break;
+				case eDamageType.Body:
+					AddKeyValuePair(name,  16);
+					break;
+				case eDamageType.Energy:
+					AddKeyValuePair(name,  22);
+					break;
+				case eDamageType.Spirit:
+					AddKeyValuePair(name,  17);
+					break;
+				default:
+					AddKeyValuePair(name, (int)val + 1);
+					break;
+			}
+		}
+
 		/// <summary>
 		/// Add a Key / Value pair
 		/// </summary>
@@ -153,6 +174,5 @@ namespace DOL.GS.PacketHandler
 			
 			return res.ToString();
 		}
-
 	}
 }

--- a/GameServer/spells/AblativeArmorSpellHandler.cs
+++ b/GameServer/spells/AblativeArmorSpellHandler.cs
@@ -236,6 +236,14 @@ namespace DOL.GS.Spells
 			#endregion
 		}
 
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "hit_buffer");
+			dw.AddKeyValuePair("bonus", Spell.Damage > 0 ? Spell.Damage : 25);
+			dw.AddKeyValuePair("damage", Spell.Value);
+		}
+
 		// for delve info
 		protected virtual string GetAblativeType()
 		{
@@ -267,7 +275,16 @@ namespace DOL.GS.Spells
 		{
 			return "Type: Magic Absorption";
 		}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "hit_buffer");
+			dw.AddKeyValuePair("bonus", Spell.Value);
+			dw.AddKeyValuePair("damage", Spell.Damage);
+		}
 	}
+
     //Both Magic/melee ablative 1.101 druids mite have a buff like this...
     [SpellHandlerAttribute("BothAblativeArmor")]
     public class BothAblativeArmorSpellHandler : AblativeArmorSpellHandler
@@ -285,5 +302,13 @@ namespace DOL.GS.Spells
         {
             return "Type: Melee/Magic Absorption";
         }
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "hit_buffer");
+			dw.AddKeyValuePair("bonus", Spell.Value);
+			dw.AddKeyValuePair("damage", Spell.Damage);
+		}
     }
 }

--- a/GameServer/spells/AblativeArmorSpellHandler.cs
+++ b/GameServer/spells/AblativeArmorSpellHandler.cs
@@ -240,6 +240,7 @@ namespace DOL.GS.Spells
 		{
 			base.TooltipDelve(ref dw);
 			dw.AddKeyValuePair("Function", "hit_buffer");
+			dw.AddKeyValuePair("parm", 1);
 			dw.AddKeyValuePair("bonus", Spell.Damage > 0 ? Spell.Damage : 25);
 			dw.AddKeyValuePair("damage", Spell.Value);
 		}
@@ -280,6 +281,7 @@ namespace DOL.GS.Spells
 		{
 			base.TooltipDelve(ref dw);
 			dw.AddKeyValuePair("Function", "hit_buffer");
+			dw.AddKeyValuePair("parm", 2);
 			dw.AddKeyValuePair("bonus", Spell.Value);
 			dw.AddKeyValuePair("damage", Spell.Damage);
 		}
@@ -307,6 +309,7 @@ namespace DOL.GS.Spells
 		{
 			base.TooltipDelve(ref dw);
 			dw.AddKeyValuePair("Function", "hit_buffer");
+			dw.AddKeyValuePair("parm", 3);
 			dw.AddKeyValuePair("bonus", Spell.Value);
 			dw.AddKeyValuePair("damage", Spell.Damage);
 		}

--- a/GameServer/spells/AfHitsBuff.cs
+++ b/GameServer/spells/AfHitsBuff.cs
@@ -107,5 +107,10 @@ namespace DOL.GS.Spells
 
         public AfHitsBuffSpellHandler(GameLiving caster, Spell spell, SpellLine spellLine) : base(caster, spell, spellLine) { }
 
+        public override void TooltipDelve(ref MiniDelveWriter dw)
+        {
+            base.TooltipDelve(ref dw);
+            dw.AddKeyValuePair("bonus", Spell.Value);
+        }
     }
 }

--- a/GameServer/spells/AllStatsBuff.cs
+++ b/GameServer/spells/AllStatsBuff.cs
@@ -101,5 +101,11 @@ namespace DOL.GS.Spells
 			}
 		}		
         public AllStatsBuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) { }
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("bonus", Spell.Value);
+		}
     }
  }

--- a/GameServer/spells/AmnesiaSpellHandler.cs
+++ b/GameServer/spells/AmnesiaSpellHandler.cs
@@ -107,5 +107,11 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public AmnesiaSpellHandler(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) {}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "amnesia");
+		}
 	}
 }

--- a/GameServer/spells/Animist/BomberSpellHandler.cs
+++ b/GameServer/spells/Animist/BomberSpellHandler.cs
@@ -128,5 +128,11 @@ namespace DOL.GS.Spells
 		public override void CastSubSpells(GameLiving target)
 		{
 		}
+
+        public override void TooltipDelve(ref MiniDelveWriter dw)
+        {
+            base.TooltipDelve(ref dw);
+            dw.AddKeyValuePair("Function", "dsummon");
+        }
     }
 }

--- a/GameServer/spells/Animist/SummonAnimistFnF.cs
+++ b/GameServer/spells/Animist/SummonAnimistFnF.cs
@@ -143,5 +143,11 @@ namespace DOL.GS.Spells
 		public override void CastSubSpells(GameLiving target)
 		{
 		}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "dsummon");
+		}
 	}
 }

--- a/GameServer/spells/Animist/SummonAnimistMainPet.cs
+++ b/GameServer/spells/Animist/SummonAnimistMainPet.cs
@@ -61,12 +61,5 @@ namespace DOL.GS.Spells
       }
       return base.GetPetBrain(owner);
     }
-
-    public override void TooltipDelve(ref MiniDelveWriter dw)
-    {
-      base.TooltipDelve(ref dw);
-      dw.AddKeyValuePair("Function", "summon");
-      dw.AddKeyValuePair("power_level", -100);
-    }
   }
 }

--- a/GameServer/spells/Animist/SummonAnimistMainPet.cs
+++ b/GameServer/spells/Animist/SummonAnimistMainPet.cs
@@ -61,5 +61,12 @@ namespace DOL.GS.Spells
       }
       return base.GetPetBrain(owner);
     }
+
+    public override void TooltipDelve(ref MiniDelveWriter dw)
+    {
+      base.TooltipDelve(ref dw);
+      dw.AddKeyValuePair("Function", "summon");
+      dw.AddKeyValuePair("power_level", -100);
+    }
   }
 }

--- a/GameServer/spells/Artifacts/AllStatsDebuff.cs
+++ b/GameServer/spells/Artifacts/AllStatsDebuff.cs
@@ -18,6 +18,7 @@
  */
 using DOL.AI.Brain;
 using DOL.GS.Effects;
+using DOL.GS.PacketHandler;
 
 namespace DOL.GS.Spells.Atlantis
 {
@@ -106,5 +107,11 @@ namespace DOL.GS.Spells.Atlantis
 			}
 		}
 		public AllStatsDebuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) { }
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("bonus", Spell.Value);
+		}
 	}
 }

--- a/GameServer/spells/Artifacts/AllStatsPercentDebuff.cs
+++ b/GameServer/spells/Artifacts/AllStatsPercentDebuff.cs
@@ -126,5 +126,11 @@ namespace DOL.GS.Spells
 			}
 		}
         public AllStatsPercentDebuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) { }
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("bonus", Spell.Value);
+		}
 	}
 }

--- a/GameServer/spells/BladeturnSpellHandler.cs
+++ b/GameServer/spells/BladeturnSpellHandler.cs
@@ -93,5 +93,12 @@ namespace DOL.GS.Spells
 
         // constructor
         public BladeturnSpellHandler(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) {}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "combat");
+			dw.AddKeyValuePair("parm", "9");
+		}
 	}
 }

--- a/GameServer/spells/BoltSpellHandler.cs
+++ b/GameServer/spells/BoltSpellHandler.cs
@@ -308,5 +308,12 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public BoltSpellHandler(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) {}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "bolt");
+			dw.AddKeyValuePair("damage", Spell.Damage * 10);
+		}
 	}
 }

--- a/GameServer/spells/Bonedancer/SummonCommanderPet.cs
+++ b/GameServer/spells/Bonedancer/SummonCommanderPet.cs
@@ -95,5 +95,12 @@ namespace DOL.GS.Spells
                 return delve;
             }
 		}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "summon");
+			dw.AddKeyValuePair("power_level", -100);
+		}
 	}
 }

--- a/GameServer/spells/Bonedancer/SummonMinionHandler.cs
+++ b/GameServer/spells/Bonedancer/SummonMinionHandler.cs
@@ -228,5 +228,11 @@ namespace DOL.GS.Spells
 				return delve;
 			}
 		}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "gsummon");
+		}
 	}
 }

--- a/GameServer/spells/CCSpellHandler.cs
+++ b/GameServer/spells/CCSpellHandler.cs
@@ -457,7 +457,16 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public MesmerizeSpellHandler(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) {}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "combat");
+			dw.AddKeyValuePair("parm", "6");
+		}
 	}
+
+
 	/// <summary>
 	/// Stun
 	/// </summary>
@@ -581,5 +590,11 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public StunSpellHandler(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) {}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "paralyze");
+		}
 	}
 }

--- a/GameServer/spells/Cabalist/SummonSimulacrum.cs
+++ b/GameServer/spells/Cabalist/SummonSimulacrum.cs
@@ -48,5 +48,12 @@ namespace DOL.GS.Spells
 			}
 			return base.CheckBeginCast(selectedTarget);
 		}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "summon");
+			dw.AddKeyValuePair("power_level", -100);
+		}
 	}
 }

--- a/GameServer/spells/CharmSpellHandler.cs
+++ b/GameServer/spells/CharmSpellHandler.cs
@@ -600,6 +600,27 @@ namespace DOL.GS.Spells
             }
         }
 
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "charm");
+			dw.AddKeyValuePair("power_level", Spell.Value);
+			var detail = string.IsNullOrWhiteSpace(Spell.Description) ? "Attempts to bring the target monster under the caster's control." : Spell.Description;
+			switch ((eCharmType)Spell.AmnesiaChance)
+			{
+				case eCharmType.All: break;
+				case eCharmType.Animal: detail += "\nSpell works on animals."; break;
+				case eCharmType.Humanoid: detail += "\nSpell works on humanoids."; break;
+				case eCharmType.Insect: detail += "\nSpell works on insects."; break;
+				case eCharmType.Reptile: detail += "\nSpell works on reptiles."; break;
+				case eCharmType.HumanoidAnimal: detail += "\nSpell works on humanoids and animals."; break;
+				case eCharmType.HumanoidAnimalInsect: detail += "\nSpell works on humanoids, insects, and animals."; break;
+				case eCharmType.HumanoidAnimalInsectMagical: detail += "\nSpell works on humanoids, insects, magical, and animals."; break;
+				case eCharmType.HumanoidAnimalInsectMagicalUndead: detail += "\nSpell works on humanoids, insects, magical, undead, and animals."; break;
+			}
+			dw.AddKeyValuePair("delve_string", detail);
+		}
+
         // Constructs new Charm spell handler
         public CharmSpellHandler(GameLiving caster, Spell spell, SpellLine line)
             : base(caster, spell, line)
@@ -612,7 +633,7 @@ namespace DOL.GS.Spells
 
         ... Can you please explain what the max level pet a hunter can charm if they are fully Beastcraft specd? The community feels its no higher then 41, but the builder says max level 50.
 
-        A: Sayeth the Oracle: ”It's 82% of the caster's level for the highest charm in beastcraft; or level 41 if the caster is 50. Spec doesn't determine the level of the pet - it's purely based on the spell.”
+        A: Sayeth the Oracle: ï¿½It's 82% of the caster's level for the highest charm in beastcraft; or level 41 if the caster is 50. Spec doesn't determine the level of the pet - it's purely based on the spell.ï¿½
 
 
 

--- a/GameServer/spells/CharmSpellHandler.cs
+++ b/GameServer/spells/CharmSpellHandler.cs
@@ -608,15 +608,15 @@ namespace DOL.GS.Spells
 			var detail = string.IsNullOrWhiteSpace(Spell.Description) ? "Attempts to bring the target monster under the caster's control." : Spell.Description;
 			switch ((eCharmType)Spell.AmnesiaChance)
 			{
-				case eCharmType.All: break;
-				case eCharmType.Animal: detail += "\nSpell works on animals."; break;
-				case eCharmType.Humanoid: detail += "\nSpell works on humanoids."; break;
-				case eCharmType.Insect: detail += "\nSpell works on insects."; break;
-				case eCharmType.Reptile: detail += "\nSpell works on reptiles."; break;
-				case eCharmType.HumanoidAnimal: detail += "\nSpell works on humanoids and animals."; break;
-				case eCharmType.HumanoidAnimalInsect: detail += "\nSpell works on humanoids, insects, and animals."; break;
-				case eCharmType.HumanoidAnimalInsectMagical: detail += "\nSpell works on humanoids, insects, magical, and animals."; break;
-				case eCharmType.HumanoidAnimalInsectMagicalUndead: detail += "\nSpell works on humanoids, insects, magical, undead, and animals."; break;
+				case eCharmType.Humanoid: dw.AddKeyValuePair("parm", "3"); break;
+				case eCharmType.Animal: dw.AddKeyValuePair("parm", "5"); break;
+				case eCharmType.Insect: dw.AddKeyValuePair("parm", "13"); break;
+				case eCharmType.HumanoidAnimal: dw.AddKeyValuePair("parm", "50"); break;
+				case eCharmType.HumanoidAnimalInsect: dw.AddKeyValuePair("parm", "51"); break;
+				case eCharmType.HumanoidAnimalInsectMagical: dw.AddKeyValuePair("parm", "52"); break;
+				case eCharmType.HumanoidAnimalInsectMagicalUndead: dw.AddKeyValuePair("parm", "53"); break;
+				case eCharmType.Reptile: dw.AddKeyValuePair("parm", "6"); break;
+				case eCharmType.All: dw.AddKeyValuePair("parm", "0"); break;
 			}
 			dw.AddKeyValuePair("delve_string", detail);
 		}

--- a/GameServer/spells/CombatHealSpellHandler.cs
+++ b/GameServer/spells/CombatHealSpellHandler.cs
@@ -44,5 +44,11 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public CombatHealSpellHandler(GameLiving caster, Spell spell, SpellLine spellLine) : base(caster, spell, spellLine) {}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("parm", "1");
+		}
 	}
 }

--- a/GameServer/spells/ConfusionSpellHandler.cs
+++ b/GameServer/spells/ConfusionSpellHandler.cs
@@ -58,7 +58,7 @@ namespace DOL.GS.Spells
 			{
 				/*
 				 *Q: What does the confusion spell do against players?
-				 *A: According to the magic man, “Confusion against a player interrupts their current action, whether it's a bow shot or spellcast.
+				 *A: According to the magic man, ï¿½Confusion against a player interrupts their current action, whether it's a bow shot or spellcast.
 				 */
 				if (Spell.Value < 0 || Util.Chance(Convert.ToInt32(Math.Abs(Spell.Value))))
 				{
@@ -180,6 +180,14 @@ namespace DOL.GS.Spells
 				npc.IsConfused = false;
 			}
 			return base.OnEffectExpires(effect, noMessages);
+		}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "combat");
+			dw.AddKeyValuePair("parm", "5");
+			dw.AddKeyValuePair("power_level", Spell.Value);
 		}
 	}
 }

--- a/GameServer/spells/Conversion.cs
+++ b/GameServer/spells/Conversion.cs
@@ -153,8 +153,14 @@ namespace DOL.GS.Spells
 			}
 		}
 		public ConversionSpellHandler(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) { }
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("bonus", Spell.Value);
+		}
 	}
-	
+
 	[SpellHandlerAttribute("MagicConversion")]
 	public class MagicConversionSpellHandler : ConversionSpellHandler
 	{

--- a/GameServer/spells/Conversion.cs
+++ b/GameServer/spells/Conversion.cs
@@ -158,6 +158,7 @@ namespace DOL.GS.Spells
 		{
 			base.TooltipDelve(ref dw);
 			dw.AddKeyValuePair("bonus", Spell.Value);
+			dw.AddKeyValuePair("parm", "1");
 		}
 	}
 
@@ -237,5 +238,11 @@ namespace DOL.GS.Spells
 		}
 
 		public MagicConversionSpellHandler(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) { }
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("parm", "0");
+		}
 	}
 }

--- a/GameServer/spells/ConvertPet.cs
+++ b/GameServer/spells/ConvertPet.cs
@@ -61,5 +61,12 @@ namespace DOL.GS.Spells
 
 			return true;
 		}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "reclaim");
+			dw.AddKeyValuePair("bonus", Spell.Value);
+		}
 	}
 }

--- a/GameServer/spells/CureDiseaseSpellHandler.cs
+++ b/GameServer/spells/CureDiseaseSpellHandler.cs
@@ -39,5 +39,11 @@ namespace DOL.GS.Spells
 			m_spellTypesToRemove = new List<string>();
 			m_spellTypesToRemove.Add("Disease");
 		}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "rem_eff_ty");
+		}
 	}
 }

--- a/GameServer/spells/CureNearsight.cs
+++ b/GameServer/spells/CureNearsight.cs
@@ -39,6 +39,13 @@ namespace DOL.GS.Spells
 			m_spellTypesToRemove = new List<string>();
 			m_spellTypesToRemove.Add("Nearsight");
             m_spellTypesToRemove.Add("Silence");
-		} 
+		}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "rem_eff_ty");
+			dw.AddKeyValuePair("parm", "12");
+		}
 	}
 }

--- a/GameServer/spells/CurePoisonSpellHandler.cs
+++ b/GameServer/spells/CurePoisonSpellHandler.cs
@@ -18,6 +18,7 @@
  */
 using System;
 using System.Collections.Generic;
+using DOL.GS.PacketHandler;
 
 namespace DOL.GS.Spells
 {
@@ -35,6 +36,13 @@ namespace DOL.GS.Spells
 			m_spellTypesToRemove = new List<string>();
 			m_spellTypesToRemove.Add("DamageOverTime");
             m_spellTypesToRemove.Add("StyleBleeding");
-		} 
+		}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "rem_eff_ty");
+			dw.AddKeyValuePair("parm", "12");
+		}
 	}
 }

--- a/GameServer/spells/Curemezz.cs
+++ b/GameServer/spells/Curemezz.cs
@@ -39,6 +39,14 @@ namespace DOL.GS.Spells
 			// RR4: now it's a list
 			m_spellTypesToRemove = new List<string>();
 			m_spellTypesToRemove.Add("Mesmerize");
-		} 
+		}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "remove_eff");
+			dw.AddKeyValuePair("parm", "6");
+			dw.AddKeyValuePair("type1", "8");
+		}
 	}
 }

--- a/GameServer/spells/DamageAddAndShield.cs
+++ b/GameServer/spells/DamageAddAndShield.cs
@@ -141,6 +141,13 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public DamageAddSpellHandler(GameLiving caster, Spell spell, SpellLine spellLine) : base(caster, spell, spellLine) { }
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "dmg_add");
+			dw.AddKeyValuePair("damage", Spell.Damage * 10);
+		}
 	}
 
 	/// <summary>
@@ -240,6 +247,13 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public DamageShieldSpellHandler(GameLiving caster, Spell spell, SpellLine spellLine) : base(caster, spell, spellLine) { }
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "dmg_shield");
+			dw.AddKeyValuePair("damage", Spell.Damage * 10);
+		}
 	}
 
 	/// <summary>

--- a/GameServer/spells/DamageSpeedDecrease.cs
+++ b/GameServer/spells/DamageSpeedDecrease.cs
@@ -185,6 +185,14 @@ namespace DOL.GS.Spells
 			}
 		}
 
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "snare");
+			dw.AddKeyValuePair("damage", Spell.Damage * 10);
+			dw.AddKeyValuePair("bonus", 100 - Spell.Value);
+		}
+
 		// counstructor
 		public DamageSpeedDecreaseSpellHandler(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) {}
 	}

--- a/GameServer/spells/DamageToPowerSpellHandler.cs
+++ b/GameServer/spells/DamageToPowerSpellHandler.cs
@@ -55,6 +55,12 @@ namespace DOL.GS.Spells
 
         // constructor
         public DamageToPowerSpellHandler(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) { }
+
+        public override void TooltipDelve(ref MiniDelveWriter dw)
+        {
+            base.TooltipDelve(ref dw);
+            dw.AddKeyValuePair("bonus", Spell.Value);
+        }
     }
 }
 

--- a/GameServer/spells/DirectDamageDebuffSpellHandler.cs
+++ b/GameServer/spells/DirectDamageDebuffSpellHandler.cs
@@ -257,6 +257,15 @@ namespace DOL.GS.Spells
 			}
 		}
 
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "nresist_dam");
+			dw.AddKeyValuePair("bonus", Spell.Value);
+			dw.AddKeyValuePair("parm", Spell.DamageType);
+			dw.AddKeyValuePair("damage", Spell.Damage * 10);
+		}
+
 		// constructor
 		public DirectDamageDebuffSpellHandler(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) {}
 	}

--- a/GameServer/spells/DirectDamageSpellHandler.cs
+++ b/GameServer/spells/DirectDamageSpellHandler.cs
@@ -235,5 +235,12 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public DirectDamageSpellHandler(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) {}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "direct");
+			dw.AddKeyValuePair("damage", Spell.Damage * 10);
+		}
 	}
 }

--- a/GameServer/spells/DiseaseSpellHandler.cs
+++ b/GameServer/spells/DiseaseSpellHandler.cs
@@ -181,5 +181,11 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public DiseaseSpellHandler(GameLiving caster, Spell spell, SpellLine spellLine) : base(caster, spell, spellLine) {}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "disease");
+		}
 	}
 }

--- a/GameServer/spells/DoTSpellHandler.cs
+++ b/GameServer/spells/DoTSpellHandler.cs
@@ -274,5 +274,12 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public DoTSpellHandler(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) { }
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "dot");
+			dw.AddKeyValuePair("damage", Spell.Damage);
+		}
 	}
 }

--- a/GameServer/spells/Druid/SummonDruidPet.cs
+++ b/GameServer/spells/Druid/SummonDruidPet.cs
@@ -48,5 +48,12 @@ namespace DOL.GS.Spells
 			}
 			return base.CheckBeginCast(selectedTarget);
 		}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "summon");
+			dw.AddKeyValuePair("power_level", -100);
+		}
 	}
 }

--- a/GameServer/spells/DualStatBuff.cs
+++ b/GameServer/spells/DualStatBuff.cs
@@ -60,6 +60,13 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public StrengthConBuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) {}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "twostat");
+			dw.AddKeyValuePair("bonus", Spell.Value);
+		}
 	}
 
 	/// <summary>
@@ -83,5 +90,13 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public DexterityQuiBuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) {}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "twostat");
+			dw.AddKeyValuePair("bonus", Spell.Value);
+			dw.AddKeyValuePair("parm", "2");
+		}
 	}
 }

--- a/GameServer/spells/DualStatDebuff.cs
+++ b/GameServer/spells/DualStatDebuff.cs
@@ -45,6 +45,13 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public StrengthConDebuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) { }
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "twostat");
+			dw.AddKeyValuePair("bonus", Spell.Value);
+		}
 	}
 
 	/// <summary>
@@ -58,6 +65,14 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public DexterityQuiDebuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) { }
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "ntwostat");
+			dw.AddKeyValuePair("bonus", Spell.Value);
+			dw.AddKeyValuePair("parm", "2");
+		}
 	}
 	/// Dex/Con Debuff for assassin poisons
 	/// <summary>
@@ -71,6 +86,13 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public DexterityConDebuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) { }
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "ntwostat");
+			dw.AddKeyValuePair("bonus", Spell.Value);
+		}
 	}
 
 	[SpellHandlerAttribute("WeaponSkillConstitutionDebuff")]
@@ -79,5 +101,12 @@ namespace DOL.GS.Spells
 		public override eProperty Property1 { get { return eProperty.WeaponSkill; } }
 		public override eProperty Property2 { get { return eProperty.Constitution; } }
 		public WeaponskillConDebuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) { }
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "ntwostat");
+			dw.AddKeyValuePair("bonus", Spell.Value);
+		}
 	}
 }

--- a/GameServer/spells/Enchanter/SummonUnderhill.cs
+++ b/GameServer/spells/Enchanter/SummonUnderhill.cs
@@ -47,5 +47,12 @@ namespace DOL.GS.Spells
 			}
 			return base.CheckBeginCast(selectedTarget);
 		}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "summon");
+			dw.AddKeyValuePair("power_level", -100);
+		}
 	}
 }

--- a/GameServer/spells/EnduranceDrainSpellHandler.cs
+++ b/GameServer/spells/EnduranceDrainSpellHandler.cs
@@ -98,28 +98,11 @@ namespace DOL.GS.Spells
 				return list;
 			}
 		}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("bonus", Spell.Value);
+		}
 	}
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/GameServer/spells/EnduranceHealSpellHandler.cs
+++ b/GameServer/spells/EnduranceHealSpellHandler.cs
@@ -143,5 +143,11 @@ namespace DOL.GS.Spells
 			}
 			return base.CheckBeginCast(selectedTarget);
 		}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("bonus", Spell.Value);
+		}
 	}
 }

--- a/GameServer/spells/HealSpellHandler.cs
+++ b/GameServer/spells/HealSpellHandler.cs
@@ -496,5 +496,12 @@ namespace DOL.GS.Spells
             max = upperLimit;
             return;
         }
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "heal");
+			dw.AddKeyValuePair("damage", Spell.Value);
+		}
     }
 }

--- a/GameServer/spells/HoTSpellHandler.cs
+++ b/GameServer/spells/HoTSpellHandler.cs
@@ -128,5 +128,13 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public HoTSpellHandler(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) {}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "regen");
+			dw.AddKeyValuePair("bonus", Spell.Value);
+			dw.AddKeyValuePair("damage", Spell.Value);
+		}
 	}
 }

--- a/GameServer/spells/Hunter/SummonHunterPet.cs
+++ b/GameServer/spells/Hunter/SummonHunterPet.cs
@@ -48,5 +48,12 @@ namespace DOL.GS.Spells
 			}
 			return base.CheckBeginCast(selectedTarget);
 		}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "summon");
+			dw.AddKeyValuePair("power_level", -100);
+		}
 	}
 }

--- a/GameServer/spells/IllnessSpellHandler.cs
+++ b/GameServer/spells/IllnessSpellHandler.cs
@@ -20,6 +20,7 @@
 using System.Collections.Generic;
 using DOL.Database;
 using DOL.GS.Effects;
+using DOL.GS.PacketHandler;
 
 namespace DOL.GS.Spells
 {
@@ -120,7 +121,13 @@ namespace DOL.GS.Spells
 			return OnEffectExpires(effect, false);
 		}		
 
-		public PveResurrectionIllness(GameLiving caster, Spell spell, SpellLine spellLine) : base(caster, spell, spellLine) {}	
+		public PveResurrectionIllness(GameLiving caster, Spell spell, SpellLine spellLine) : base(caster, spell, spellLine) {}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("bonus", Spell.Value);
+		}
 	}
 
 	/// <summary>

--- a/GameServer/spells/LifeTransferSpellHandler.cs
+++ b/GameServer/spells/LifeTransferSpellHandler.cs
@@ -159,7 +159,7 @@ namespace DOL.GS.Spells
             {
                 GamePlayer joueur_a_considerer = (m_caster is NecromancerPet ? ((m_caster as NecromancerPet).Brain as IControlledBrain).GetPlayerOwner() : m_caster as GamePlayer);
 
-                int POURCENTAGE_SOIN_RP = ServerProperties.Properties.HEAL_PVP_DAMAGE_VALUE_RP; // ...% de bonus RP pour les soins effectués
+                int POURCENTAGE_SOIN_RP = ServerProperties.Properties.HEAL_PVP_DAMAGE_VALUE_RP; // ...% de bonus RP pour les soins effectuï¿½s
                 long Bonus_RP_Soin = Convert.ToInt64((double)healedrp * POURCENTAGE_SOIN_RP / 100);
 
                 if (Bonus_RP_Soin >= 1)
@@ -173,7 +173,7 @@ namespace DOL.GS.Spells
                     }
 
                     joueur_a_considerer.GainRealmPoints(Bonus_RP_Soin, false);
-                    joueur_a_considerer.Out.SendMessage("Vous gagnez " + Bonus_RP_Soin.ToString() + " points de royaume pour avoir soigné un membre de votre royaume.", eChatType.CT_Important, eChatLoc.CL_SystemWindow);
+                    joueur_a_considerer.Out.SendMessage("Vous gagnez " + Bonus_RP_Soin.ToString() + " points de royaume pour avoir soignï¿½ un membre de votre royaume.", eChatType.CT_Important, eChatLoc.CL_SystemWindow);
                 }
             }
 
@@ -196,6 +196,13 @@ namespace DOL.GS.Spells
 					MessageToCaster(target.GetName(0, true)+" is fully healed.", eChatType.CT_Spell);
 
 			return true;
+		}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "transfer");
+			dw.AddKeyValuePair("damage", Spell.Value);
 		}
 	}
 }

--- a/GameServer/spells/LifedrainSpellHandler.cs
+++ b/GameServer/spells/LifedrainSpellHandler.cs
@@ -69,5 +69,13 @@ namespace DOL.GS.Spells
 
         // constructor
         public LifedrainSpellHandler(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) { }
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "lifedrain");
+			dw.AddKeyValuePair("bonus", Spell.LifeDrainReturn / 10);
+			dw.AddKeyValuePair("damage", Spell.Damage * 10);
+		}
     }
 }

--- a/GameServer/spells/Masterlevel/Banelord.cs
+++ b/GameServer/spells/Masterlevel/Banelord.cs
@@ -397,6 +397,12 @@ namespace DOL.GS.Spells
         }
 
         public EffectivenessDeBuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) { }
+
+        public override void TooltipDelve(ref MiniDelveWriter dw)
+        {
+            base.TooltipDelve(ref dw);
+            dw.AddKeyValuePair("bonus", Spell.Value);
+        }
     }
     #endregion
 

--- a/GameServer/spells/Masterlevel/Battlemaster.cs
+++ b/GameServer/spells/Masterlevel/Battlemaster.cs
@@ -167,6 +167,12 @@ namespace DOL.GS.Spells
 		}
 
         public Grapple(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) { }
+
+        public override void TooltipDelve(ref MiniDelveWriter dw)
+        {
+            base.TooltipDelve(ref dw);
+            dw.AddKeyValuePair("Function", "grapple");
+        }
     }
     #endregion
 

--- a/GameServer/spells/NearsightSpellHandler.cs
+++ b/GameServer/spells/NearsightSpellHandler.cs
@@ -147,7 +147,17 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public NearsightSpellHandler(GameLiving caster, Spell spell, SpellLine spellLine) : base(caster, spell, spellLine) {}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "combat");
+			dw.AddKeyValuePair("power_level", Spell.Value);
+			dw.AddKeyValuePair("parm", "12");
+		}
 	}
+
+
 	/// <summary>
 	/// Reduce efficacity of nearsight effect
 	/// </summary>
@@ -164,5 +174,11 @@ namespace DOL.GS.Spells
 		}	
 		// constructor
 		public NearsightReductionSpellHandler(GameLiving caster, Spell spell, SpellLine spellLine) : base(caster, spell, spellLine) {}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("bonus", Spell.Value);
+		}
 	}
 }

--- a/GameServer/spells/Necromancer/PetSpellHandler.cs
+++ b/GameServer/spells/Necromancer/PetSpellHandler.cs
@@ -143,5 +143,17 @@ namespace DOL.GS.Spells
 			: base(caster, spell, spellLine)
 		{
 		}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "petcast");
+			if (Spell.SubSpellID != 0)
+			{
+				var spell = SkillBase.GetSpellByID(Spell.SubSpellID);
+				if (spell != null)
+					dw.AddKeyValuePair("parm", unchecked((ushort)spell.InternalID));
+			}
+		}
 	}
 }

--- a/GameServer/spells/Necromancer/SummonNecromancerPet.cs
+++ b/GameServer/spells/Necromancer/SummonNecromancerPet.cs
@@ -145,5 +145,12 @@ namespace DOL.GS.Spells
 		{
 			return new NecromancerPet(template, m_summonConBonus, m_summonHitsBonus);
 		}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "ssummon");
+			dw.AddKeyValuePair("power_level", -100);
+		}
 	}
 }

--- a/GameServer/spells/PetLifedrainSpellHandler.cs
+++ b/GameServer/spells/PetLifedrainSpellHandler.cs
@@ -60,5 +60,13 @@ namespace DOL.spells
                 MessageToLiving(player, "You cannot absorb any more life.", eChatType.CT_SpellResisted);
             }
         }
+
+        public override void TooltipDelve(ref MiniDelveWriter dw)
+        {
+            base.TooltipDelve(ref dw);
+            dw.AddKeyValuePair("Function", "lifedrain");
+            dw.AddKeyValuePair("damage", Spell.Damage * 10);
+            dw.AddKeyValuePair("bonus", Spell.LifeDrainReturn / 10);
+        }
     }
 }

--- a/GameServer/spells/PowerDrain.cs
+++ b/GameServer/spells/PowerDrain.cs
@@ -100,7 +100,13 @@ namespace DOL.GS.Spells
 		/// <param name="line"></param>
 		public PowerDrain(GameLiving caster, Spell spell, SpellLine line)
 			: base(caster, spell, line) { }
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "powerdrain");
+			dw.AddKeyValuePair("damage", Spell.Damage * 10);
+			dw.AddKeyValuePair("bonus", Spell.LifeDrainReturn);
+		}
 	}
-	
-	
 }

--- a/GameServer/spells/PowerTransfer.cs
+++ b/GameServer/spells/PowerTransfer.cs
@@ -115,5 +115,12 @@ namespace DOL.GS.Spells
 		/// <param name="line"></param>
 		public PowerTransfer(GameLiving caster, Spell spell, SpellLine line) 
             : base(caster, spell, line) { }
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "power_xfer");
+			dw.AddKeyValuePair("damage", Spell.Value * 10);
+		}
 	}
 }

--- a/GameServer/spells/ProcSpellHandler.cs
+++ b/GameServer/spells/ProcSpellHandler.cs
@@ -380,6 +380,15 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public OffensiveProcSpellHandler(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) { }
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "off_proc");
+			dw.AddKeyValuePair("bonus", Spell.Frequency);
+			if (m_procSpell != null)
+				dw.AddKeyValuePair("parm", unchecked((ushort)m_procSpell.InternalID));
+		}
 	}
 
 	/// <summary>
@@ -448,6 +457,15 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public DefensiveProcSpellHandler(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) { }
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "def_proc");
+			dw.AddKeyValuePair("bonus", Spell.Frequency);
+			if(m_procSpell != null)
+				dw.AddKeyValuePair("parm", unchecked((ushort)m_procSpell.InternalID));
+		}
 	}
 	
 	[SpellHandler( "OffensiveProcPvE" )]

--- a/GameServer/spells/RegenBuff.cs
+++ b/GameServer/spells/RegenBuff.cs
@@ -36,6 +36,13 @@ namespace DOL.GS.Spells
 		public override eProperty Property1 { get { return eProperty.HealthRegenerationRate; } }
 
 		public HealthRegenSpellHandler(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) {}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "enhancement");
+			dw.AddKeyValuePair("damage", Spell.Value);
+		}
 	}
 
 	/// <summary>
@@ -56,6 +63,14 @@ namespace DOL.GS.Spells
 		public override eProperty Property1 { get { return eProperty.PowerRegenerationRate; } }
 
 		public PowerRegenSpellHandler(GameLiving caster, Spell spell, SpellLine spellLine) : base(caster, spell, spellLine) {}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "enhancement");
+			dw.AddKeyValuePair("damage", Spell.Value);
+			dw.AddKeyValuePair("parm", "2");
+		}
 	}
 
 	/// <summary>
@@ -248,5 +263,13 @@ namespace DOL.GS.Spells
 		/// <param name="spell">The spell used</param>
 		/// <param name="line">The spell line used</param>
 		public EnduranceRegenSpellHandler(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) {}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "enhancement");
+			dw.AddKeyValuePair("parm", "3");
+			dw.AddKeyValuePair("damage", Spell.Value);
+		}
 	}
 }

--- a/GameServer/spells/ResistBuff.cs
+++ b/GameServer/spells/ResistBuff.cs
@@ -61,6 +61,14 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public BodyResistBuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) { }
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "resistance");
+			dw.AddKeyValuePair("parm", "16");
+			dw.AddKeyValuePair("bonus", Spell.Value);
+		}
 	}
 
 	/// <summary>
@@ -74,6 +82,14 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public ColdResistBuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) { }
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "resistance");
+			dw.AddKeyValuePair("parm", "12");
+			dw.AddKeyValuePair("bonus", Spell.Value);
+		}
 	}
 
 	/// <summary>
@@ -87,6 +103,14 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public EnergyResistBuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) { }
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "resistance");
+			dw.AddKeyValuePair("bonus", Spell.Value);
+			dw.AddKeyValuePair("parm", "22");
+		}
 	}
 
 	/// <summary>
@@ -100,6 +124,14 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public HeatResistBuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) { }
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "resistance");
+			dw.AddKeyValuePair("bonus", Spell.Value);
+			dw.AddKeyValuePair("parm", "10");
+		}
 	}
 
 	/// <summary>
@@ -113,6 +145,14 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public MatterResistBuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) { }
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "resistance");
+			dw.AddKeyValuePair("bonus", Spell.Value);
+			dw.AddKeyValuePair("parm", "15");
+		}
 	}
 
 	/// <summary>
@@ -126,6 +166,14 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public SpiritResistBuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) { }
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "resistance");
+			dw.AddKeyValuePair("parm", "98");
+			dw.AddKeyValuePair("bonus", Spell.Value);
+		}
 	}
 
 	/// <summary>
@@ -162,6 +210,14 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public HeatColdMatterBuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) { }
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "resistance");
+			dw.AddKeyValuePair("bonus", Spell.Value);
+			dw.AddKeyValuePair("parm", "97");
+		}
 	}
 
 	/// <summary>
@@ -186,6 +242,12 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public AllMagicResistsBuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) { }
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("bonus", Spell.Value);
+		}
 	}
 
 	/// <summary>
@@ -205,6 +267,13 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public CrushSlashThrustBuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) { }
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "resistance");
+			dw.AddKeyValuePair("bonus", Spell.Value);
+		}
 	}
 
 	[SpellHandlerAttribute("CrushResistBuff")]
@@ -215,6 +284,13 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public CrushResistBuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) { }
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "resistance");
+			dw.AddKeyValuePair("bonus", Spell.Value);
+		}
 	}
 
 	/// <summary>
@@ -228,6 +304,13 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public SlashResistBuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) { }
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "resistance");
+			dw.AddKeyValuePair("bonus", Spell.Value);
+		}
 	}
 
 	/// <summary>
@@ -241,6 +324,12 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public ThrustResistBuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) { }
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("bonus", Spell.Value);
+		}
 	}
 
 	/// <summary>
@@ -271,6 +360,12 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public AllResistsBuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) { }
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("bonus", Spell.Value);
+		}
 	}
 
 }

--- a/GameServer/spells/ResistDebuff.cs
+++ b/GameServer/spells/ResistDebuff.cs
@@ -212,6 +212,14 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public BodyResistDebuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) {}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "nresistance");
+			dw.AddKeyValuePair("parm", "16");
+			dw.AddKeyValuePair("bonus", Spell.Value);
+		}
 	}
 
 	/// <summary>
@@ -225,6 +233,14 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public ColdResistDebuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) {}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "nresistance");
+			dw.AddKeyValuePair("parm", "12");
+			dw.AddKeyValuePair("bonus", Spell.Value);
+		}
 	}
 
 	/// <summary>
@@ -238,6 +254,14 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public EnergyResistDebuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) {}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "nresistance");
+			dw.AddKeyValuePair("bonus", Spell.Value);
+			dw.AddKeyValuePair("parm", "22");
+		}
 	}
 
 	/// <summary>
@@ -251,6 +275,14 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public HeatResistDebuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) {}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "nresistance");
+			dw.AddKeyValuePair("bonus", Spell.Value);
+			dw.AddKeyValuePair("parm", "10");
+		}
 	}
 
 	/// <summary>
@@ -264,6 +296,14 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public MatterResistDebuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) {}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "nresistance");
+			dw.AddKeyValuePair("bonus", Spell.Value);
+			dw.AddKeyValuePair("parm", "15");
+		}
 	}
 
 	/// <summary>
@@ -277,6 +317,14 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public SpiritResistDebuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) {}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "nresistance");
+			dw.AddKeyValuePair("parm", "98");
+			dw.AddKeyValuePair("bonus", Spell.Value);
+		}
 	}
 
 	/// <summary>
@@ -290,6 +338,13 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public SlashResistDebuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) {}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "nresistance");
+			dw.AddKeyValuePair("bonus", Spell.Value);
+		}
 	}
 
 	/// <summary>
@@ -303,6 +358,13 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public ThrustResistDebuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) {}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "nresistance");
+			dw.AddKeyValuePair("bonus", Spell.Value);
+		}
 	}
 
 	/// <summary>
@@ -316,7 +378,15 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public CrushResistDebuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) {}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "nresistance");
+			dw.AddKeyValuePair("bonus", Spell.Value);
+		}
 	}
+
 	/// <summary>
 	/// Crush/Slash/Thrust resistance debuff
 	/// </summary>
@@ -335,8 +405,14 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public CrushSlashThrustDebuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) {}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("bonus", Spell.Value);
+		}
 	}
-	
+
 	[SpellHandlerAttribute("EssenceSear")]
 	public class EssenceResistDebuff : AbstractResistDebuff
 	{

--- a/GameServer/spells/ResurrectSpellHandler.cs
+++ b/GameServer/spells/ResurrectSpellHandler.cs
@@ -323,5 +323,16 @@ namespace DOL.GS.Spells
 				return list;
 			}
 		}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "raise_dead");
+			dw.AddKeyValuePair("damage", Spell.ResurrectHealth);
+			dw.AddKeyValuePair("bonus", Spell.ResurrectMana);
+			dw.AddKeyValuePair("amount_increase", Spell.ResurrectMana);
+			dw.AddKeyValuePair("type1", "65");
+			dw.AddKeyValuePair("target", "8");
+		}
 	}
 }

--- a/GameServer/spells/ResurrectSpellHandler.cs
+++ b/GameServer/spells/ResurrectSpellHandler.cs
@@ -330,9 +330,6 @@ namespace DOL.GS.Spells
 			dw.AddKeyValuePair("Function", "raise_dead");
 			dw.AddKeyValuePair("damage", Spell.ResurrectHealth);
 			dw.AddKeyValuePair("bonus", Spell.ResurrectMana);
-			dw.AddKeyValuePair("amount_increase", Spell.ResurrectMana);
-			dw.AddKeyValuePair("type1", "65");
-			dw.AddKeyValuePair("target", "8");
 		}
 	}
 }

--- a/GameServer/spells/Savage/SavageBuff.cs
+++ b/GameServer/spells/Savage/SavageBuff.cs
@@ -165,7 +165,17 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public SavageParryBuff(GameLiving caster, Spell spell, SpellLine spellLine) : base(caster, spell, spellLine) {}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "combat");
+			dw.AddKeyValuePair("cost_type", "2");
+			dw.AddKeyValuePair("bonus", Spell.Value);
+			dw.AddKeyValuePair("parm", "15");
+		}
 	}
+
 	[SpellHandlerAttribute("SavageEvadeBuff")]
 	public class SavageEvadeBuff : AbstractSavageStatBuff
 	{
@@ -173,7 +183,17 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public SavageEvadeBuff(GameLiving caster, Spell spell, SpellLine spellLine) : base(caster, spell, spellLine) {}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "combat");
+			dw.AddKeyValuePair("cost_type", "2");
+			dw.AddKeyValuePair("bonus", Spell.Value);
+			dw.AddKeyValuePair("parm", "16");
+		}
 	}
+
 	[SpellHandlerAttribute("SavageCombatSpeedBuff")]
 	public class SavageCombatSpeedBuff : AbstractSavageStatBuff
 	{
@@ -181,6 +201,16 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public SavageCombatSpeedBuff(GameLiving caster, Spell spell, SpellLine spellLine) : base(caster, spell, spellLine) {}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "combat");
+			dw.AddKeyValuePair("cost_type", "2");
+			dw.AddKeyValuePair("bonus", Spell.Value);
+			dw.AddKeyValuePair("parm", "36");
+			dw.AddKeyValuePair("power_level", Spell.Value * 2);
+		}
 	}
 	[SpellHandlerAttribute("SavageDPSBuff")]
 	public class SavageDPSBuff : AbstractSavageStatBuff
@@ -189,7 +219,15 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public SavageDPSBuff(GameLiving caster, Spell spell, SpellLine spellLine) : base(caster, spell, spellLine) {}
-	}	
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("cost_type", "2");
+			dw.AddKeyValuePair("damage", Spell.Value);
+		}
+	}
+
 	[SpellHandlerAttribute("SavageSlashResistanceBuff")]
 	public class SavageSlashResistanceBuff : AbstractSavageResistBuff
 	{
@@ -197,7 +235,17 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public SavageSlashResistanceBuff(GameLiving caster, Spell spell, SpellLine spellLine) : base(caster, spell, spellLine) {}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "resistance");
+			dw.AddKeyValuePair("cost_type", "2");
+			dw.AddKeyValuePair("bonus", Spell.Value);
+			dw.AddKeyValuePair("parm", eDamageType.Slash);
+		}
 	}
+
 	[SpellHandlerAttribute("SavageThrustResistanceBuff")]
 	public class SavageThrustResistanceBuff : AbstractSavageResistBuff
 	{
@@ -205,7 +253,17 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public SavageThrustResistanceBuff(GameLiving caster, Spell spell, SpellLine spellLine) : base(caster, spell, spellLine) {}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "resistance");
+			dw.AddKeyValuePair("cost_type", "2");
+			dw.AddKeyValuePair("bonus", Spell.Value);
+			dw.AddKeyValuePair("parm", eDamageType.Thrust);
+		}
 	}
+
 	[SpellHandlerAttribute("SavageCrushResistanceBuff")]
 	public class SavageCrushResistanceBuff : AbstractSavageResistBuff
 	{
@@ -213,6 +271,15 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public SavageCrushResistanceBuff(GameLiving caster, Spell spell, SpellLine spellLine) : base(caster, spell, spellLine) {}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "resistance");
+			dw.AddKeyValuePair("cost_type", "2");
+			dw.AddKeyValuePair("bonus", Spell.Value);
+			dw.AddKeyValuePair("parm", eDamageType.Crush);
+		}
 	}
 }
 

--- a/GameServer/spells/Savage/SavageEnduranceHeal.cs
+++ b/GameServer/spells/Savage/SavageEnduranceHeal.cs
@@ -56,5 +56,13 @@ namespace DOL.GS.Spells
 			}
 			return base.CheckBeginCast(Caster);
 		}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "fat_heal");
+			dw.AddKeyValuePair("cost_type", "2");
+			dw.AddKeyValuePair("damage", Spell.Value);
+		}
 	}
 }

--- a/GameServer/spells/SingleStatBuff.cs
+++ b/GameServer/spells/SingleStatBuff.cs
@@ -123,6 +123,13 @@ namespace DOL.GS.Spells
 
         // constructor
         public StrengthBuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) { }
+
+        public override void TooltipDelve(ref MiniDelveWriter dw)
+        {
+            base.TooltipDelve(ref dw);
+            dw.AddKeyValuePair("Function", "stat");
+            dw.AddKeyValuePair("bonus", Spell.Value);
+        }
     }
 
     /// <summary>
@@ -144,6 +151,14 @@ namespace DOL.GS.Spells
 
         // constructor
         public DexterityBuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) { }
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "stat");
+			dw.AddKeyValuePair("bonus", Spell.Value);
+			dw.AddKeyValuePair("parm", "2");
+		}
     }
 
     /// <summary>
@@ -165,6 +180,14 @@ namespace DOL.GS.Spells
 
         // constructor
         public ConstitutionBuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) { }
+
+        public override void TooltipDelve(ref MiniDelveWriter dw)
+        {
+            base.TooltipDelve(ref dw);
+            dw.AddKeyValuePair("Function", "stat");
+            dw.AddKeyValuePair("parm", "3");
+            dw.AddKeyValuePair("bonus", Spell.Value);
+        }
     }
 
     /// <summary>
@@ -186,6 +209,13 @@ namespace DOL.GS.Spells
 
         // constructor
         public ArmorFactorBuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) { }
+
+        public override void TooltipDelve(ref MiniDelveWriter dw)
+        {
+            base.TooltipDelve(ref dw);
+            dw.AddKeyValuePair("Function", "shield");
+            dw.AddKeyValuePair("bonus", Spell.Value);
+        }
     }
 
     /// <summary>
@@ -206,6 +236,13 @@ namespace DOL.GS.Spells
 
         // constructor
         public ArmorAbsorptionBuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) { }
+
+        public override void TooltipDelve(ref MiniDelveWriter dw)
+        {
+            base.TooltipDelve(ref dw);
+            dw.AddKeyValuePair("Function", "absorb");
+            dw.AddKeyValuePair("bonus", Spell.Value);
+        }
     }
 
     /// <summary>
@@ -226,6 +263,15 @@ namespace DOL.GS.Spells
 
         // constructor
         public CombatSpeedBuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) { }
+
+        public override void TooltipDelve(ref MiniDelveWriter dw)
+        {
+            base.TooltipDelve(ref dw);
+            dw.AddKeyValuePair("Function", "combat");
+            dw.AddKeyValuePair("parm", "36");
+            dw.AddKeyValuePair("power_level", Spell.Value * 2);
+            dw.AddKeyValuePair("bonus", Spell.Value);
+        }
     }
     
     /// <summary>
@@ -286,6 +332,12 @@ namespace DOL.GS.Spells
 
         // constructor
         public MeleeDamageBuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) { }
+
+        public override void TooltipDelve(ref MiniDelveWriter dw)
+        {
+            base.TooltipDelve(ref dw);
+            dw.AddKeyValuePair("bonus", Spell.Value);
+        }
     }
 
     /// <summary>
@@ -306,6 +358,16 @@ namespace DOL.GS.Spells
 
         // constructor
         public MesmerizeDurationBuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) { }
+
+        public override void TooltipDelve(ref MiniDelveWriter dw)
+        {
+            base.TooltipDelve(ref dw);
+            dw.AddKeyValuePair("Function", "mez_dampen");
+            dw.AddKeyValuePair("bonus", Spell.Value);
+            dw.AddKeyValuePair("damage_type", eDamageType.Energy);
+            dw.AddKeyValuePair("dur_type", "2");
+            dw.AddKeyValuePair("power_level", "29");
+        }
     }
 
 
@@ -319,6 +381,14 @@ namespace DOL.GS.Spells
 
         // constructor
         public AcuityBuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) { }
+
+        public override void TooltipDelve(ref MiniDelveWriter dw)
+        {
+            base.TooltipDelve(ref dw);
+            dw.AddKeyValuePair("Function", "twostat");
+            dw.AddKeyValuePair("parm", "3");
+            dw.AddKeyValuePair("bonus", Spell.Value);
+        }
     }
 
     /// <summary>
@@ -355,7 +425,14 @@ namespace DOL.GS.Spells
 
         // constructor
         public EvadeChanceBuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) { }
+
+        public override void TooltipDelve(ref MiniDelveWriter dw)
+        {
+            base.TooltipDelve(ref dw);
+            dw.AddKeyValuePair("bonus", Spell.Value);
+        }
     }
+
     /// <summary>
     /// Parry chance buff
     /// </summary>
@@ -366,7 +443,14 @@ namespace DOL.GS.Spells
 
         // constructor
         public ParryChanceBuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) { }
+
+        public override void TooltipDelve(ref MiniDelveWriter dw)
+        {
+            base.TooltipDelve(ref dw);
+            dw.AddKeyValuePair("bonus", Spell.Value);
+        }
     }
+
     /// <summary>
     /// WeaponSkill buff
     /// </summary>
@@ -377,7 +461,14 @@ namespace DOL.GS.Spells
 
         // constructor
         public WeaponSkillBuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) { }
+
+        public override void TooltipDelve(ref MiniDelveWriter dw)
+        {
+            base.TooltipDelve(ref dw);
+            dw.AddKeyValuePair("bonus", Spell.Value);
+        }
     }
+
     /// <summary>
     /// Stealth Skill buff
     /// </summary>
@@ -388,7 +479,14 @@ namespace DOL.GS.Spells
 
         // constructor
         public StealthSkillBuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) { }
+
+        public override void TooltipDelve(ref MiniDelveWriter dw)
+        {
+            base.TooltipDelve(ref dw);
+            dw.AddKeyValuePair("bonus", Spell.Value);
+        }
     }
+
     /// <summary>
     /// To Hit buff
     /// </summary>
@@ -399,7 +497,14 @@ namespace DOL.GS.Spells
 
         // constructor
         public ToHitSkillBuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) { }
+
+        public override void TooltipDelve(ref MiniDelveWriter dw)
+        {
+            base.TooltipDelve(ref dw);
+            dw.AddKeyValuePair("bonus", Spell.Value);
+        }
     }
+
     /// <summary>
     /// Magic Resists Buff
     /// </summary>
@@ -417,6 +522,13 @@ namespace DOL.GS.Spells
     {
         public override eProperty Property1 { get { return eProperty.StyleAbsorb; } }
         public StyleAbsorbBuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) { }
+
+        public override void TooltipDelve(ref MiniDelveWriter dw)
+        {
+            base.TooltipDelve(ref dw);
+            dw.AddKeyValuePair("Function", "absorb");
+            dw.AddKeyValuePair("bonus", Spell.Value);
+        }
     }
 
     [SpellHandlerAttribute("ExtraHP")]
@@ -445,6 +557,13 @@ namespace DOL.GS.Spells
 
         // constructor
         public PaladinArmorFactorBuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) { }
+
+        public override void TooltipDelve(ref MiniDelveWriter dw)
+        {
+            base.TooltipDelve(ref dw);
+            dw.AddKeyValuePair("Function", "shield");
+            dw.AddKeyValuePair("bonus", Spell.Value);
+        }
     }
 
     [Obsolete("This class will be removed. Please use FlexibleSkillBuff instead!")]
@@ -459,6 +578,12 @@ namespace DOL.GS.Spells
     {
         public override eProperty Property1 { get { return eProperty.Skill_Flexible_Weapon; } }
         public FlexibleSkillBuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) { }
+
+        public override void TooltipDelve(ref MiniDelveWriter dw)
+        {
+            base.TooltipDelve(ref dw);
+            dw.AddKeyValuePair("bonus", Spell.Value);
+        }
     }
 
     [SpellHandler("ResiPierceBuff")]

--- a/GameServer/spells/SingleStatDebuff.cs
+++ b/GameServer/spells/SingleStatDebuff.cs
@@ -107,6 +107,13 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public StrengthDebuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) {}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "nstat");
+			dw.AddKeyValuePair("bonus", Spell.Value);
+		}
 	}
 
 	/// <summary>
@@ -119,6 +126,14 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public DexterityDebuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) {}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "nstat");
+			dw.AddKeyValuePair("bonus", Spell.Value);
+			dw.AddKeyValuePair("parm", "2");
+		}
 	}
 
 	/// <summary>
@@ -131,6 +146,14 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public ConstitutionDebuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) {}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "nstat");
+			dw.AddKeyValuePair("parm", "3");
+			dw.AddKeyValuePair("bonus", Spell.Value);
+		}
 	}
 
 	/// <summary>
@@ -143,6 +166,13 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public ArmorFactorDebuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) {}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "nshield");
+			dw.AddKeyValuePair("bonus", Spell.Value);
+		}
 	}
 
 	/// <summary>
@@ -163,6 +193,13 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public ArmorAbsorptionDebuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) {}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "nabsorb");
+			dw.AddKeyValuePair("bonus", Spell.Value);
+		}
 	}
 
 	/// <summary>
@@ -183,6 +220,14 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public CombatSpeedDebuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) {}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "combat");
+			dw.AddKeyValuePair("parm", "2");
+			dw.AddKeyValuePair("power_level", -Spell.Value);
+		}
 	}
 
 	/// <summary>
@@ -203,6 +248,13 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public MeleeDamageDebuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) {}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "ndamage");
+			dw.AddKeyValuePair("bonus", Spell.Value);
+		}
 	}
 
 	/// <summary>
@@ -243,6 +295,12 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public FumbleChanceDebuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) {}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("bonus", Spell.Value);
+		}
 	}
 	
 	/// <summary>
@@ -266,7 +324,14 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public SkillsDebuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) {}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("bonus", Spell.Value);
+		}
 	}
+
 	/// <summary>
 	/// Acuity stat baseline debuff
 	/// </summary>
@@ -277,7 +342,14 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public AcuityDebuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) {}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("bonus", Spell.Value);
+		}
 	}
+
 	/// <summary>
 	/// Quickness stat baseline debuff
 	/// </summary>
@@ -288,7 +360,14 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public QuicknessDebuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) {}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("bonus", Spell.Value);
+		}
 	}
+
 	/// <summary>
 	/// ToHit Skill debuff
 	/// </summary>
@@ -299,5 +378,11 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public ToHitSkillDebuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) {}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("bonus", Spell.Value);
+		}
 	}
  }

--- a/GameServer/spells/SpeedDecreaseSpellHandler.cs
+++ b/GameServer/spells/SpeedDecreaseSpellHandler.cs
@@ -109,5 +109,12 @@ namespace DOL.GS.Spells
 		public SpeedDecreaseSpellHandler(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line)
 		{
 		}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "snare");
+			dw.AddKeyValuePair("bonus", 100 - Spell.Value);
+		}
 	}
 }

--- a/GameServer/spells/SpeedEnhancementSpellHandler.cs
+++ b/GameServer/spells/SpeedEnhancementSpellHandler.cs
@@ -296,5 +296,13 @@ namespace DOL.GS.Spells
 		/// <param name="spell"></param>
 		/// <param name="line"></param>
 		public SpeedEnhancementSpellHandler(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) { }
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "combat");
+			dw.AddKeyValuePair("bonus", Spell.Value);
+			dw.AddKeyValuePair("parm", "10");
+		}
 	}
 }

--- a/GameServer/spells/SpeedOfTheRealmHandler.cs
+++ b/GameServer/spells/SpeedOfTheRealmHandler.cs
@@ -19,6 +19,7 @@
 
 using DOL.GS.Effects;
 using DOL.Database;
+using DOL.GS.PacketHandler;
 
 namespace DOL.GS.Spells
 {
@@ -71,5 +72,13 @@ namespace DOL.GS.Spells
 		/// <param name="spell"></param>
 		/// <param name="line"></param>
 		public SpeedOfTheRealmHandler(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) { }
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "combat");
+			dw.AddKeyValuePair("bonus", Spell.Value);
+			dw.AddKeyValuePair("parm", "35");
+		}
 	}
 }

--- a/GameServer/spells/SpellHandler.cs
+++ b/GameServer/spells/SpellHandler.cs
@@ -4068,7 +4068,7 @@ namespace DOL.GS.Spells
 				if (spell == null)
 					spell = Spell.MultipleSubSpells.Select(SkillBase.GetSpellByID).FirstOrDefault();
 				if (spell != null)
-					dw.AddKeyValuePair("delve_spell", spell.InternalID);
+					dw.AddKeyValuePair("link", spell.InternalID);
 			}
 
 			// default values, remove them if Function changes in a specific SpellHandler
@@ -4098,6 +4098,8 @@ namespace DOL.GS.Spells
 					return 3;
 				case "Area":
 					return 0; // TODO
+				case "Corpse":
+					return 8;
 				default:
 					return 0;
 			}

--- a/GameServer/spells/SpellHandler.cs
+++ b/GameServer/spells/SpellHandler.cs
@@ -4025,59 +4025,56 @@ namespace DOL.GS.Spells
 		{
 			if (dw == null)
 				return;
-			
-			dw.AddKeyValuePair("Function", "light"); // Function of type "light" allows custom description to show with no hardcoded text.  Temporary Fix - tolakram
-			//.Value("Function", spellHandler.FunctionName ?? "0")
+
 			dw.AddKeyValuePair("Index", unchecked((ushort)Spell.InternalID));
 			dw.AddKeyValuePair("Name", Spell.Name);
-			
+
 			if (Spell.CastTime > 2000)
 				dw.AddKeyValuePair("cast_timer", Spell.CastTime - 2000); //minus 2 seconds (why mythic?)
 			else if (!Spell.IsInstantCast)
 				dw.AddKeyValuePair("cast_timer", 0); //minus 2 seconds (why mythic?)
-			
 			if (Spell.IsInstantCast)
 				dw.AddKeyValuePair("instant","1");
-			//.Value("damage", spellHandler.GetDelveValueDamage, spellHandler.GetDelveValueDamage != 0)
-			if ((int)Spell.DamageType > 0)
-				dw.AddKeyValuePair("damage_type", (int) Spell.DamageType + 1); // Damagetype not the same as dol
-			//.Value("type1", spellHandler.GetDelveValueType1, spellHandler.GetDelveValueType1 > 0)
+
+			dw.AddKeyValuePair("damage_type", Spell.DamageType);
+
 			if (Spell.Level > 0)
 			{
 				dw.AddKeyValuePair("level", Spell.Level);
 				dw.AddKeyValuePair("power_level", Spell.Level);
 			}
-
 			if (Spell.CostPower)
 				dw.AddKeyValuePair("power_cost", Spell.Power);
-			//.Value("round_cost",spellHandler.GetDelveValueRoundCost,spellHandler.GetDelveValueRoundCost!=0)
-			//.Value("power_level", spellHandler.GetDelveValuePowerLevel,spellHandler.GetDelveValuePowerLevel!=0)
 			if (Spell.Range > 0)
 				dw.AddKeyValuePair("range", Spell.Range);
 			if (Spell.Duration > 0)
-				dw.AddKeyValuePair("duration", Spell.Duration/1000); //seconds
+				dw.AddKeyValuePair("duration", Spell.Duration / 1000); //seconds
 			if (GetDurationType() > 0)
 				dw.AddKeyValuePair("dur_type", GetDurationType());
-			//.Value("parm",spellHandler.GetDelveValueParm,spellHandler.GetDelveValueParm>0)
 			if (Spell.HasRecastDelay)
-				dw.AddKeyValuePair("timer_value", Spell.RecastDelay/1000);
-			//.Value("bonus", spellHandler.GetDelveValueBonus, spellHandler.GetDelveValueBonus > 0)
-			//.Value("no_combat"," ",Util.Chance(50))//TODO
-			//.Value("link",14000)
-			//.Value("ability",4) // ??
-			//.Value("use_timer",4)
+				dw.AddKeyValuePair("timer_value", Spell.RecastDelay / 1000);
 			if (GetSpellTargetType() > 0)
 				dw.AddKeyValuePair("target", GetSpellTargetType());
-			//.Value("frequency", spellHandler.GetDelveValueFrequency, spellHandler.GetDelveValueFrequency != 0)
-			if (!string.IsNullOrEmpty(Spell.Description))
-				dw.AddKeyValuePair("description_string", Spell.Description);
 			if (Spell.IsAoE)
 				dw.AddKeyValuePair("radius", Spell.Radius);
 			if (Spell.IsConcentration)
 				dw.AddKeyValuePair("concentration_points", Spell.Concentration);
-			//.Value("num_targets", spellHandler.GetDelveValueNumTargets, spellHandler.GetDelveValueNumTargets>0)
-			//.Value("no_interrupt", spell.Interruptable ? (char)0 : (char)1) //Buggy?
-			//log.Info(dw.ToString());
+			if (Spell.Frequency > 0)
+				dw.AddKeyValuePair("frequency", Spell.Frequency);
+
+			if (Spell.HasSubSpell)
+			{
+				var spell = Spell.SubSpellID > 0 ? SkillBase.GetSpellByID(Spell.SubSpellID) : null;
+				if (spell == null)
+					spell = Spell.MultipleSubSpells.Select(SkillBase.GetSpellByID).FirstOrDefault();
+				if (spell != null)
+					dw.AddKeyValuePair("delve_spell", spell.InternalID);
+			}
+
+			// default values, remove them if Function changes in a specific SpellHandler
+			dw.AddKeyValuePair("Function", "light"); // Function of type "light" allows custom description to show with no hardcoded text.
+			if (!string.IsNullOrEmpty(Spell.Description))
+				dw.AddKeyValuePair("delve_string", Spell.Description);
 		}
 		
 		/// <summary>

--- a/GameServer/spells/Spirit Master/SummonSpiritFighter.cs
+++ b/GameServer/spells/Spirit Master/SummonSpiritFighter.cs
@@ -46,5 +46,12 @@ namespace DOL.GS.Spells
 			}
 			return base.CheckBeginCast(selectedTarget);
 		}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "summon");
+			dw.AddKeyValuePair("power_level", -100);
+		}
 	}
 }

--- a/GameServer/spells/SpreadhealSpellHandler.cs
+++ b/GameServer/spells/SpreadhealSpellHandler.cs
@@ -140,5 +140,12 @@ namespace DOL.GS.Spells
 
 			return true;
 		}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "spreadheal");
+			dw.AddKeyValuePair("damage", Spell.Value);
+		}
 	}
 }

--- a/GameServer/spells/StyleBleeding.cs
+++ b/GameServer/spells/StyleBleeding.cs
@@ -156,5 +156,13 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public StyleBleeding(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) {}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "dot");
+			dw.AddKeyValuePair("damage", Spell.Damage);
+			dw.AddKeyValuePair("parm", "20");
+		}
 	}
 }

--- a/GameServer/spells/StyleCombatSpeedDebuff.cs
+++ b/GameServer/spells/StyleCombatSpeedDebuff.cs
@@ -46,5 +46,12 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public StyleCombatSpeedDebuff(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) {}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "add_effect");
+			dw.AddKeyValuePair("type1", "8");
+		}
 	}
 }

--- a/GameServer/spells/StyleStun.cs
+++ b/GameServer/spells/StyleStun.cs
@@ -76,5 +76,12 @@ namespace DOL.GS.Spells
 
 		// constructor
 		public StyleStun(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) {}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "add_effect");
+			dw.AddKeyValuePair("type1", "22");
+		}
 	}
 }

--- a/GameServer/spells/StyleTaunt.cs
+++ b/GameServer/spells/StyleTaunt.cs
@@ -67,5 +67,20 @@ namespace DOL.GS.Spells
 
 		// constructor
         public StyleTaunt(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line) { }
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			if (Spell.Value < 0)
+			{
+				dw.AddKeyValuePair("Function", "detaunt");
+				dw.AddKeyValuePair("damage", -Spell.Value);
+			}
+			else
+			{
+				dw.AddKeyValuePair("Function", "taunt");
+				dw.AddKeyValuePair("damage", Spell.Value);
+			}
+		}
 	}
 }

--- a/GameServer/spells/SummonSpellHandler.cs
+++ b/GameServer/spells/SummonSpellHandler.cs
@@ -288,5 +288,14 @@ namespace DOL.GS.Spells
 				return list;
 			}
 		}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "summon");
+			dw.AddKeyValuePair("power_level", -Spell.Damage);
+			if (Spell.Value != 0)
+				dw.AddKeyValuePair("damage", Spell.Value);
+		}
 	}
 }

--- a/GameServer/spells/TauntSpellHandler.cs
+++ b/GameServer/spells/TauntSpellHandler.cs
@@ -103,5 +103,12 @@ namespace DOL.GS.Spells
 
 
 		public TauntSpellHandler(GameLiving caster, Spell spell, SpellLine spellLine) : base(caster, spell, spellLine) {}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "taunt");
+			dw.AddKeyValuePair("damage", Spell.Damage);
+		}
 	}
 }

--- a/GameServer/spells/Theurgist/SummonTheurgistPet.cs
+++ b/GameServer/spells/Theurgist/SummonTheurgistPet.cs
@@ -106,5 +106,11 @@ namespace DOL.GS.Spells
 			base.GetPetLocation(out x, out y, out z, out heading, out region);
 			heading = Caster.Heading;
 		}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("Function", "dsummon");
+		}
 	}
 }

--- a/GameServer/spells/UnbreakableSpeedDecreaseSpellHandler.cs
+++ b/GameServer/spells/UnbreakableSpeedDecreaseSpellHandler.cs
@@ -194,5 +194,11 @@ namespace DOL.GS.Spells
 		public UnbreakableSpeedDecreaseSpellHandler(GameLiving caster, Spell spell, SpellLine line) : base(caster, spell, line)
 		{
 		}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("bonus", 100 - Spell.Value);
+		}
 	}
 }

--- a/GameServer/spells/buff/SingleStatAbilityBuffHandler.cs
+++ b/GameServer/spells/buff/SingleStatAbilityBuffHandler.cs
@@ -20,6 +20,7 @@
 using System;
 
 using DOL.GS;
+using DOL.GS.PacketHandler;
 
 namespace DOL.GS.Spells
 {
@@ -76,10 +77,16 @@ namespace DOL.GS.Spells
 		public StrengthAbilityBuffHandler(GameLiving caster, Spell spell, SpellLine line)
 			: base(caster, spell, line)
 		{
-		}		
+		}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("bonus", Spell.Value);
+		}
 	}
-	
-    [SpellHandlerAttribute("DexterityAbilityBuff")]
+
+	[SpellHandlerAttribute("DexterityAbilityBuff")]
 	public class DexterityAbilityBuffHandler : SingleStatAbilityBuffHandler
 	{
 		public override eProperty Property1 { get { return eProperty.Dexterity; } }
@@ -87,9 +94,15 @@ namespace DOL.GS.Spells
 		public DexterityAbilityBuffHandler(GameLiving caster, Spell spell, SpellLine line)
 			: base(caster, spell, line)
 		{
-		}		
+		}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("bonus", Spell.Value);
+		}
 	}
-	
+
     [SpellHandlerAttribute("ConstitutionAbilityBuff")]
 	public class ConstitutionAbilityBuffHandler : SingleStatAbilityBuffHandler
 	{
@@ -98,9 +111,15 @@ namespace DOL.GS.Spells
 		public ConstitutionAbilityBuffHandler(GameLiving caster, Spell spell, SpellLine line)
 			: base(caster, spell, line)
 		{
-		}		
+		}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("bonus", Spell.Value);
+		}
 	}
-	
+
     [SpellHandlerAttribute("QuicknessAbilityBuff")]
 	public class QuicknessAbilityBuffHandler : SingleStatAbilityBuffHandler
 	{
@@ -109,10 +128,16 @@ namespace DOL.GS.Spells
 		public QuicknessAbilityBuffHandler(GameLiving caster, Spell spell, SpellLine line)
 			: base(caster, spell, line)
 		{
-		}		
+		}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("bonus", Spell.Value);
+		}
 	}
-	
-    [SpellHandlerAttribute("AcuityAbilityBuff")]
+
+	[SpellHandlerAttribute("AcuityAbilityBuff")]
 	public class AcuityAbilityBuffHandler : SingleStatAbilityBuffHandler
 	{
 		public override eProperty Property1 { get { return eProperty.Acuity; } }
@@ -120,9 +145,15 @@ namespace DOL.GS.Spells
 		public AcuityAbilityBuffHandler(GameLiving caster, Spell spell, SpellLine line)
 			: base(caster, spell, line)
 		{
-		}		
+		}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("bonus", Spell.Value);
+		}
 	}
-	
+
     [SpellHandlerAttribute("MaxHealthAbilityBuff")]
 	public class MaxHealthAbilityBuffHandler : SingleStatAbilityBuffHandler
 	{
@@ -131,6 +162,12 @@ namespace DOL.GS.Spells
 		public MaxHealthAbilityBuffHandler(GameLiving caster, Spell spell, SpellLine line)
 			: base(caster, spell, line)
 		{
-		}		
+		}
+
+		public override void TooltipDelve(ref MiniDelveWriter dw)
+		{
+			base.TooltipDelve(ref dw);
+			dw.AddKeyValuePair("bonus", Spell.Value);
+		}
 	}
 }


### PR DESCRIPTION
The purpose of this commit is to give a better tooltip for spells with 1.110+.
It's clearly not 100% correct but it's a really big task to do it, I extracted all possible "Function" keywords:
```
absorb
accuracy
add_effect
add_radius
addattack
af_hit
amnesia
araisedead
archery
archmagery
armorpiece_debuff
arrogant
aura
autores
bainshee_pulse
ball
battery
bedazzle
bolt
breath
buff_shear
charm
climb
combat
combat_heal
cost_reduction
cower
critical
crit_buff
damage
damage_type
dashing
dcharm
dconvert
def_proc
degrade
degrade_hurt
direct
direct_chain
direct_inc
disarm
disease
dmg_add
dmg_shield
dmg_suppress
dmg_to_power
doppelgang
dot
dsummon
dummy
efatigue
ehealth
end_drain
enhance_ab
enhancement
epower
fat_heal
fatigue
feather
font
g_absorb
gate
grapple
gsummon
haste
heal
heal_bonus
healsight
hit_buffer
hold_storm
ill_animist
ill_bard
ill_bone
illusion
invisible
item
level
lifedrain
light
lull
mag_pierce
mez_dampen
mod
nabsorb
narchmage
narrogant
nbonus
ndamage
ndisorient
nencumber
nfatigue
nhidden
nillusion
no_cost
nradius
nresist_dam
nresistance
nshield
nskill
nstat
nstat_block
nstat_fade
nstat_perc
nstatdrain
nstyle
ntarget
ntransfer
ntwostat
nullskill
nweaponskill
off_proc
olife_drain
omni_heal
paralyze
petcast
plifedrain
power_heal
power_xfer
powerdrain
preserve
proj_shield
pshield
purge
queue
raise_dead
realmlore
reclaim
recover
regen
regen_perc
rem_eff_ty
rem_rnd_buf
remove_eff
reset_qc
resistance
reveal
rune
rune_sweep
s_predict
sever
shield
siege
siege_protection
skill
snare
snare_dampen
soff_proc
sp_suppress
speedwarp
spell_pulse
spreadheal
ssummon
stat
storm
styleheal
summon
suppress
taunt
teleport
tempest
transfer
true_speed
twostat
vanish
vision
vortex
xrbchp_bonus
xrecover
```

Many of them are not for spells but it can help to find some function used by spells.