### PR TITLE
Replace Power cost by Health Cost for savage spells in Delves

### DIFF
--- a/GameServer/spells/Savage/SavageBuff.cs
+++ b/GameServer/spells/Savage/SavageBuff.cs
@@ -19,6 +19,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using DOL.GS;
 using DOL.GS.Effects;
 using DOL.GS.PacketHandler;
@@ -89,6 +90,89 @@ namespace DOL.GS.Spells
 
                 return list;
             }
+        }
+
+        /// <summary>
+		/// Return the given Delve Writer with added keyvalue pairs.
+        /// Add cost type equal 2 to replace power cost by health cost 
+		/// </summary>
+		/// <param name="dw"></param>
+		/// <param name="id"></param>
+		public override void TooltipDelve(ref MiniDelveWriter dw, int id, GameClient client)
+        {
+            if (dw == null)
+                return;
+
+            int level = Spell.Level;
+            int spellID = Spell.ID;
+
+            foreach (SpellLine line in client.Player.GetSpellLines())
+            {
+                Spell s = SkillBase.GetSpellList(line.KeyName).Where(o => o.ID == spellID).FirstOrDefault();
+                if (s != null)
+                {
+                    level = s.Level;
+                    break;
+                }
+            }
+
+            dw.AddKeyValuePair("Function", "light"); 
+
+            dw.AddKeyValuePair("Index", unchecked((short)id));
+            dw.AddKeyValuePair("Name", Spell.Name);
+
+            if (Spell.CastTime > 2000)
+                dw.AddKeyValuePair("cast_timer", Spell.CastTime - 2000); 
+            else if (!Spell.IsInstantCast)
+                dw.AddKeyValuePair("cast_timer", 0); 
+
+            if (Spell.IsInstantCast)
+                dw.AddKeyValuePair("instant", "1");
+
+            if ((int)Spell.DamageType > 0)
+                dw.AddKeyValuePair("damage_type", Spell.GetDelveDamageType()); 
+
+            if (Spell.Level > 0)
+                dw.AddKeyValuePair("level", level);
+            if (Spell.CostPower)
+            {
+                dw.AddKeyValuePair("power_cost", Spell.Power);
+                dw.AddKeyValuePair("cost_type", 2);
+            }
+
+
+            if (Spell.Range > 0)
+                dw.AddKeyValuePair("range", Spell.Range);
+            if (Spell.Duration > 0)
+                dw.AddKeyValuePair("duration", Spell.Duration / 1000); 
+            if (GetDurationType() > 0)
+                dw.AddKeyValuePair("dur_type", GetDurationType());
+
+            if (Spell.HasRecastDelay)
+                dw.AddKeyValuePair("timer_value", Spell.RecastDelay / 1000);
+
+            if (GetSpellTargetType() > 0)
+                dw.AddKeyValuePair("target", GetSpellTargetType());
+
+            string description = string.Empty;
+            if (!string.IsNullOrEmpty(Spell.Description))
+                description = Spell.Description;
+
+            if (Spell.Damage > 0)
+            {
+                description += string.Format(" Value: ({0})", Spell.Damage);
+            }
+            else if (Spell.Value > 0)
+            {
+                description += string.Format(" Value: ({0})", Spell.Value);
+            }
+
+
+            dw.AddKeyValuePair("description_string", description);
+            if (Spell.IsAoE)
+                dw.AddKeyValuePair("radius", Spell.Radius);
+            if (Spell.IsConcentration)
+                dw.AddKeyValuePair("concentration_points", Spell.Concentration);
         }
 
 		/// <summary>

--- a/GameServer/spells/Savage/SavageEnduranceHeal.cs
+++ b/GameServer/spells/Savage/SavageEnduranceHeal.cs
@@ -17,6 +17,7 @@
  *
  */
 using System;
+using System.Linq;
 using System.Collections;
 using DOL.GS.PacketHandler;
 using DOL.Language;
@@ -56,5 +57,88 @@ namespace DOL.GS.Spells
 			}
 			return base.CheckBeginCast(Caster);
 		}
+
+        /// <summary>
+		/// Return the given Delve Writer with added keyvalue pairs.
+        /// Add cost type equal 2 to replace power cost by health cost 
+		/// </summary>
+		/// <param name="dw"></param>
+		/// <param name="id"></param>
+		public override void TooltipDelve(ref MiniDelveWriter dw, int id, GameClient client)
+        {
+            if (dw == null)
+                return;
+
+            int level = Spell.Level;
+            int spellID = Spell.ID;
+
+            foreach (SpellLine line in client.Player.GetSpellLines())
+            {
+                Spell s = SkillBase.GetSpellList(line.KeyName).Where(o => o.ID == spellID).FirstOrDefault();
+                if (s != null)
+                {
+                    level = s.Level;
+                    break;
+                }
+            }
+
+            dw.AddKeyValuePair("Function", "light");
+
+            dw.AddKeyValuePair("Index", unchecked((short)id));
+            dw.AddKeyValuePair("Name", Spell.Name);
+
+            if (Spell.CastTime > 2000)
+                dw.AddKeyValuePair("cast_timer", Spell.CastTime - 2000);
+            else if (!Spell.IsInstantCast)
+                dw.AddKeyValuePair("cast_timer", 0);
+
+            if (Spell.IsInstantCast)
+                dw.AddKeyValuePair("instant", "1");
+
+            if ((int)Spell.DamageType > 0)
+                dw.AddKeyValuePair("damage_type", Spell.GetDelveDamageType());
+
+            if (Spell.Level > 0)
+                dw.AddKeyValuePair("level", level);
+            if (Spell.CostPower)
+            {
+                dw.AddKeyValuePair("power_cost", Spell.Power);
+                dw.AddKeyValuePair("cost_type", 2);
+            }
+
+
+            if (Spell.Range > 0)
+                dw.AddKeyValuePair("range", Spell.Range);
+            if (Spell.Duration > 0)
+                dw.AddKeyValuePair("duration", Spell.Duration / 1000);
+            if (GetDurationType() > 0)
+                dw.AddKeyValuePair("dur_type", GetDurationType());
+
+            if (Spell.HasRecastDelay)
+                dw.AddKeyValuePair("timer_value", Spell.RecastDelay / 1000);
+
+            if (GetSpellTargetType() > 0)
+                dw.AddKeyValuePair("target", GetSpellTargetType());
+
+            string description = string.Empty;
+            if (!string.IsNullOrEmpty(Spell.Description))
+                description = Spell.Description;
+
+            if (Spell.Damage > 0)
+            {
+                description += string.Format(" Value: ({0})", Spell.Damage);
+            }
+            else if (Spell.Value > 0)
+            {
+                description += string.Format(" Value: ({0})", Spell.Value);
+            }
+
+
+            dw.AddKeyValuePair("description_string", description);
+            if (Spell.IsAoE)
+                dw.AddKeyValuePair("radius", Spell.Radius);
+            if (Spell.IsConcentration)
+                dw.AddKeyValuePair("concentration_points", Spell.Concentration);
+        }
 	}
 }


### PR DESCRIPTION
Savage Class use Health instead of power for its spells, as a result, it should be indicated in the Delves.