### PR TITLE
Load Mobs In disabled Zones server property

### DIFF
--- a/GameServer/serverproperty/ServerProperties.cs
+++ b/GameServer/serverproperty/ServerProperties.cs
@@ -606,6 +606,12 @@ namespace DOL.GS.ServerProperties
 		public static int SET_DIFFICULTY_ON_EPIC_ENCOUNTERS;
 
 		/// <summary>
+		/// Load mobs in disabled zones
+		/// </summary>
+		[ServerProperty("world", "load_mobs_in_disabled_zones", "Should Mobs be loaded in disabled zones?", false)]
+		public static bool  DISABLED_MOBS_IN_DISABLED_REGIONS;
+
+		/// <summary>
 		/// A serialised list of disabled RegionIDs
 		/// </summary>
 		[ServerProperty("world", "disabled_regions", "Serialized list of disabled region IDs, separated by semi-colon or a range with a dash (ie 1-5;7;9)", "")]

--- a/GameServer/world/WorldMgr.cs
+++ b/GameServer/world/WorldMgr.cs
@@ -349,8 +349,17 @@ namespace DOL.GS
 					mobList.AddRange(DOLDB<Mob>.SelectObjects(DB.Column(nameof(Mob.Region)).IsEqualTo(loadRegion)));
 				}
 			}
+			 
+			if (ServerProperties.Properties.DISABLED_MOBS_IN_DISABLED_REGIONS == false)
+			{
+				foreach (string loadRegion in Util.SplitCSV(ServerProperties.Properties.DISABLED_REGIONS, true))
+				{
+					mobList.AddRange(DOLDB<Mob>.SelectObjects(DB.Column(nameof(Mob.Region)).IsEqualTo(loadRegion)));
+				}
+			}
 			else
 			{
+
 				mobList.AddRange(GameServer.Database.SelectAllObjects<Mob>());
 			}
 


### PR DESCRIPTION
If we are disabling zones it would seem we should disable the loading of mobs in these zones also to free up some resources. So added a server property to allow feature.