### PR TITLE
remove useless SQL prepare statement

### DIFF
--- a/DOLDatabase/SQLObjectDatabase.cs
+++ b/DOLDatabase/SQLObjectDatabase.cs
@@ -667,7 +667,6 @@ namespace DOL.Database
 							{
 								cmd.CommandText = selectFromExpression + whereClause.ParameterizedText;
 								FillSQLParameter(whereClause.Parameters, cmd.Parameters);
-								cmd.Prepare();
 
 								using (var reader = cmd.ExecuteReader())
 								{


### PR DESCRIPTION
The prepare statement is useful only if we re-use the prepared statement but in DOL, a new statement is created every time.