### PR TITLE
Do not delve the 'weapon' stats of an instrument

### DIFF
--- a/GameServer/gameobjects/GameInventoryItem.cs
+++ b/GameServer/gameobjects/GameInventoryItem.cs
@@ -409,12 +409,17 @@ namespace DOL.GS
 				delve.Add(" ");
 			}
 
-			if ((Object_Type >= (int)eObjectType.GenericWeapon) && (Object_Type <= (int)eObjectType._LastWeapon) ||
-			    Object_Type == (int)eObjectType.Instrument)
+			if ((Object_Type >= (int)eObjectType.GenericWeapon) && (Object_Type <= (int)eObjectType._LastWeapon))
 			{
 				WriteUsableClasses(delve, player.Client);
 				WriteMagicalBonuses(delve, player.Client, false);
 				DelveWeaponStats(delve, player);
+			}
+
+			if( Object_Type == (int)eObjectType.Instrument )
+			{
+				WriteUsableClasses(delve, player.Client);
+				WriteMagicalBonuses(delve, player.Client, false);
 			}
 
 			if (Object_Type >= (int)eObjectType.Cloth && Object_Type <= (int)eObjectType.Scale)


### PR DESCRIPTION
An instrument does not have DPS or SPD, Effective Damage, etc...

For instruments, DPS_AF is used to indicate what kind of instrument the object is (drum, lute, flute, harp).
Currently, delving instruments show "0.1 Base DPS / 0.1 Clamped DPS / 0.1 Effective DPS" etc...

With this change I remove `DelveWeaponStats` which is not necessary for instruments.