### PR TITLE
Spell tooltip fix : Retrieve the correct spell level

### DIFF
--- a/GameServer/gameutils/Skill/Delve/SongDelve.cs
+++ b/GameServer/gameutils/Skill/Delve/SongDelve.cs
@@ -19,6 +19,7 @@
 using DOL.GS.PacketHandler;
 using DOL.GS.Spells;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace DOL.GS.Delve
 {
@@ -34,6 +35,24 @@ namespace DOL.GS.Delve
 			DelveType = "Song";
 			Index = unchecked((short)spellHandler.Spell.InternalID);
 		}
+                
+        public SongDelve(int id, GameClient client) : this(id)
+        {
+            int level = Spell.Level;
+            int spellID = Spell.ID;
+
+            foreach (SpellLine line in client.Player.GetSpellLines())
+            {
+                Spell s = SkillBase.GetSpellList(line.KeyName).Where(o => o.ID == spellID).FirstOrDefault();
+                if (s != null)
+                {
+                    level = s.Level;
+                    break;
+                }
+            }
+            Spell.Level = level;
+
+        }
 
         public override ClientDelve GetClientDelve()
         {

--- a/GameServer/gameutils/Skill/Delve/SpellDelve.cs
+++ b/GameServer/gameutils/Skill/Delve/SpellDelve.cs
@@ -19,6 +19,7 @@
 using DOL.GS.PacketHandler;
 using DOL.GS.Spells;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace DOL.GS.Delve
 {
@@ -37,7 +38,25 @@ namespace DOL.GS.Delve
 			Index = unchecked((short)spellHandler.Spell.InternalID);
 		}
 
-		public override ClientDelve GetClientDelve()
+
+        public SpellDelve(Spell spell, GameClient client) : this(spell)
+        {
+            int level = Spell.Level;
+            int spellID = Spell.ID;
+
+            foreach (SpellLine line in client.Player.GetSpellLines())
+            {
+                Spell s = SkillBase.GetSpellList(line.KeyName).Where(o => o.ID == spellID).FirstOrDefault();
+                if (s != null)
+                {
+                    level = s.Level;
+                    break;
+                }
+            }
+            Spell.Level = level;
+
+        }
+        public override ClientDelve GetClientDelve()
 		{
 			if (spellHandler == null) return NotFoundClientDelve;
 

--- a/GameServer/packets/Client/168/DetailDisplayHandler.cs
+++ b/GameServer/packets/Client/168/DetailDisplayHandler.cs
@@ -930,10 +930,10 @@ namespace DOL.GS.PacketHandler.Client.v168
 				case 26://SongsNew
 					if (client.CanSendTooltip(26, objectId))
 					{
-						client.Out.SendDelveInfo(new SongDelve(objectId).GetClientDelve().ClientMessage);
-						var spell = SkillBase.GetSpellByTooltipID(objectId);
-						client.Out.SendDelveInfo(new SpellDelve(spell).GetClientDelve().ClientMessage);
-					}
+                        client.Out.SendDelveInfo(new SongDelve(objectId).GetClientDelve().ClientMessage);
+                        var spell = SkillBase.GetSpellByTooltipID(objectId);
+                        client.Out.SendDelveInfo(new SpellDelve(spell).GetClientDelve().ClientMessage);
+                    }
 					break;
 				case 27://RANew
 					if (client.CanSendTooltip(27, objectId))

--- a/GameServer/packets/Client/168/DetailDisplayHandler.cs
+++ b/GameServer/packets/Client/168/DetailDisplayHandler.cs
@@ -930,9 +930,9 @@ namespace DOL.GS.PacketHandler.Client.v168
 				case 26://SongsNew
 					if (client.CanSendTooltip(26, objectId))
 					{
-                        client.Out.SendDelveInfo(new SongDelve(objectId).GetClientDelve().ClientMessage);
+                        client.Out.SendDelveInfo(new SongDelve(objectId, client).GetClientDelve().ClientMessage);
                         var spell = SkillBase.GetSpellByTooltipID(objectId);
-                        client.Out.SendDelveInfo(new SpellDelve(spell).GetClientDelve().ClientMessage);
+                        client.Out.SendDelveInfo(new SpellDelve(spell, client).GetClientDelve().ClientMessage);
                     }
 					break;
 				case 27://RANew

--- a/GameServer/packets/Client/168/DetailDisplayHandler.cs
+++ b/GameServer/packets/Client/168/DetailDisplayHandler.cs
@@ -920,8 +920,8 @@ namespace DOL.GS.PacketHandler.Client.v168
 					if (client.CanSendTooltip(24, objectId))
 					{
 						var spell = SkillBase.GetSpellByTooltipID(objectId);
-						client.Out.SendDelveInfo(new SpellDelve(spell).GetClientDelve().ClientMessage);
-					}
+                        client.Out.SendDelveInfo(new SpellDelve(spell, client).GetClientDelve().ClientMessage);
+                    }
 					break;
 				case 25://StylesNew
 					if (client.CanSendTooltip(25, objectId))


### PR DESCRIPTION
Retrieve the correct spell level to show in the tool tip.

This fix is simplier than the previous PR