### PR TITLE
Fix character creation and realm switching in 1.126+

### DIFF
--- a/GameServer/packets/Server/PacketLib1126.cs
+++ b/GameServer/packets/Server/PacketLib1126.cs
@@ -31,11 +31,21 @@ namespace DOL.GS.PacketHandler
 	{
 		private static readonly ILog log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
 
-		/// <summary>
-		/// Constructs a new PacketLib for Client Version 1.126
-		/// </summary>
-		/// <param name="client">the gameclient this lib is associated with</param>
-		public PacketLib1126(GameClient client)
+        protected override byte ServerTypeID
+        {
+			get
+			{
+				var serverType = GameServer.Instance.Configuration.ServerType;
+				switch (serverType)
+				{
+					case eGameServerType.GST_PvP: return 1;
+					case eGameServerType.GST_PvE: return 3;
+					default: return 7; //Ywain; 0x00 no longer working
+				}
+			}
+		}
+
+        public PacketLib1126(GameClient client)
 			: base(client)
 		{
 		}

--- a/GameServer/packets/Server/PacketLib1126.cs
+++ b/GameServer/packets/Server/PacketLib1126.cs
@@ -102,9 +102,10 @@ namespace DOL.GS.PacketHandler
 
 			int firstSlot = (byte)realm * 100;
 
+			var enableRealmSwitcherBit = GameServer.ServerRules.IsAllowedCharsInAllRealms(m_gameClient) ? 1 : 0;
 			using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.CharacterOverview1126)))
 			{
-				pak.WriteIntLowEndian(0); // 0x01 & 0x02 are flags
+				pak.WriteIntLowEndian((uint)enableRealmSwitcherBit); // 0x01 & 0x02 are flags
 				pak.WriteIntLowEndian(0);
 				pak.WriteIntLowEndian(0);
 				pak.WriteIntLowEndian(0);

--- a/GameServer/packets/Server/PacketLib1126.cs
+++ b/GameServer/packets/Server/PacketLib1126.cs
@@ -333,9 +333,6 @@ namespace DOL.GS.PacketHandler
 			}
 		}
 
-		/// <summary>
-		/// This packet may have been updated anywhere from 1125b-1126a - not sure
-		/// </summary>
 		public override void SendUpdateWeaponAndArmorStats()
 		{
 			if (m_gameClient.Player == null)
@@ -351,10 +348,10 @@ namespace DOL.GS.PacketHandler
 				pak.WriteByte(0x00); //unk
 
 				// weapondamage
-				var wd = (int)(m_gameClient.Player.WeaponDamage(m_gameClient.Player.AttackWeapon) * 100.0);
-				pak.WriteByte((byte)(wd / 100));
+				var wd = (int)(m_gameClient.Player.WeaponDamage(m_gameClient.Player.AttackWeapon) * 100);
+				pak.WriteByte((byte)(wd / 0x100));
 				pak.WriteByte(0x00);
-				pak.WriteByte((byte)(wd % 100));
+				pak.WriteByte((byte)(wd % 0x100));
 				pak.WriteByte(0x00);
 				// weaponskill
 				int ws = m_gameClient.Player.DisplayedWeaponSkill;

--- a/GameServer/packets/Server/PacketLib1127.cs
+++ b/GameServer/packets/Server/PacketLib1127.cs
@@ -16,7 +16,6 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  *
  */
-
 using log4net;
 using System.Reflection;
 

--- a/GameServer/packets/Server/PacketLib168.cs
+++ b/GameServer/packets/Server/PacketLib168.cs
@@ -46,10 +46,21 @@ namespace DOL.GS.PacketHandler
 	{
 		private const int MaxPacketLength = 2048;
 
-		/// <summary>
-		/// Defines a logger for this class.
-		/// </summary>
 		private static readonly ILog log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+
+		protected virtual byte ServerTypeID
+        {
+			get
+			{
+				var serverType = GameServer.Instance.Configuration.ServerType;
+				switch (serverType)
+				{
+					case eGameServerType.GST_PvP: return 1;
+					case eGameServerType.GST_PvE: return 3;
+					default: return 0;
+				}
+			}
+        }
 
 		/// <summary>
 		/// Constructs a new PacketLib for Version 1.68 clients
@@ -121,7 +132,7 @@ namespace DOL.GS.PacketHandler
 
 		public virtual void SendLoginGranted()
 		{
-			SendLoginGranted(GameServer.ServerRules.GetColorHandling(m_gameClient));
+			SendLoginGranted(ServerTypeID);
 		}
 
 		public virtual void SendLoginGranted(byte color)
@@ -3723,7 +3734,7 @@ namespace DOL.GS.PacketHandler
 
 		public virtual void SendRegionColorScheme()
 		{
-			SendRegionColorScheme(GameServer.ServerRules.GetColorHandling(m_gameClient));
+			SendRegionColorScheme(ServerTypeID);
 		}
 
 		public virtual void SendVampireEffect(GameLiving living, bool show)

--- a/GameServer/packets/Server/PacketLib175.cs
+++ b/GameServer/packets/Server/PacketLib175.cs
@@ -523,15 +523,13 @@ namespace DOL.GS.PacketHandler
 
         public override void SendLoginGranted()
         {
-            //[Freya] Nidel: Can use realm button in character selection screen
-
-            if (ServerProperties.Properties.ALLOW_ALL_REALMS || m_gameClient.Account.PrivLevel > (int)ePrivLevel.Player)
+            if (GameServer.ServerRules.IsAllowedCharsInAllRealms(m_gameClient))
             {
                 SendLoginGranted(1);
             }
             else
             {
-                SendLoginGranted(GameServer.ServerRules.GetColorHandling(m_gameClient));
+                SendLoginGranted(ServerTypeID);
             }
         }
     }

--- a/GameServer/serverrules/IServerRules.cs
+++ b/GameServer/serverrules/IServerRules.cs
@@ -328,6 +328,7 @@ namespace DOL.GS.ServerRules
 		/// </summary>
 		/// <param name="client">The client asking for color handling</param>
 		/// <returns>The color handling</returns>
+		[Obsolete("This is going to be removed. Use PacketLib168.ServerTypeID instead.")]
 		byte GetColorHandling(GameClient client);
 		
 		/// <summary>


### PR DESCRIPTION
Fix character creation, which was previously not usable with other server rules than PvE/PvP
Fix realm switcher not being available after logging a char in and out
Fix a small calculation error in PacketLib1126 weapon damage calc