### PR TITLE
fix packet: writing pascal string off by one + max length

### DIFF
--- a/DOLBase/Network/PacketOut.cs
+++ b/DOLBase/Network/PacketOut.cs
@@ -202,7 +202,7 @@ namespace DOL.Network
 			Write(bytes, 0, bytes.Length);
 		}
 
-		public void WritePascalStringIntLE(string str)
+		public void WritePascalStringIntLE(string str, int maxlen = 2048)
 		{
 			if (str == null || str.Length <= 0)
 			{
@@ -211,8 +211,9 @@ namespace DOL.Network
 			}
 
 			byte[] bytes = Constants.DefaultEncoding.GetBytes(str);
-			WriteIntLowEndian((uint)bytes.Length + 1);
-			Write(bytes, 0, bytes.Length);
+			var len = Math.Min(maxlen - 1, bytes.Length);
+			WriteIntLowEndian((uint)len + 1);
+			Write(bytes, 0, len);
 			WriteByte(0);
 		}
 

--- a/GameServer/packets/Server/PacketLib1125.cs
+++ b/GameServer/packets/Server/PacketLib1125.cs
@@ -184,7 +184,7 @@ namespace DOL.GS.PacketHandler
 							}
 
 							pak.WriteByte((byte)c.Level); // moved
-							pak.WritePascalStringIntLE(c.Name);
+							pak.WritePascalStringIntLE(c.Name, 0x18);
 							pak.WriteByte(0x18); // no idea
 							pak.WriteInt(1); // no idea
 							pak.WriteByte((byte)c.EyeSize);
@@ -209,18 +209,18 @@ namespace DOL.GS.PacketHandler
 							{
 								locationDescription = (locationDescription.Substring(0, 20)) + "...";
 							}
-							pak.WritePascalStringIntLE(locationDescription);
+							pak.WritePascalStringIntLE(locationDescription, 0x18);
 
 							string classname = "";
 							if (c.Class != 0)
 							{
 								classname = ((eCharacterClass)c.Class).ToString();
 							}
-							pak.WritePascalStringIntLE(classname);
+							pak.WritePascalStringIntLE(classname, 0x18);
 
 							string racename = m_gameClient.RaceToTranslatedName(c.Race, c.Gender);
 
-							pak.WritePascalStringIntLE(racename);
+							pak.WritePascalStringIntLE(racename, 0x18);
 							pak.WriteShortLowEndian((ushort)c.CurrentModel); // moved
 																			 // something here
 							pak.WriteByte((byte)c.Region);
@@ -711,7 +711,7 @@ namespace DOL.GS.PacketHandler
 								pak.WriteShortLowEndian((ushort)value2);
 								pak.WriteIntLowEndian((uint)item.Price);
 								pak.WriteShortLowEndian((ushort)item.Model);
-								pak.WritePascalStringIntLE(item.Name);
+								pak.WritePascalStringIntLE(item.Name, 0x30);
 							}
 							else
 							{

--- a/GameServer/packets/Server/PacketLib1126.cs
+++ b/GameServer/packets/Server/PacketLib1126.cs
@@ -228,7 +228,7 @@ namespace DOL.GS.PacketHandler
 						armsColor = (ushort)(arms.Emblem != 0 ? arms.Emblem : arms.Color);
 
 					pak.WriteByte((byte)c.Level);
-					pak.WritePascalStringIntLE(c.Name);
+					pak.WritePascalStringIntLE(c.Name, 0x18);
 					pak.WriteIntLowEndian(0x18);
 					pak.WriteByte(1); // always 1 ?
 					pak.WriteByte(c.EyeSize); // seems to be : 0xF0 = eyes, 0x0F = nose
@@ -242,9 +242,9 @@ namespace DOL.GS.PacketHandler
 					pak.WriteByte(c.CustomisationStep); //1 = auto generate config, 2= config ended by player, 3= enable config to player
 					pak.WriteByte(c.MoodType);
 					pak.Fill(0x0, 13);
-					pak.WritePascalStringIntLE(locationDescription);
-					pak.WritePascalStringIntLE(classname);
-					pak.WritePascalStringIntLE(racename);
+					pak.WritePascalStringIntLE(locationDescription, 0x18);
+					pak.WritePascalStringIntLE(classname, 0x18);
+					pak.WritePascalStringIntLE(racename, 0x18);
 					pak.WriteShortLowEndian((ushort)c.CurrentModel);
 
 					pak.WriteByte((byte)c.Region);
@@ -326,7 +326,7 @@ namespace DOL.GS.PacketHandler
 				var ip = region.ServerIP;
 				if (ip == "any" || ip == "0.0.0.0" || ip == "127.0.0.1" || ip.StartsWith("10.") || ip.StartsWith("192.168."))
 					ip = ((IPEndPoint)m_gameClient.Socket.LocalEndPoint).Address.ToString();
-				pak.WritePascalStringIntLE(ip);
+				pak.WritePascalStringIntLE(ip, 0x14);
 				pak.WriteIntLowEndian(region.ServerPort);
 				pak.WriteIntLowEndian(region.ServerPort);
 				SendTCP(pak);


### PR DESCRIPTION
A fix with big changes, it fixes the character overview for 1.125+.
The WriteByte(0) seems odd but it was what I got from official server (with 1.127e).

After a small time with disassembled game.dll, I retrieved some string limits.