### PR TITLE
Github Actions Build with more verbosity

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           $Env:DOTNET_CLI_TELEMETRY_OPTOUT=1
           $assembly_version="$(cat release_info/version.txt)"
-          dotnet build -c "${{ matrix.build_target}}" -p:Version="$assembly_version" "Dawn of Light.sln"
+          dotnet build -c "${{ matrix.build_target}}" -p:Version="$assembly_version" "Dawn of Light.sln" --verbosity detailed
       - name: Test Build
         run: |
           dotnet test .\build\Tests\${{ matrix.build_target }}\lib\Tests.dll -v n --filter "DOL.UnitTests&TestCategory!=Explicit"
@@ -89,7 +89,7 @@ jobs:
         run: |
           $Env:DOTNET_CLI_TELEMETRY_OPTOUT=1
           $assembly_version="$(cat release_info/version.txt)"
-          dotnet build -c "${{ matrix.build_target}}" -p:Version="$assembly_version" "Net5\DOLdotnet.sln"
+          dotnet build -c "${{ matrix.build_target}}" -p:Version="$assembly_version" "Net5\DOLdotnet.sln" --verbosity detailed
       - name: Test Build
         run: |
           dotnet test .\Net5\build\Tests\${{ matrix.build_target }}\lib\Tests.dll -v n --filter "DOL.UnitTests&TestCategory!=Explicit"

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           $Env:DOTNET_CLI_TELEMETRY_OPTOUT=1
           $assembly_version="$(cat release_info/version.txt)"
-          dotnet build -c "${{ matrix.build_target}}" -p:Version="$assembly_version" "Dawn of Light.sln" --verbosity detailed
+          dotnet build -c "${{ matrix.build_target}}" -p:Version="$assembly_version" "Dawn of Light.sln" --verbosity normal
       - name: Test Build
         run: |
           dotnet test .\build\Tests\${{ matrix.build_target }}\lib\Tests.dll -v n --filter "DOL.UnitTests&TestCategory!=Explicit"
@@ -89,7 +89,7 @@ jobs:
         run: |
           $Env:DOTNET_CLI_TELEMETRY_OPTOUT=1
           $assembly_version="$(cat release_info/version.txt)"
-          dotnet build -c "${{ matrix.build_target}}" -p:Version="$assembly_version" "Net5\DOLdotnet.sln" --verbosity detailed
+          dotnet build -c "${{ matrix.build_target}}" -p:Version="$assembly_version" "Net5\DOLdotnet.sln" --verbosity normal
       - name: Test Build
         run: |
           dotnet test .\Net5\build\Tests\${{ matrix.build_target }}\lib\Tests.dll -v n --filter "DOL.UnitTests&TestCategory!=Explicit"

--- a/.github/workflows/test_runner.yml
+++ b/.github/workflows/test_runner.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Build
         run: |
-          dotnet build -c ${{ matrix.build_target }} "Net5/Tests/Tests.csproj"
+          dotnet build -c ${{ matrix.build_target }} "Net5/Tests/Tests.csproj" --verbosity detailed
       - name: Test
         run: |
           dotnet test ./Net5/build/Tests/${{ matrix.build_target }}/lib/Tests.dll -v n --filter "DOL.UnitTests&TestCategory!=Explicit"
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Build
         run: |
-          dotnet build -c ${{ matrix.build_target }} "Net5/DOLdotnet.sln"
+          dotnet build -c ${{ matrix.build_target }} "Net5/DOLdotnet.sln" --verbosity detailed
       - name: Test
         run: |
           dotnet test .\Net5\build\Tests\${{ matrix.build_target }}\lib\Tests.dll -v n --filter "DOL.UnitTests&TestCategory!=Explicit"
@@ -53,7 +53,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build
-        run: dotnet build -c ${{ matrix.build_target }} "Tests/Tests.csproj"
+        run: dotnet build -c ${{ matrix.build_target }} "Tests/Tests.csproj" --verbosity detailed
       - name: Test
         run: |
           dotnet test ./build/Tests/${{ matrix.build_target }}/lib/Tests.dll -v n --filter "DOL.UnitTests&TestCategory!=Explicit"
@@ -69,7 +69,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build
-        run: dotnet build -c ${{ matrix.build_target }} "Tests\Tests.csproj"
+        run: dotnet build -c ${{ matrix.build_target }} "Tests\Tests.csproj" --verbosity detailed
       - name: Test
         run: |
           dotnet test .\build\Tests\${{ matrix.build_target }}\lib\Tests.dll -v n --filter "DOL.UnitTests&TestCategory!=Explicit"

--- a/.github/workflows/test_runner.yml
+++ b/.github/workflows/test_runner.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Build
         run: |
-          dotnet build -c ${{ matrix.build_target }} "Net5/Tests/Tests.csproj" --verbosity detailed
+          dotnet build -c ${{ matrix.build_target }} "Net5/Tests/Tests.csproj" --verbosity normal
       - name: Test
         run: |
           dotnet test ./Net5/build/Tests/${{ matrix.build_target }}/lib/Tests.dll -v n --filter "DOL.UnitTests&TestCategory!=Explicit"
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Build
         run: |
-          dotnet build -c ${{ matrix.build_target }} "Net5/DOLdotnet.sln" --verbosity detailed
+          dotnet build -c ${{ matrix.build_target }} "Net5/DOLdotnet.sln" --verbosity normal
       - name: Test
         run: |
           dotnet test .\Net5\build\Tests\${{ matrix.build_target }}\lib\Tests.dll -v n --filter "DOL.UnitTests&TestCategory!=Explicit"
@@ -53,7 +53,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build
-        run: dotnet build -c ${{ matrix.build_target }} "Tests/Tests.csproj" --verbosity detailed
+        run: dotnet build -c ${{ matrix.build_target }} "Tests/Tests.csproj" --verbosity normal
       - name: Test
         run: |
           dotnet test ./build/Tests/${{ matrix.build_target }}/lib/Tests.dll -v n --filter "DOL.UnitTests&TestCategory!=Explicit"
@@ -69,7 +69,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build
-        run: dotnet build -c ${{ matrix.build_target }} "Tests\Tests.csproj" --verbosity detailed
+        run: dotnet build -c ${{ matrix.build_target }} "Tests\Tests.csproj" --verbosity normal
       - name: Test
         run: |
           dotnet test .\build\Tests\${{ matrix.build_target }}\lib\Tests.dll -v n --filter "DOL.UnitTests&TestCategory!=Explicit"


### PR DESCRIPTION
Allow to check more easily which Nuget dependencies were used for the releases build.