### PR TITLE
Adjustment on keep lord auto-heal for low level BG

### DIFF
--- a/GameServer/ai/brain/Guards/Lord.cs
+++ b/GameServer/ai/brain/Guards/Lord.cs
@@ -15,26 +15,23 @@ namespace DOL.AI.Brain
 
 		public override void Think()
 		{
-			if (GS.ServerProperties.Properties.KEEP_LORD_HEAL_ITSELF == true)
-            {
-				if (Body != null && Body.Spells.Count == 0)
+			// Add auto heal for lord above level 15
+			if (Body != null && Body.Spells.Count == 0 && Body.Level>=15)
+			{
+				switch (Body.Realm)
 				{
-					switch (Body.Realm)
-					{
-						case eRealm.None:
-						case eRealm.Albion:
-							Body.Spells.Add(GuardSpellDB.AlbLordHealSpell);
-							break;
-						case eRealm.Midgard:
-							Body.Spells.Add(GuardSpellDB.MidLordHealSpell);
-							break;
-						case eRealm.Hibernia:
-							Body.Spells.Add(GuardSpellDB.HibLordHealSpell);
-							break;
-					}
+					case eRealm.None:
+					case eRealm.Albion:
+						Body.Spells.Add(GuardSpellDB.AlbLordHealSpell);
+						break;
+					case eRealm.Midgard:
+						Body.Spells.Add(GuardSpellDB.MidLordHealSpell);
+						break;
+					case eRealm.Hibernia:
+						Body.Spells.Add(GuardSpellDB.HibLordHealSpell);
+						break;
 				}
 			}
-
 			base.Think();
 		}
 		

--- a/GameServer/ai/brain/Guards/Lord.cs
+++ b/GameServer/ai/brain/Guards/Lord.cs
@@ -15,22 +15,26 @@ namespace DOL.AI.Brain
 
 		public override void Think()
 		{
-			if (Body != null && Body.Spells.Count == 0)
-			{
-				switch (Body.Realm)
+			if (GS.ServerProperties.Properties.KEEP_LORD_HEAL_ITSELF == true)
+            {
+				if (Body != null && Body.Spells.Count == 0)
 				{
-					case eRealm.None:
-					case eRealm.Albion:
-						Body.Spells.Add(GuardSpellDB.AlbLordHealSpell);
-						break;
-					case eRealm.Midgard:
-						Body.Spells.Add(GuardSpellDB.MidLordHealSpell);
-						break;
-					case eRealm.Hibernia:
-						Body.Spells.Add(GuardSpellDB.HibLordHealSpell);
-						break;
+					switch (Body.Realm)
+					{
+						case eRealm.None:
+						case eRealm.Albion:
+							Body.Spells.Add(GuardSpellDB.AlbLordHealSpell);
+							break;
+						case eRealm.Midgard:
+							Body.Spells.Add(GuardSpellDB.MidLordHealSpell);
+							break;
+						case eRealm.Hibernia:
+							Body.Spells.Add(GuardSpellDB.HibLordHealSpell);
+							break;
+					}
 				}
 			}
+
 			base.Think();
 		}
 		

--- a/GameServer/keeps/Gameobjects/Guards/GameKeepGuard.cs
+++ b/GameServer/keeps/Gameobjects/Guards/GameKeepGuard.cs
@@ -1269,7 +1269,7 @@ namespace DOL.GS.Keeps
 				DBSpell spell = BaseHealSpell;
 				spell.CastTime = 2;
 				spell.Target = "Self";
-				spell.Value = 225;
+				spell.Value = -2.5; // 2.5% of caster health instead of constant value
 				if (GameServer.Instance.Configuration.ServerType != eGameServerType.GST_PvE)
 					spell.Uninterruptible = true;
 				return spell;

--- a/GameServer/serverproperty/ServerProperties.cs
+++ b/GameServer/serverproperty/ServerProperties.cs
@@ -1479,6 +1479,13 @@ namespace DOL.GS.ServerProperties
 		#endregion
 
 		#region KEEPS
+
+		/// <summary>
+		/// Possibility for the Keep Lord to heal itself
+		/// </summary>
+		[ServerProperty("keeps", "keep_lord_heal_itself", "Possibility for the Keep Lord to heal itself", true)]
+		public static bool KEEP_LORD_HEAL_ITSELF;
+
 		/// <summary>
 		/// Number of seconds between allowed LOS checks for keep guards
 		/// </summary>

--- a/GameServer/serverproperty/ServerProperties.cs
+++ b/GameServer/serverproperty/ServerProperties.cs
@@ -1479,13 +1479,6 @@ namespace DOL.GS.ServerProperties
 		#endregion
 
 		#region KEEPS
-
-		/// <summary>
-		/// Possibility for the Keep Lord to heal itself
-		/// </summary>
-		[ServerProperty("keeps", "keep_lord_heal_itself", "Possibility for the Keep Lord to heal itself", true)]
-		public static bool KEEP_LORD_HEAL_ITSELF;
-
 		/// <summary>
 		/// Number of seconds between allowed LOS checks for keep guards
 		/// </summary>


### PR DESCRIPTION
Possibility to remove the Keep Lord to heal itself 
0=no self heal
1=self heal (which is the default)
On low level keeps (battlegrounds), the keep lord seems impossible to kill with a little group if he has a non-interruptible self heal
