### PR TITLE
Improve SpellHandler to perform repeated checks "during" cast for long running spells

### DIFF
--- a/GameServer/serverproperty/ServerProperties.cs
+++ b/GameServer/serverproperty/ServerProperties.cs
@@ -2287,9 +2287,12 @@ namespace DOL.GS.ServerProperties
 		[ServerProperty("spells", "spell_interrupt_again", "", 100)]
 		public static int SPELL_INTERRUPT_AGAIN;
 
-		[ServerProperty("spells", "spell_interrupt_maxstagelength", "Max length of stage 1 and 3, 1000 = 1 second", 1500)]
+		[ServerProperty( "spells", "spell_interrupt_maxstagelength", "Max length of stages 1 and 3, 1000 = 1 second", 1500 )]
 		public static int SPELL_INTERRUPT_MAXSTAGELENGTH;
-		
+
+		[ServerProperty( "spells", "spell_interrupt_max_intermediate_stagelength", "Max length of stage 2, 1000 = 1 second. 999999 to disable", 3000 )]
+		public static int SPELL_INTERRUPT_MAX_INTERMEDIATE_STAGELENGTH;
+
 		[ServerProperty("spells", "spell_charm_named_check", "Prevents charm spell to work on Named Mobs, 0 = disable, 1 = enable", 1)]
 		public static int SPELL_CHARM_NAMED_CHECK;
 


### PR DESCRIPTION
At the moment the spell handler only performs 3 checks. This is okay for most casts which are shorter than 5 seconds total.
For other spells which are longer, this will be a problem since a lot of things can happen in the meantime of each check.

Let’s take the example of a cast which lasts 15 seconds: `time = 15000`.
`step1 = time / 3` i.e. step 1 = 5000 but with the current values for the server properties step1 is limited to 1500 so step1 = 1500.
Same thing for step3 = 1500.
It follows `step2 = time - step1 - step3` so step2 = 12000.

What this means is the following: CheckAfterCast is executed after 1500ms
CheckDuringCast is executed 12000ms later
CheckEndCast executed 1500ms after.

A lot of things can happen between AfterCast and DuringCast in a 12000ms interval. It would be nice to be able to check more often (i.e. enemy goes out of view, etc…)

Hence the proposal to limit the duration of step2 and to repeat CheckDuringCast several times while the cast is running. This code only impacts long running casts.

“Several times” depend on the value of the new server properties added in this PR. This code will try to subdivide the 12000 ms into the closest integer duration which matches the server properties.