### PR TITLE
Fix bug when loot items as GM:

### DIFF
--- a/GameServer/gameobjects/GameLiving.cs
+++ b/GameServer/gameobjects/GameLiving.cs
@@ -4406,7 +4406,12 @@ namespace DOL.GS
 			lock (Attackers)
 			{
 				m_attackers.Remove(attacker);
-			}
+                // If GM use viewloot, need remove the attacker from the xpGainers, else if he deco/reco
+                // and redo the action, he apears twice in the list and the bug is happen
+                lock (m_xpGainers)
+                    if (m_xpGainers.Contains(attacker) && Health == MaxHealth)
+                        m_xpGainers.Remove(attacker);
+            }
 		}
 		/// <summary>
 		/// Called when this living dies


### PR DESCRIPTION
If GM use viewloot, need remove the attacker from the xpGainers, else if he deco/reco and redo the action, he appears twice in the list and the bug does happen

Cherry-picked from @Lord-Seithenin (Dawn-of-Light/DOLSharp#315)