### PR TITLE
Accept currency item if ID is the same

### DIFF
--- a/GameServer/Finance/Wallet.cs
+++ b/GameServer/Finance/Wallet.cs
@@ -23,7 +23,7 @@ namespace DOL.GS.Finance
                 lock (owner.Inventory)
                 {
                     return currency.Mint(owner.Inventory.GetItemRange(eInventorySlot.FirstBackpack, eInventorySlot.LastBackpack)
-                        .Where(i => i.Template.ClassType.ToLower() == $"Currency.{currency.Name}".ToLower())
+                        .Where(i => currency.IsSameCurrencyItem(i.Template))
                         .Aggregate(0, (acc, i) => acc + i.Count));
                 }
             }
@@ -60,7 +60,7 @@ namespace DOL.GS.Finance
                     if (GetBalance(currency).Amount < money.Amount) return false;
 
                     var validCurrencyItemsInventory = owner.Inventory.GetItemRange(eInventorySlot.FirstBackpack, eInventorySlot.LastBackpack)
-                        .Where(i => i.Template.ClassType.ToLower() == $"Currency.{currency.Name}".ToLower());
+                        .Where(i => currency.IsSameCurrencyItem(i.Template));
                     var remainingDue = (int)money.Amount;
                     foreach (var currencyItem in validCurrencyItemsInventory)
                     {

--- a/GameServer/gameobjects/GameMerchant.cs
+++ b/GameServer/gameobjects/GameMerchant.cs
@@ -500,48 +500,48 @@ namespace DOL.GS
 	public class GameBloodSealsMerchant : GameItemCurrencyMerchant
 	{
         protected override Currency Currency 
-            => Currency.Item("BloodSeal");
+            => Currency.Item("BloodSeal", "Blood Seals");
 	}
 
     [Obsolete("This is going to be removed. See GameItemCurrencyMerchant's obsolete message for more details.")]
 	public class GameDiamondSealsMerchant : GameItemCurrencyMerchant
 	{
 		protected override Currency Currency 
-            => Currency.Item("DiamondSeal");
+            => Currency.Item("DiamondSeal", "Diamond Seals");
 	}
 
     [Obsolete("This is going to be removed. See GameItemCurrencyMerchant's obsolete message for more details.")]
 	public class GameSapphireSealsMerchant : GameItemCurrencyMerchant
 	{
 		protected override Currency Currency 
-            => Currency.Item("SapphireSeal");
+            => Currency.Item("SapphireSeal", "Sapphire Seals");
 	}
 
 	[Obsolete("This is going to be removed. See GameItemCurrencyMerchant's obsolete message for more details.")]
     public class GameEmeraldSealsMerchant : GameItemCurrencyMerchant
 	{
 		protected override Currency Currency 
-            => Currency.Item("EmeraldSeal");
+            => Currency.Item("EmeraldSeal", "Emerald Seals");
 	}
 
     [Obsolete("This is going to be removed. See GameItemCurrencyMerchant's obsolete message for more details.")]
 	public class GameAuruliteMerchant : GameItemCurrencyMerchant
 	{
 		protected override Currency Currency 
-            => Currency.Item("aurulite");
+            => Currency.Item("aurulite", "units of aurulite");
 	}
 	
     [Obsolete("This is going to be removed. See GameItemCurrencyMerchant's obsolete message for more details.")]
 	public class GameAtlanteanGlassMerchant : GameItemCurrencyMerchant
 	{
 		protected override Currency Currency 
-            => Currency.Item("atlanteanglass");
+            => Currency.Item("atlanteanglass", "Atlantean Glass");
 	}
 	
     [Obsolete("This is going to be removed. See GameItemCurrencyMerchant's obsolete message for more details.")]
 	public class GameDragonMerchant : GameItemCurrencyMerchant
 	{
 		protected override Currency Currency 
-            => Currency.Item("dragonscales");
+            => Currency.Item("dragonscales", "Dragon Scales");
 	}
 }

--- a/GameServer/gameutils/MerchantCatalog.cs
+++ b/GameServer/gameutils/MerchantCatalog.cs
@@ -29,7 +29,7 @@ namespace DOL.GS.Profession
         public byte SlotPosition { get; } = 0;
         public byte Page { get; } = 0;
         public ItemTemplate Item { get; }
-        public long CurrencyAmount {get; } = 0;
+        public long CurrencyAmount { get; } = 0;
 
         public MerchantCatalogEntry(byte slotPosition, byte page, ItemTemplate itemTemplate, long currencyAmount)
         {
@@ -140,10 +140,7 @@ namespace DOL.GS.Profession
                 var page = catalog.GetPage(dbMerchantItem.PageNumber);
                 if (dbMerchantItem.SlotPosition == currencySlotPosition)
                 {
-                    var currencyId = (byte)dbMerchantItem.Price;
-                    var itemTemplateId = dbMerchantItem.ItemTemplateID;
-                    var pageCurrency = CreateCurrencyFromId(currencyId, itemTemplateId);
-                    page.SetCurrency(pageCurrency);
+                    page.SetCurrency(GetCurrencyFrom(dbMerchantItem));
                 }
                 var itemTemplate = GameServer.Database.FindObjectByKey<ItemTemplate>(dbMerchantItem.ItemTemplateID);
                 if (itemTemplate == null) continue;
@@ -154,12 +151,17 @@ namespace DOL.GS.Profession
             return catalog;
         }
 
-        private static Currency CreateCurrencyFromId(byte currencyId, string itemCurrencyId = null)
+        private static Currency GetCurrencyFrom(MerchantItem merchantItem)
         {
+            var currencyId = (byte)merchantItem.Price;
+            var itemCurrencyId = merchantItem.ItemTemplateID;
             switch (currencyId)
             {
                 case 1: return Currency.Copper;
-                case 2: return Currency.Item(itemCurrencyId);
+                case 2: 
+                    var itemTemplate = GameServer.Database.FindObjectByKey<ItemTemplate>(itemCurrencyId);
+                    if (itemTemplate == null) return Currency.Item(itemCurrencyId, $"units of {itemCurrencyId}");
+                    else return Currency.Item(itemCurrencyId, itemTemplate.Name);
                 case 3: return Currency.BountyPoints;
                 case 4: return Currency.Mithril;
                 default: throw new System.NotImplementedException($"Currency with id {currencyId} is not implemented.");

--- a/GameServer/packets/Server/PacketLib168.cs
+++ b/GameServer/packets/Server/PacketLib168.cs
@@ -1850,7 +1850,7 @@ namespace DOL.GS.PacketHandler
 		{
             foreach (var page in catalog.GetAllPages())
             {
-                if (page.Currency.Equals(Currency.Copper) == false) windowType = ConvertCurrencyToMerchantWindowType(page.Currency);
+                windowType = ConvertCurrencyToMerchantWindowType(page.Currency);
                 using (GSTCPPacketOut pak = new GSTCPPacketOut(GetPacketCode(eServerPackets.MerchantWindow)))
                 {
                     pak.WriteByte((byte)page.EntryCount); //Item count on this page


### PR DESCRIPTION
Merchants accept also ItemTemplates that have no ClassType but same Id_nb as ItemCurrency.id
Separate ToText() and ID
Determine ToText() by ItemTemplate.Name of Item.Id_nb == ItemCurrency.id 
Fix wrong display of Copper MerchantCatalogPages that follow other ones