### PR TITLE
Cleanup .Net5 build output

### DIFF
--- a/GameServerScripts/GameServerScripts.csproj
+++ b/GameServerScripts/GameServerScripts.csproj
@@ -23,7 +23,7 @@
     <WarningLevel>4</WarningLevel>
     <NoWarn>1591</NoWarn>
     <TreatWarningsAsErrors>False</TreatWarningsAsErrors>
-    <OutputPath>..\$(Configuration)\lib\</OutputPath>
+    <OutputPath>..\build\GameServerScripts\$(Configuration)\lib\</OutputPath>
     <NoWin32Manifest>False</NoWin32Manifest>
     <CheckForOverflowUnderflow>False</CheckForOverflowUnderflow>
     <IntermediateOutputPath>..\build\GameServerScripts\$(Configuration)\obj\</IntermediateOutputPath>

--- a/Net5/DOLBase/DOLBase.csproj
+++ b/Net5/DOLBase/DOLBase.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>DOLBase</AssemblyName>
     <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
     <IntermediateOutputPath>..\build\DOLBase\$(Configuration)\obj\</IntermediateOutputPath>
-    <OutputPath>..\$(Configuration)\lib\</OutputPath>
+    <OutputPath>..\build\DOLBase\$(Configuration)\lib\</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   <PropertyGroup>

--- a/Net5/DOLConfig/DOLConfig.csproj
+++ b/Net5/DOLConfig/DOLConfig.csproj
@@ -21,6 +21,7 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <EmbeddedResourceUseDependentUponConvention>false</EmbeddedResourceUseDependentUponConvention>
     <SatelliteResourceLanguages>none</SatelliteResourceLanguages>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyTitle>Dawn of Light - DOLConfig</AssemblyTitle>

--- a/Net5/DOLConfig/DOLConfig.csproj
+++ b/Net5/DOLConfig/DOLConfig.csproj
@@ -20,6 +20,7 @@
     <IntermediateOutputPath>..\build\DOLConfig\$(Configuration)\obj</IntermediateOutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <EmbeddedResourceUseDependentUponConvention>false</EmbeddedResourceUseDependentUponConvention>
+    <SatelliteResourceLanguages>none</SatelliteResourceLanguages>
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyTitle>Dawn of Light - DOLConfig</AssemblyTitle>

--- a/Net5/DOLDatabase/DOLDatabase.csproj
+++ b/Net5/DOLDatabase/DOLDatabase.csproj
@@ -10,7 +10,7 @@
     <OutputType>Library</OutputType>
     <AssemblyName>DOLDatabase</AssemblyName>
     <RunPostBuildEvent>OnOutputUpdated</RunPostBuildEvent>
-    <OutputPath>..\$(Configuration)\lib\</OutputPath>
+    <OutputPath>..\build\DOLDatabase\$(Configuration)\lib\</OutputPath>
     <IntermediateOutputPath>..\build\DOLDatabase\$(Configuration)\obj\</IntermediateOutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>

--- a/Net5/DOLServer/DOLServer.csproj
+++ b/Net5/DOLServer/DOLServer.csproj
@@ -14,6 +14,7 @@
     <OutputPath>..\$(Configuration)\</OutputPath>
     <IntermediateOutputPath>..\build\DOLServer\$(Configuration)\obj\</IntermediateOutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <SatelliteResourceLanguages>none</SatelliteResourceLanguages>
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyTitle>Dawn of Light - DOLServer</AssemblyTitle>

--- a/Net5/DOLServer/DOLServer.csproj
+++ b/Net5/DOLServer/DOLServer.csproj
@@ -51,5 +51,8 @@
   <ItemGroup>
     <Compile Include="..\..\DOLServer\**\*.cs" />
   </ItemGroup>
+  <Target Name="CreateLibFolder" AfterTargets="Build">
+    <MakeDir Directories="$(OutDir)lib" />
+  </Target>
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/Net5/DOLServer/DOLServer.csproj
+++ b/Net5/DOLServer/DOLServer.csproj
@@ -15,6 +15,7 @@
     <IntermediateOutputPath>..\build\DOLServer\$(Configuration)\obj\</IntermediateOutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <SatelliteResourceLanguages>none</SatelliteResourceLanguages>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyTitle>Dawn of Light - DOLServer</AssemblyTitle>

--- a/Net5/GameServer/GameServer.csproj
+++ b/Net5/GameServer/GameServer.csproj
@@ -10,7 +10,7 @@
     <AssemblyName>GameServer</AssemblyName>
     <RunPostBuildEvent>OnOutputUpdated</RunPostBuildEvent>
     <IntermediateOutputPath>..\build\GameServer\$(Configuration)\obj\</IntermediateOutputPath>
-    <OutputPath>..\$(Configuration)\lib\</OutputPath>
+    <OutputPath>..\build\GameServer\$(Configuration)\lib\</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   <PropertyGroup>

--- a/Net5/GameServerScripts/GameServerScripts.csproj
+++ b/Net5/GameServerScripts/GameServerScripts.csproj
@@ -10,7 +10,7 @@
     <OutputType>Library</OutputType>
     <AssemblyName>GameServerScripts</AssemblyName>
     <RunPostBuildEvent>OnOutputUpdated</RunPostBuildEvent>
-    <OutputPath>..\$(Configuration)\lib\</OutputPath>
+    <OutputPath>..\build\GameServerScripts\$(Configuration)\lib\</OutputPath>
     <IntermediateOutputPath>..\build\GameServerScripts\$(Configuration)\obj\</IntermediateOutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>

--- a/Net5/Tests/Tests.csproj
+++ b/Net5/Tests/Tests.csproj
@@ -13,6 +13,7 @@
     <OutputPath>..\build\Tests\$(Configuration)\lib\</OutputPath>
     <IntermediateOutputPath>..\build\Tests\$(Configuration)\obj\</IntermediateOutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <SatelliteResourceLanguages>none</SatelliteResourceLanguages>
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyTitle>Dawn of Light - Tests</AssemblyTitle>


### PR DESCRIPTION
Remove unused redundant libraries
Remove satellite language resources (from Microsoft.CodeAnalysis)
Remove precompiled GameServerScripts (on .Net Framework as well)