### PR TITLE
Automatically equip left-handed items

### DIFF
--- a/GameServer/gameutils/GamePlayerInventory.cs
+++ b/GameServer/gameutils/GamePlayerInventory.cs
@@ -554,6 +554,7 @@ namespace DOL.GS
 			    || (slot >= eInventorySlot.HouseVault_First && slot <= eInventorySlot.HouseVault_Last)
 			    || (slot >= eInventorySlot.Consignment_First && slot <= eInventorySlot.Consignment_Last)
 			    || (slot == eInventorySlot.PlayerPaperDoll)
+			    || (slot == eInventorySlot.NewPlayerPaperDoll)
 			    || (slot == eInventorySlot.Mythical)
 			    // INVENTAIRE DES CHEVAUX
 			    || (slot >= eInventorySlot.FirstBagHorse && slot <= eInventorySlot.LastBagHorse))

--- a/GameServer/packets/Client/168/PlayerMoveItemRequestHandler.cs
+++ b/GameServer/packets/Client/168/PlayerMoveItemRequestHandler.cs
@@ -288,13 +288,22 @@ namespace DOL.GS.PacketHandler.Client.v168
 				if (item == null) return;
 
 				toClientSlot = 0;
+                
 				if (item.Item_Type >= (int)eInventorySlot.MinEquipable && item.Item_Type <= (int)eInventorySlot.MaxEquipable)
-					toClientSlot = (ushort)item.Item_Type;
+                {
+                    // If item can be used in left-hand we force it in the right hand (as we don't know whether it is intended to be used as right or left)
+                    if( item.Item_Type == (int)eInventorySlot.LeftHandWeapon && item.Hand == 2 )
+                        toClientSlot = (int)eInventorySlot.RightHandWeapon;
+                    else
+                        toClientSlot = (ushort)item.Item_Type;
+                }
+                
 				if (toClientSlot == 0)
 				{
 					client.Out.SendInventorySlotsUpdate(new int[] { fromClientSlot });
 					return;
 				}
+                
 				if (toClientSlot == (int)eInventorySlot.LeftBracer || toClientSlot == (int)eInventorySlot.RightBracer)
 				{
 					if (client.Player.Inventory.GetItem(eInventorySlot.LeftBracer) == null)


### PR DESCRIPTION
Here we consider items that are Item_Type = LeftHandWeapon and Hand = 2.
When moved from any slot onto the player paper doll, they were given a toSlot = LeftHand.
This would work for characters with ability to wield left handed weapons.
But if the character does not have this ability, the object would simply tell "This can't go there.".

The proper solution is to always put "Usable in left hand" weapons in the right hand weapon.
I verified on live and this is the expected behaviour.
If you want to put a weapon in the left slot, you have to tell it explicitely by putting it on the left slot and not on the paper doll.