### PR TITLE
fix text encoding

### DIFF
--- a/DOLBase/Constants.cs
+++ b/DOLBase/Constants.cs
@@ -100,6 +100,6 @@ namespace DOL
 		/// <summary>
 		/// The default encoding to use for all string operations in packet writing or reading.
 		/// </summary>
-		public static readonly Encoding DefaultEncoding = Encoding.GetEncoding(1252);
+		public static readonly Encoding DefaultEncoding = CodePagesEncodingProvider.Instance.GetEncoding(1252);
 	}
 }

--- a/DOLBase/Constants.cs
+++ b/DOLBase/Constants.cs
@@ -100,6 +100,6 @@ namespace DOL
 		/// <summary>
 		/// The default encoding to use for all string operations in packet writing or reading.
 		/// </summary>
-		public static readonly Encoding DefaultEncoding = Encoding.Default;
+		public static readonly Encoding DefaultEncoding = Encoding.GetEncoding(1252);
 	}
 }

--- a/DOLBase/DOLBase.csproj
+++ b/DOLBase/DOLBase.csproj
@@ -54,6 +54,7 @@
   <ItemGroup>
     <PackageReference Include="SharpZipLib" Version="1.3.2" PrivateAssets="all" />
     <PackageReference Include="log4net" Version="2.0.12" PrivateAssets="all" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="5.0.0" />
   </ItemGroup>
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/Net5/DOLBase/DOLBase.csproj
+++ b/Net5/DOLBase/DOLBase.csproj
@@ -32,6 +32,7 @@
   <ItemGroup>
     <PackageReference Include="SharpZipLib" Version="1.3.2" />
     <PackageReference Include="log4net" Version="2.0.12" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\DOLBase\**\*.cs" />


### PR DESCRIPTION
Daoc use Windows-1252 as text encoding which is the default encoding in .net 4.8 on windows but it's utf-8 for other platforms (and .net core).