### PR TITLE
Fix ScriptCompiler error display

### DIFF
--- a/GameServer/commands/admincommands/code.cs
+++ b/GameServer/commands/admincommands/code.cs
@@ -17,8 +17,6 @@
  *
  */
 using System;
-using System.IO;
-using System.Linq;
 using System.Reflection;
 using System.Text;
 using DOL.GS.PacketHandler;
@@ -38,24 +36,7 @@ namespace DOL.GS.Commands
 		public static void ExecuteCode(GameClient client, string methodBody)
 		{
 			var compiler = new DOLScriptCompiler();
-			var compiledAssembly = compiler.CompileFromSource(GetCode(methodBody));
-
-			var errorMessages = compiler.GetErrorMessages();
-			if(errorMessages.Any())
-            {
-				if (client.Player != null)
-				{
-					client.Out.SendMessage(LanguageMgr.GetTranslation(client.Account.Language, "AdminCommands.Code.ErrorCompiling"), eChatType.CT_System, eChatLoc.CL_PopupWindow);
-
-					foreach (var errorMessage in errorMessages)
-						client.Out.SendMessage(errorMessage, eChatType.CT_System, eChatLoc.CL_PopupWindow);
-				}
-				else
-				{
-					log.Debug("Error compiling code.");
-				}
-				return;
-			}
+			var compiledAssembly = compiler.CompileFromText(client, GetCode(methodBody));
 
 			var methodinf = compiledAssembly.GetType("DynCode").GetMethod("DynMethod");
 

--- a/GameServer/gameutils/ScriptMgr.cs
+++ b/GameServer/gameutils/ScriptMgr.cs
@@ -520,11 +520,6 @@ namespace DOL.GS
 				if (compileVB) compiler.SetToVisualBasicNet();
 
 				var compiledAssembly = compiler.Compile(outputFile, files);
-				foreach (var errorMessage in compiler.GetDetailedErrorMessages())
-				{
-					log.Error(errorMessage);
-				}
-				if (compiler.HasErrors) return false;
 				compilationSuccessful = true;
 
 				AddOrReplaceAssembly(compiledAssembly);


### PR DESCRIPTION
Causing errors weren't displayed when compilation failed
Move error display to DOLScriptCompiler