### PR TITLE
Fix Pets following player erratically

### DIFF
--- a/GameServer/gameobjects/GameNPC.cs
+++ b/GameServer/gameobjects/GameNPC.cs
@@ -1747,7 +1747,7 @@ namespace DOL.GS
             if (InCombat || Brain is BomberBrain)
                 WalkTo(newX, newY, (ushort)newZ, MaxSpeed);
             else if (MaxSpeed < GetDistance(new Point2D(newX, newY)))
-                WalkTo(newX, newY, (ushort)newZ, Math.Min(MaxSpeed, followLiving.CurrentSpeed + 50));
+                WalkTo(newX, newY, (ushort)newZ, (short)Math.Min(MaxSpeed, followLiving.CurrentSpeed + 50));
             else
                 WalkTo(newX, newY, (ushort)newZ, (short)GetDistance(new Point2D(newX, newY)));
             return ServerProperties.Properties.GAMENPC_FOLLOWCHECK_TIME;

--- a/GameServer/gameobjects/GameNPC.cs
+++ b/GameServer/gameobjects/GameNPC.cs
@@ -1747,7 +1747,7 @@ namespace DOL.GS
             if (InCombat || Brain is BomberBrain)
                 WalkTo(newX, newY, (ushort)newZ, MaxSpeed);
             else if (MaxSpeed < GetDistance(new Point2D(newX, newY)))
-                WalkTo(newX, newY, (ushort)newZ, Math.Min(MaxSpeed, followLiving.CurrentSpeed));
+                WalkTo(newX, newY, (ushort)newZ, Math.Min(MaxSpeed, followLiving.CurrentSpeed + 50));
             else
                 WalkTo(newX, newY, (ushort)newZ, (short)GetDistance(new Point2D(newX, newY)));
             return ServerProperties.Properties.GAMENPC_FOLLOWCHECK_TIME;

--- a/GameServer/gameobjects/GameNPC.cs
+++ b/GameServer/gameobjects/GameNPC.cs
@@ -1743,8 +1743,14 @@ namespace DOL.GS
 			newX = (int)(followTarget.X - diffx);
 			newY = (int)(followTarget.Y - diffy);
 			newZ = (int)(followTarget.Z - diffz);
-			WalkTo(newX, newY, (ushort)newZ, MaxSpeed);
-			return ServerProperties.Properties.GAMENPC_FOLLOWCHECK_TIME;
+
+            if (InCombat || Brain is BomberBrain)
+                WalkTo(newX, newY, (ushort)newZ, MaxSpeed);
+            else if (MaxSpeed < GetDistance(new Point2D(newX, newY)))
+                WalkTo(newX, newY, (ushort)newZ, Math.Min(MaxSpeed, followLiving.CurrentSpeed));
+            else
+                WalkTo(newX, newY, (ushort)newZ, (short)GetDistance(new Point2D(newX, newY)));
+            return ServerProperties.Properties.GAMENPC_FOLLOWCHECK_TIME;
 		}
 
 		/// <summary>


### PR DESCRIPTION
- Now Pets will follow players in relation with their speed
- In order to make this work, some adaptations were necessary on BomberBrains while in combat in order to hit their target normally (without beeing stuck)