### PR TITLE
Auto Level CLs

### DIFF
--- a/GameServer/gameobjects/GamePlayer.cs
+++ b/GameServer/gameobjects/GamePlayer.cs
@@ -15281,7 +15281,10 @@ namespace DOL.GS
 
 			ChampionExperience += experience;
 			Out.SendUpdatePoints();
-		}
+
+            if (ServerProperties.Properties.AUTO_CHAMPION_LEVELUP && ChampionExperience >= ChampionExperienceForNextLevel)
+                ChampionLevelUp();
+        }
 
 
 		/// <summary>

--- a/GameServer/gameobjects/GamePlayer.cs
+++ b/GameServer/gameobjects/GamePlayer.cs
@@ -5138,6 +5138,15 @@ namespace DOL.GS
 
 			if (Level == MaxLevel)
 			{
+				if (ServerProperties.Properties.AUTO_CHAMPION_LEVELUP && !Champion)
+				{
+                    RemoveChampionLevels();
+                    Champion = true;
+                    Out.SendUpdatePlayer();
+                    SaveIntoDatabase();
+                    Out.SendMessage(LanguageMgr.GetTranslation(Client.Account.Language, "KingNPC.WhisperReceive.IsNowChampion"), eChatType.CT_System, eChatLoc.CL_SystemWindow);
+                }
+
 				if (CanGenerateNews)
 				{
 					string message = LanguageMgr.GetTranslation(Client.Account.Language, "GamePlayer.OnLevelUp.Reached", Name, Level, LastPositionUpdateZone.Description);

--- a/GameServer/serverproperty/ServerProperties.cs
+++ b/GameServer/serverproperty/ServerProperties.cs
@@ -395,14 +395,20 @@ namespace DOL.GS.ServerProperties
 		/// </summary>
 		[ServerProperty("log", "log_inventory_other", "Enable other logging in inventory log (log_inventory must be enabled)", true)]
 		public static bool LOG_INVENTORY_OTHER;
-		#endregion
+        #endregion
 
-		#region SERVER
+        #region SERVER
 
-		/// <summary>
-		/// Enable/Disable Autokick Timer
-		/// </summary>
-		[ServerProperty("server", "player idle kick", "Enable auto kick for inactive players", false)]
+        /// <summary>
+        /// Gain Champion Levels when  you gain CLXP, without having to visit the king
+        /// </summary>
+        [ServerProperty("server", "auto champion levelup", "Gain champion levels automatically, without having to visit the king", false)]
+        public static bool AUTO_CHAMPION_LEVELUP;
+
+        /// <summary>
+        /// Enable/Disable Autokick Timer
+        /// </summary>
+        [ServerProperty("server", "player idle kick", "Enable auto kick for inactive players", false)]
 		public static bool KICK_IDLE_PLAYER_STATUS;
 
 		/// <summary>


### PR DESCRIPTION
Are you tired of schlepping your mailed heinie back to Jordheim, just to get a patronizing pat on the head from the king?  Is that throne room access guard in TnN undressing you with his eyes every single time you walk by?  Is running around Camelot, ON FOOT, simply beneath your station?

Set the AUTO_CHAMPION_LEVELUP server property to true, and leave all that behind today!

Disabled by default, because it's not livelike.