### PR TITLE
Added CharacterClassOverride Table

### DIFF
--- a/DOLDatabase/Tables/CharacterClass.cs
+++ b/DOLDatabase/Tables/CharacterClass.cs
@@ -17,9 +17,8 @@
  *
  */
 using DOL.Database.Attributes;
-using DOL.Database;
 
-namespace DOLDatabase
+namespace DOL.Database
 {
 	[DataTable(TableName = "CharacterClass")]
 	public class DBCharacterClass : DataObject

--- a/DOLDatabase/Tables/CharacterClass.cs
+++ b/DOLDatabase/Tables/CharacterClass.cs
@@ -21,22 +21,15 @@ using DOL.Database;
 
 namespace DOLDatabase
 {
-	/// <summary>
-	/// Values which override hardcoded class default properties
-	/// </summary>
-	[DataTable(TableName = "CharacterClassOverride")]
-	public class CharacterClassOverride : DataObject
+	[DataTable(TableName = "CharacterClass")]
+	public class CharacterClass : DataObject
 	{
-		// TEGS Rename CharacterClassOverride?
-
 		private int m_classID;
 		private int m_specializationMultiplier;
 		private int m_baseHP;
 		private int m_baseWeaponSkill;
-		private int m_baseWeaponSkillRanged;
 		private string m_autoTrainableSkills;
 		private string m_eligibleRaces;
-		private int m_maxPulsingSpells;
 
 		[PrimaryKey]
 		public int ClassID
@@ -92,24 +85,10 @@ namespace DOLDatabase
 		}
 
 		/// <summary>
-		/// Base ranged weapon skill
-		/// </summary>
-		[DataElement]
-		public int BaseWeaponSkillRanged
-		{
-			get { return m_baseWeaponSkillRanged; }
-			set
-			{
-				Dirty = true;
-				m_baseWeaponSkillRanged = value;
-			}
-		}
-
-		/// <summary>
 		/// Skills which are auto trained
 		/// </summary>
 		[DataElement]
-		public string AutoTrainableSkills
+		public string AutoTrainSkills
 		{
 			get { return m_autoTrainableSkills; }
 			set
@@ -130,20 +109,6 @@ namespace DOLDatabase
 			{
 				Dirty = true;
 				m_eligibleRaces = value;
-			}
-		}
-
-		/// <summary>
-		/// How many pulsing spells a class can have running at once
-		/// </summary>
-		[DataElement]
-		public int MaxPulsingSpells
-		{
-			get { return m_maxPulsingSpells; }
-			set
-			{
-				Dirty = true;
-				m_maxPulsingSpells = value;
 			}
 		}
 	}

--- a/DOLDatabase/Tables/CharacterClass.cs
+++ b/DOLDatabase/Tables/CharacterClass.cs
@@ -22,7 +22,7 @@ using DOL.Database;
 namespace DOLDatabase
 {
 	[DataTable(TableName = "CharacterClass")]
-	public class CharacterClass : DataObject
+	public class DBCharacterClass : DataObject
 	{
 		private int m_classID;
 		private int m_specializationMultiplier;

--- a/DOLDatabase/Tables/CharacterClassOverride.cs
+++ b/DOLDatabase/Tables/CharacterClassOverride.cs
@@ -1,0 +1,150 @@
+﻿/*
+ * DAWN OF LIGHT - The first free open source DAoC server emulator
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ */
+using DOL.Database.Attributes;
+using DOL.Database;
+
+namespace DOLDatabase
+{
+	/// <summary>
+	/// Values which override hardcoded class default properties
+	/// </summary>
+	[DataTable(TableName = "CharacterClassOverride")]
+	public class CharacterClassOverride : DataObject
+	{
+		// TEGS Rename CharacterClassOverride?
+
+		private int m_classID;
+		private int m_specializationMultiplier;
+		private int m_baseHP;
+		private int m_baseWeaponSkill;
+		private int m_baseWeaponSkillRanged;
+		private string m_autoTrainableSkills;
+		private string m_eligibleRaces;
+		private int m_maxPulsingSpells;
+
+		[PrimaryKey]
+		public int ClassID
+		{
+			get => m_classID; 
+			set
+			{
+				Dirty = true;
+				m_classID = value;
+			}
+		}
+
+		/// <summary>
+		/// Spec points gained per level
+		/// </summary>
+		[DataElement]
+		public int SpecializationMultiplier
+		{
+			get { return m_specializationMultiplier; }
+			set
+			{
+				Dirty = true;
+				m_specializationMultiplier = value;
+			}
+		}
+
+		/// <summary>
+		/// Base hits
+		/// </summary>
+		[DataElement]
+		public int BaseHP
+		{
+			get { return m_baseHP; }
+			set
+			{
+				Dirty = true;
+				m_baseHP = value;
+			}
+		}
+
+		/// <summary>
+		/// Base melee weapon skill
+		/// </summary>
+		[DataElement]
+		public int BaseWeaponSkill
+		{
+			get { return m_baseWeaponSkill; }
+			set
+			{
+				Dirty = true;
+				m_baseWeaponSkill = value;
+			}
+		}
+
+		/// <summary>
+		/// Base ranged weapon skill
+		/// </summary>
+		[DataElement]
+		public int BaseWeaponSkillRanged
+		{
+			get { return m_baseWeaponSkillRanged; }
+			set
+			{
+				Dirty = true;
+				m_baseWeaponSkillRanged = value;
+			}
+		}
+
+		/// <summary>
+		/// Skills which are auto trained
+		/// </summary>
+		[DataElement]
+		public string AutoTrainableSkills
+		{
+			get { return m_autoTrainableSkills; }
+			set
+			{
+				Dirty = true;
+				m_autoTrainableSkills = value;
+			}
+		}
+
+		/// <summary>
+		/// Which races are eligible for this class
+		/// </summary>
+		[DataElement]
+		public string EligibleRaces
+		{
+			get { return m_eligibleRaces; }
+			set
+			{
+				Dirty = true;
+				m_eligibleRaces = value;
+			}
+		}
+
+		/// <summary>
+		/// How many pulsing spells a class can have running at once
+		/// </summary>
+		[DataElement]
+		public int MaxPulsingSpells
+		{
+			get { return m_maxPulsingSpells; }
+			set
+			{
+				Dirty = true;
+				m_maxPulsingSpells = value;
+			}
+		}
+	}
+}

--- a/DOLDatabase/Tables/DBCharacterClass.cs
+++ b/DOLDatabase/Tables/DBCharacterClass.cs
@@ -23,91 +23,76 @@ namespace DOL.Database
 	[DataTable(TableName = "CharacterClass")]
 	public class DBCharacterClass : DataObject
 	{
-		private int m_classID;
-		private int m_specializationMultiplier;
-		private int m_baseHP;
-		private int m_baseWeaponSkill;
-		private string m_autoTrainableSkills;
-		private string m_eligibleRaces;
+		private int id;
+		private int specPointMultiplier;
+		private int baseHP;
+		private int baseWeaponSkill;
+		private string autoTrainableSkills;
+		private string eligibleRaces;
 
 		[PrimaryKey]
-		public int ClassID
+		public int ID
 		{
-			get => m_classID; 
+			get => id; 
 			set
 			{
 				Dirty = true;
-				m_classID = value;
+				id = value;
 			}
 		}
 
-		/// <summary>
-		/// Spec points gained per level
-		/// </summary>
 		[DataElement]
-		public int SpecializationMultiplier
+		public int SpecPointMultiplier
 		{
-			get { return m_specializationMultiplier; }
+			get { return specPointMultiplier; }
 			set
 			{
 				Dirty = true;
-				m_specializationMultiplier = value;
+				specPointMultiplier = value;
 			}
 		}
 
-		/// <summary>
-		/// Base hits
-		/// </summary>
 		[DataElement]
 		public int BaseHP
 		{
-			get { return m_baseHP; }
+			get { return baseHP; }
 			set
 			{
 				Dirty = true;
-				m_baseHP = value;
+				baseHP = value;
 			}
 		}
 
-		/// <summary>
-		/// Base melee weapon skill
-		/// </summary>
 		[DataElement]
 		public int BaseWeaponSkill
 		{
-			get { return m_baseWeaponSkill; }
+			get { return baseWeaponSkill; }
 			set
 			{
 				Dirty = true;
-				m_baseWeaponSkill = value;
+				baseWeaponSkill = value;
 			}
 		}
 
-		/// <summary>
-		/// Skills which are auto trained
-		/// </summary>
 		[DataElement]
 		public string AutoTrainSkills
 		{
-			get { return m_autoTrainableSkills; }
+			get { return autoTrainableSkills; }
 			set
 			{
 				Dirty = true;
-				m_autoTrainableSkills = value;
+				autoTrainableSkills = value;
 			}
 		}
 
-		/// <summary>
-		/// Which races are eligible for this class
-		/// </summary>
 		[DataElement]
 		public string EligibleRaces
 		{
-			get { return m_eligibleRaces; }
+			get { return eligibleRaces; }
 			set
 			{
 				Dirty = true;
-				m_eligibleRaces = value;
+				eligibleRaces = value;
 			}
 		}
 	}

--- a/GameServer/gameobjects/CharacterClasses/CharacterClassBase.cs
+++ b/GameServer/gameobjects/CharacterClasses/CharacterClassBase.cs
@@ -185,8 +185,7 @@ namespace DOL.GS
 			if (GameServer.Instance == null) return;
 			if (GameServer.Database is not ObjectDatabase) return;
 
-            GameServer.Database.RegisterDataObject(typeof(DOLDatabase.CharacterClass));
-			var dbClassOverrideTable = GameServer.Database.SelectAllObjects<DOLDatabase.CharacterClass>();
+			var dbClassOverrideTable = DOLDB<DBCharacterClass>.SelectAllObjects();
 
             foreach (var dbClassOverride in dbClassOverrideTable)
             {

--- a/GameServer/gameobjects/CharacterClasses/CharacterClassBase.cs
+++ b/GameServer/gameobjects/CharacterClasses/CharacterClassBase.cs
@@ -24,13 +24,18 @@ using DOL.Events;
 using DOL.GS.PacketHandler;
 using DOL.Language;
 using DOL.GS.Realm;
+using DOLDatabase;
+using log4net;
+using ICSharpCode.SharpZipLib.Tar;
 
 namespace DOL.GS
 {
+	
+
 	/// <summary>
 	/// The Base class for all Character Classes in DOL
 	/// </summary>
-	public abstract class CharacterClassBase : ICharacterClass
+	public class CharacterClassBase : ICharacterClass
 	{
 		private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
 
@@ -62,53 +67,76 @@ namespace DOL.GS
 		/// <summary>
 		/// multiplier for specialization points per level in 10th
 		/// </summary>
-		protected int m_specializationMultiplier = 10;
+		protected int m_specializationMultiplier;
 
 		/// <summary>
 		/// BaseHP for hp calculation
 		/// </summary>
-		protected int m_baseHP = 600;
+		protected int m_baseHP;
 
 		/// <summary>
 		/// Stat gained every level.
 		///	see eStat consts
 		/// </summary>
-		protected eStat m_primaryStat = eStat.UNDEFINED;
+		protected eStat m_primaryStat;
 
 		/// <summary>
 		/// Stat gained every second level.
 		/// see eStat consts
 		/// </summary>
-		protected eStat m_secondaryStat = eStat.UNDEFINED;
+		protected eStat m_secondaryStat;
 
 		/// <summary>
 		/// Stat gained every third level.
 		/// see eStat consts
 		/// </summary>
-		protected eStat m_tertiaryStat = eStat.UNDEFINED;
+		protected eStat m_tertiaryStat;
 
 		/// <summary>
 		/// Stat that affects the power/mana pool.
 		/// Do not set if they do not have a power pool/spells
 		/// </summary>
-		protected eStat m_manaStat = eStat.UNDEFINED;
+		protected eStat m_manaStat;
 
 		/// <summary>
 		/// Weapon Skill Base value to influence weapon skill calc
 		/// </summary>
-		protected int m_wsbase = 400;
+		protected int m_baseWeaponSkill;
 
 		/// <summary>
 		/// Weapon Skill Base value to influence ranged weapon skill calc
 		/// </summary>
-		protected int m_wsbaseRanged = 440;
+		protected int m_baseWeaponSkillRanged;
+
+		/// <summary>
+		/// How many chants can be run at once
+		/// </summary>
+		protected ushort m_maxPulsingSpells;
 
 		/// <summary>
 		/// The GamePlayer for this character
 		/// </summary>
 		public GamePlayer Player { get; private set; }
 
-		private static readonly string[] AutotrainableSkills = Array.Empty<string>();
+		private static readonly List<string> DefaultAutoTrainableSkills = new() { };
+
+		protected List<string> m_autotrainableSkills;
+
+		protected List<PlayerRace> m_eligibleRaces;
+
+		protected struct ClassOverride
+		{
+			public byte ClassID;
+			public int SpecializationMultiplier;
+			public int BaseHP;
+			public int BaseWeaponSkill;
+			public int BaseWeaponSkillRanged;
+			public ushort MaxPulsingSpells;
+			public List<string> AutotrainableSkills;
+			public List<PlayerRace> EligibleRaces;
+		}
+
+		protected static Dictionary<byte, ClassOverride> m_classOverride = new Dictionary<byte, ClassOverride>(0);
 
 		public CharacterClassBase()
 		{
@@ -116,7 +144,18 @@ namespace DOL.GS
 			m_name = "Unknown Class";
 			m_basename = "Unknown Base Class";
 			m_profession = "";
-
+			m_specializationMultiplier = 10;
+			m_baseHP = 600;
+			m_primaryStat = eStat.UNDEFINED;
+			m_secondaryStat = eStat.UNDEFINED;
+			m_tertiaryStat = eStat.UNDEFINED;
+			m_manaStat = eStat.UNDEFINED;
+			m_baseWeaponSkill = 400;
+			m_baseWeaponSkillRanged = 440;
+			m_autotrainableSkills = DefaultAutoTrainableSkills;
+			m_eligibleRaces = PlayerRace.AllRaces;
+			m_maxPulsingSpells = 1;
+			
 			// initialize members from attributes
 			Attribute[] attrs = Attribute.GetCustomAttributes(this.GetType(), typeof(CharacterClassAttribute));
 			foreach (Attribute attr in attrs)
@@ -131,6 +170,93 @@ namespace DOL.GS
 					break;
 				}
 			}
+
+			LoadClassOverride(eCharacterClass.Unknown);
+		}
+
+		static CharacterClassBase()
+		{
+			LoadClassOverrideDictionary();
+		}
+
+		/// <summary>
+		/// Load class override data from the DB
+		/// </summary>
+		static private void LoadClassOverrideDictionary()
+		{
+			var dbClassOverrideTable = GameServer.Database.SelectAllObjects<CharacterClassOverride>();
+
+			if (dbClassOverrideTable != null)
+				foreach (var dbClassOverride in dbClassOverrideTable)
+				{
+					if (dbClassOverride.ClassID < 0 || dbClassOverride.ClassID > byte.MaxValue
+						|| !Enum.IsDefined(typeof(eCharacterClass), (byte)dbClassOverride.ClassID))
+					{
+						log.Error($"LoadClassOverrideDictionary(): ClassID {dbClassOverride.ClassID} in table CharacterClass is out of range ({eCharacterClass.Unknown}-{eCharacterClass.MaulerHib}");
+						continue;
+					}
+
+					ClassOverride classOverride = new()
+					{
+						ClassID = (byte)dbClassOverride.ClassID,
+						SpecializationMultiplier = dbClassOverride.SpecializationMultiplier,
+						BaseHP = dbClassOverride.BaseHP,
+						BaseWeaponSkill = dbClassOverride.BaseWeaponSkill,
+						BaseWeaponSkillRanged = dbClassOverride.BaseWeaponSkillRanged
+					};
+
+					if (dbClassOverride.MaxPulsingSpells < 0 || dbClassOverride.MaxPulsingSpells > ushort.MaxValue)
+					{
+						classOverride.MaxPulsingSpells = 0;
+						log.Error($"LoadClassOverrideDictionary(): MaxPulsingSpell {dbClassOverride.MaxPulsingSpells} for ClassID {dbClassOverride.ClassID} is out of range");
+					}
+					else
+						classOverride.MaxPulsingSpells = (ushort)dbClassOverride.MaxPulsingSpells;
+
+					classOverride.AutotrainableSkills = new(0);
+					if (!String.IsNullOrEmpty(dbClassOverride.AutoTrainableSkills))
+						foreach (string s in dbClassOverride.AutoTrainableSkills.Split(';',','))
+							if (!String.IsNullOrEmpty(s))
+								classOverride.AutotrainableSkills.Add(s);
+
+					classOverride.EligibleRaces = new(0);
+					if (!String.IsNullOrEmpty(dbClassOverride.EligibleRaces))
+						foreach (string s in dbClassOverride.EligibleRaces.Split(';',','))
+							if (!String.IsNullOrEmpty(s) && Enum.TryParse<eRace>(s, out eRace race) && PlayerRace.TryGetRace(race, out  PlayerRace pRace))
+								classOverride.EligibleRaces.Add(pRace);
+
+					m_classOverride.Add(classOverride.ClassID, classOverride);
+				}
+		}
+
+		/// <summary>
+		/// Replace class data with values in the DB
+		/// </summary>
+		protected void LoadClassOverride(eCharacterClass charClass)
+		{
+			if (m_classOverride.TryGetValue((byte)charClass, out ClassOverride cOverride))
+			{
+				if (cOverride.SpecializationMultiplier > 0)
+					m_specializationMultiplier = cOverride.SpecializationMultiplier;
+
+				if (cOverride.BaseHP > 0)
+					m_baseHP = cOverride.BaseHP;
+
+				if (cOverride.BaseWeaponSkill > 0)
+					m_baseWeaponSkill = cOverride.BaseWeaponSkill;
+
+				if (cOverride.BaseWeaponSkillRanged > 0)
+					m_baseWeaponSkillRanged = cOverride.BaseWeaponSkillRanged;
+
+				if (cOverride.MaxPulsingSpells > 0)
+					m_maxPulsingSpells = cOverride.MaxPulsingSpells;
+
+				if (cOverride.AutotrainableSkills.Count > 0)
+					m_autotrainableSkills = cOverride.AutotrainableSkills;
+
+				if (cOverride.EligibleRaces.Count > 0)
+					m_eligibleRaces = cOverride.EligibleRaces;
+			}
 		}
 
 		public virtual void Init(GamePlayer player)
@@ -142,7 +268,7 @@ namespace DOL.GS
 			Player = player;
 		}
 
-		public abstract List<PlayerRace> EligibleRaces { get; }
+		public List<PlayerRace> EligibleRaces => m_eligibleRaces;
 
 		public string FemaleName
 		{
@@ -216,20 +342,20 @@ namespace DOL.GS
 
 		public int WeaponSkillBase
 		{
-			get { return m_wsbase; }
+			get { return m_baseWeaponSkill; }
 		}
 
 		public int WeaponSkillRangedBase
 		{
-			get { return m_wsbaseRanged; }
+			get { return m_baseWeaponSkillRanged; }
 		}
 
 		/// <summary>
 		/// Maximum number of pulsing spells that can be active simultaneously
 		/// </summary>
-		public virtual ushort MaxPulsingSpells
+		public ushort MaxPulsingSpells
 		{
-			get { return 1; }
+			get { return m_maxPulsingSpells; }
 		}
 
 		public virtual string GetTitle(GamePlayer player, int level)
@@ -256,9 +382,9 @@ namespace DOL.GS
 		/// can train in.  Added by Echostorm for RAs
 		/// </summary>
 		/// <returns></returns>
-		public virtual IList<string> GetAutotrainableSkills()
+		public IList<string> GetAutotrainableSkills()
 		{
-			return AutotrainableSkills;
+			return m_autotrainableSkills;
 		}
 
 		/// <summary>
@@ -459,22 +585,4 @@ namespace DOL.GS
 			return true;
 		}
 	}
-
-	/// <summary>
-	/// Usable default Character Class, if not other can be found or used
-	/// just for getting things valid in problematic situations
-	/// </summary>
-	public class DefaultCharacterClass : CharacterClassBase
-	{
-		public DefaultCharacterClass()
-			: base()
-		{
-			m_id = 0;
-			m_name = "Unknown";
-			m_basename = "Unknown Class";
-			m_profession = "None";
-		}
-
-        public override List<PlayerRace> EligibleRaces => PlayerRace.AllRaces;
-    }
 }

--- a/GameServer/gameobjects/CharacterClasses/CharacterClassBase.cs
+++ b/GameServer/gameobjects/CharacterClasses/CharacterClassBase.cs
@@ -184,6 +184,7 @@ namespace DOL.GS
 		/// </summary>
 		static private void LoadClassOverrideDictionary()
 		{
+			GameServer.Database.RegisterDataObject(typeof(CharacterClassOverride));
 			var dbClassOverrideTable = GameServer.Database.SelectAllObjects<CharacterClassOverride>();
 
 			if (dbClassOverrideTable != null)

--- a/GameServer/gameobjects/CharacterClasses/CharacterClassBase.cs
+++ b/GameServer/gameobjects/CharacterClasses/CharacterClassBase.cs
@@ -181,17 +181,17 @@ namespace DOL.GS
 
             foreach (var dbClassOverride in dbClassOverrideTable)
             {
-                if (dbClassOverride.ClassID < 0 || dbClassOverride.ClassID > byte.MaxValue
-                    || !Enum.IsDefined(typeof(eCharacterClass), (byte)dbClassOverride.ClassID))
+                if (dbClassOverride.ID < 0 || dbClassOverride.ID > byte.MaxValue
+                    || !Enum.IsDefined(typeof(eCharacterClass), (byte)dbClassOverride.ID))
                 {
-                    log.Error($"LoadClassOverrideDictionary(): ClassID {dbClassOverride.ClassID} in table CharacterClass is out of range ({eCharacterClass.Unknown}-{eCharacterClass.MaulerHib}");
+                    log.Error($"LoadClassOverrideDictionary(): ClassID {dbClassOverride.ID} in table CharacterClass is out of range ({eCharacterClass.Unknown}-{eCharacterClass.MaulerHib}");
                     continue;
                 }
 
                 ClassOverride classOverride = new()
                 {
-                    ClassID = (byte)dbClassOverride.ClassID,
-                    SpecializationMultiplier = dbClassOverride.SpecializationMultiplier,
+                    ClassID = (byte)dbClassOverride.ID,
+                    SpecializationMultiplier = dbClassOverride.SpecPointMultiplier,
                     BaseHP = dbClassOverride.BaseHP,
                     BaseWeaponSkill = dbClassOverride.BaseWeaponSkill
                 };

--- a/GameServer/gameobjects/CharacterClasses/CharacterClassBase.cs
+++ b/GameServer/gameobjects/CharacterClasses/CharacterClassBase.cs
@@ -24,7 +24,6 @@ using DOL.Events;
 using DOL.GS.PacketHandler;
 using DOL.Language;
 using DOL.GS.Realm;
-using DOLDatabase;
 using DOL.Database;
 
 namespace DOL.GS
@@ -171,15 +170,10 @@ namespace DOL.GS
 			LoadClassOverride(eCharacterClass.Unknown);
 		}
 
-		static CharacterClassBase()
-		{
-			LoadClassOverrideDictionary();
-		}
-
 		/// <summary>
 		/// Load class override data from the DB
 		/// </summary>
-		static private void LoadClassOverrideDictionary()
+		static public void LoadClassOverrideDictionary()
 		{
 			// Make sure we aren't using a FakeDatabase used in testing
 			if (GameServer.Instance == null) return;

--- a/GameServer/gameobjects/CharacterClasses/CharacterClassBase.cs
+++ b/GameServer/gameobjects/CharacterClasses/CharacterClassBase.cs
@@ -190,47 +190,46 @@ namespace DOL.GS
 			GameServer.Database.RegisterDataObject(typeof(CharacterClassOverride));
 			var dbClassOverrideTable = GameServer.Database.SelectAllObjects<CharacterClassOverride>();
 
-			if (dbClassOverrideTable != null)
-				foreach (var dbClassOverride in dbClassOverrideTable)
-				{
-					if (dbClassOverride.ClassID < 0 || dbClassOverride.ClassID > byte.MaxValue
-						|| !Enum.IsDefined(typeof(eCharacterClass), (byte)dbClassOverride.ClassID))
-					{
-						log.Error($"LoadClassOverrideDictionary(): ClassID {dbClassOverride.ClassID} in table CharacterClass is out of range ({eCharacterClass.Unknown}-{eCharacterClass.MaulerHib}");
-						continue;
-					}
+            foreach (var dbClassOverride in dbClassOverrideTable)
+            {
+                if (dbClassOverride.ClassID < 0 || dbClassOverride.ClassID > byte.MaxValue
+                    || !Enum.IsDefined(typeof(eCharacterClass), (byte)dbClassOverride.ClassID))
+                {
+                    log.Error($"LoadClassOverrideDictionary(): ClassID {dbClassOverride.ClassID} in table CharacterClass is out of range ({eCharacterClass.Unknown}-{eCharacterClass.MaulerHib}");
+                    continue;
+                }
 
-					ClassOverride classOverride = new()
-					{
-						ClassID = (byte)dbClassOverride.ClassID,
-						SpecializationMultiplier = dbClassOverride.SpecializationMultiplier,
-						BaseHP = dbClassOverride.BaseHP,
-						BaseWeaponSkill = dbClassOverride.BaseWeaponSkill,
-						BaseWeaponSkillRanged = dbClassOverride.BaseWeaponSkillRanged
-					};
+                ClassOverride classOverride = new()
+                {
+                    ClassID = (byte)dbClassOverride.ClassID,
+                    SpecializationMultiplier = dbClassOverride.SpecializationMultiplier,
+                    BaseHP = dbClassOverride.BaseHP,
+                    BaseWeaponSkill = dbClassOverride.BaseWeaponSkill,
+                    BaseWeaponSkillRanged = dbClassOverride.BaseWeaponSkillRanged
+                };
 
-					if (dbClassOverride.MaxPulsingSpells < 0 || dbClassOverride.MaxPulsingSpells > ushort.MaxValue)
-					{
-						classOverride.MaxPulsingSpells = 0;
-						log.Error($"LoadClassOverrideDictionary(): MaxPulsingSpell {dbClassOverride.MaxPulsingSpells} for ClassID {dbClassOverride.ClassID} is out of range");
-					}
-					else
-						classOverride.MaxPulsingSpells = (ushort)dbClassOverride.MaxPulsingSpells;
+                if (dbClassOverride.MaxPulsingSpells < 0 || dbClassOverride.MaxPulsingSpells > ushort.MaxValue)
+                {
+                    classOverride.MaxPulsingSpells = 0;
+                    log.Error($"LoadClassOverrideDictionary(): MaxPulsingSpell {dbClassOverride.MaxPulsingSpells} for ClassID {dbClassOverride.ClassID} is out of range");
+                }
+                else
+                    classOverride.MaxPulsingSpells = (ushort)dbClassOverride.MaxPulsingSpells;
 
-					classOverride.AutotrainableSkills = new(0);
-					if (!String.IsNullOrEmpty(dbClassOverride.AutoTrainableSkills))
-						foreach (string s in dbClassOverride.AutoTrainableSkills.Split(';',','))
-							if (!String.IsNullOrEmpty(s))
-								classOverride.AutotrainableSkills.Add(s);
+                classOverride.AutotrainableSkills = new(0);
+                if (!String.IsNullOrEmpty(dbClassOverride.AutoTrainableSkills))
+                    foreach (string s in dbClassOverride.AutoTrainableSkills.Split(';', ','))
+                        if (!String.IsNullOrEmpty(s))
+                            classOverride.AutotrainableSkills.Add(s);
 
-					classOverride.EligibleRaces = new(0);
-					if (!String.IsNullOrEmpty(dbClassOverride.EligibleRaces))
-						foreach (string s in dbClassOverride.EligibleRaces.Split(';',','))
-							if (!String.IsNullOrEmpty(s) && Enum.TryParse<eRace>(s, out eRace race) && PlayerRace.TryGetRace(race, out  PlayerRace pRace))
-								classOverride.EligibleRaces.Add(pRace);
+                classOverride.EligibleRaces = new(0);
+                if (!String.IsNullOrEmpty(dbClassOverride.EligibleRaces))
+                    foreach (string s in dbClassOverride.EligibleRaces.Split(';', ','))
+                        if (!String.IsNullOrEmpty(s) && Enum.TryParse<eRace>(s, out eRace race) && PlayerRace.TryGetRace(race, out PlayerRace pRace))
+                            classOverride.EligibleRaces.Add(pRace);
 
-					m_classOverride.Add(classOverride.ClassID, classOverride);
-				}
+                m_classOverride.Add(classOverride.ClassID, classOverride);
+            }
 		}
 
 		/// <summary>

--- a/GameServer/gameobjects/CharacterClasses/CharacterClassBase.cs
+++ b/GameServer/gameobjects/CharacterClasses/CharacterClassBase.cs
@@ -184,8 +184,8 @@ namespace DOL.GS
 		static private void LoadClassOverrideDictionary()
 		{
 			// Make sure we aren't using a FakeDatabase used in testing
-			if (GameServer.Database is not ObjectDatabase)
-				return;
+			if (GameServer.Instance == null) return;
+			if (GameServer.Database is not ObjectDatabase) return;
 
 			GameServer.Database.RegisterDataObject(typeof(CharacterClassOverride));
 			var dbClassOverrideTable = GameServer.Database.SelectAllObjects<CharacterClassOverride>();

--- a/GameServer/gameobjects/CharacterClasses/CharacterClassBase.cs
+++ b/GameServer/gameobjects/CharacterClasses/CharacterClassBase.cs
@@ -335,9 +335,10 @@ namespace DOL.GS
 			get { return m_maxPulsingSpells; }
 		}
 
-		public virtual string GetTitle(GamePlayer player, int level)
+		public string GetTitle(GamePlayer player, int level)
 		{
-			
+			if (!HasAdvancedFromBaseClass()) level = 0;
+
 			// Clamp level in 5 by 5 steps - 50 is the max available translation for now
 			int clamplevel = Math.Min(50, (level / 5) * 5);
 			

--- a/GameServer/gameobjects/CharacterClasses/CharacterClassBase.cs
+++ b/GameServer/gameobjects/CharacterClasses/CharacterClassBase.cs
@@ -166,8 +166,6 @@ namespace DOL.GS
 					break;
 				}
 			}
-
-			LoadClassOverride(eCharacterClass.Unknown);
 		}
 
 		/// <summary>
@@ -217,7 +215,7 @@ namespace DOL.GS
 		/// <summary>
 		/// Replace class data with values in the DB
 		/// </summary>
-		protected void LoadClassOverride(eCharacterClass charClass)
+		public void LoadClassOverride(eCharacterClass charClass)
 		{
 			if (m_classOverride.TryGetValue((byte)charClass, out ClassOverride cOverride))
 			{

--- a/GameServer/gameobjects/CharacterClasses/CharacterClassBase.cs
+++ b/GameServer/gameobjects/CharacterClasses/CharacterClassBase.cs
@@ -129,8 +129,6 @@ namespace DOL.GS
 			public int SpecializationMultiplier;
 			public int BaseHP;
 			public int BaseWeaponSkill;
-			public int BaseWeaponSkillRanged;
-			public ushort MaxPulsingSpells;
 			public List<string> AutotrainableSkills;
 			public List<PlayerRace> EligibleRaces;
 		}
@@ -187,8 +185,8 @@ namespace DOL.GS
 			if (GameServer.Instance == null) return;
 			if (GameServer.Database is not ObjectDatabase) return;
 
-			GameServer.Database.RegisterDataObject(typeof(CharacterClassOverride));
-			var dbClassOverrideTable = GameServer.Database.SelectAllObjects<CharacterClassOverride>();
+            GameServer.Database.RegisterDataObject(typeof(DOLDatabase.CharacterClass));
+			var dbClassOverrideTable = GameServer.Database.SelectAllObjects<DOLDatabase.CharacterClass>();
 
             foreach (var dbClassOverride in dbClassOverrideTable)
             {
@@ -204,21 +202,12 @@ namespace DOL.GS
                     ClassID = (byte)dbClassOverride.ClassID,
                     SpecializationMultiplier = dbClassOverride.SpecializationMultiplier,
                     BaseHP = dbClassOverride.BaseHP,
-                    BaseWeaponSkill = dbClassOverride.BaseWeaponSkill,
-                    BaseWeaponSkillRanged = dbClassOverride.BaseWeaponSkillRanged
+                    BaseWeaponSkill = dbClassOverride.BaseWeaponSkill
                 };
 
-                if (dbClassOverride.MaxPulsingSpells < 0 || dbClassOverride.MaxPulsingSpells > ushort.MaxValue)
-                {
-                    classOverride.MaxPulsingSpells = 0;
-                    log.Error($"LoadClassOverrideDictionary(): MaxPulsingSpell {dbClassOverride.MaxPulsingSpells} for ClassID {dbClassOverride.ClassID} is out of range");
-                }
-                else
-                    classOverride.MaxPulsingSpells = (ushort)dbClassOverride.MaxPulsingSpells;
-
                 classOverride.AutotrainableSkills = new(0);
-                if (!String.IsNullOrEmpty(dbClassOverride.AutoTrainableSkills))
-                    foreach (string s in dbClassOverride.AutoTrainableSkills.Split(';', ','))
+                if (!String.IsNullOrEmpty(dbClassOverride.AutoTrainSkills))
+                    foreach (string s in dbClassOverride.AutoTrainSkills.Split(';', ','))
                         if (!String.IsNullOrEmpty(s))
                             classOverride.AutotrainableSkills.Add(s);
 
@@ -247,12 +236,6 @@ namespace DOL.GS
 
 				if (cOverride.BaseWeaponSkill > 0)
 					m_baseWeaponSkill = cOverride.BaseWeaponSkill;
-
-				if (cOverride.BaseWeaponSkillRanged > 0)
-					m_baseWeaponSkillRanged = cOverride.BaseWeaponSkillRanged;
-
-				if (cOverride.MaxPulsingSpells > 0)
-					m_maxPulsingSpells = cOverride.MaxPulsingSpells;
 
 				if (cOverride.AutotrainableSkills.Count > 0)
 					m_autotrainableSkills = cOverride.AutotrainableSkills;

--- a/GameServer/gameobjects/CharacterClasses/CharacterClassBase.cs
+++ b/GameServer/gameobjects/CharacterClasses/CharacterClassBase.cs
@@ -25,8 +25,7 @@ using DOL.GS.PacketHandler;
 using DOL.Language;
 using DOL.GS.Realm;
 using DOLDatabase;
-using log4net;
-using ICSharpCode.SharpZipLib.Tar;
+using DOL.Database;
 
 namespace DOL.GS
 {
@@ -184,6 +183,10 @@ namespace DOL.GS
 		/// </summary>
 		static private void LoadClassOverrideDictionary()
 		{
+			// Make sure we aren't using a FakeDatabase used in testing
+			if (GameServer.Database is not ObjectDatabase)
+				return;
+
 			GameServer.Database.RegisterDataObject(typeof(CharacterClassOverride));
 			var dbClassOverrideTable = GameServer.Database.SelectAllObjects<CharacterClassOverride>();
 

--- a/GameServer/gameobjects/CharacterClasses/ICharacterClass.cs
+++ b/GameServer/gameobjects/CharacterClasses/ICharacterClass.cs
@@ -144,6 +144,8 @@ namespace DOL.GS
 		bool CanChangeCastingSpeed(SpellLine line, Spell spell);
 		GameTrainer.eChampionTrainerType ChampionTrainerType();
 		List<PlayerRace> EligibleRaces { get; }
+
+		void LoadClassOverride(eCharacterClass characterClass);
 	}
 
 	/// <summary>

--- a/GameServer/gameobjects/CustomNPC/Doppelganger.cs
+++ b/GameServer/gameobjects/CustomNPC/Doppelganger.cs
@@ -144,7 +144,7 @@ namespace DOL.GS
             else
                 Gender = eGender.Female;
 
-            ICharacterClass characterClass = new DefaultCharacterClass();
+            ICharacterClass characterClass = new CharacterClassBase();
 
             switch (Util.Random(2))
             {

--- a/GameServer/gameobjects/GamePlayer.cs
+++ b/GameServer/gameobjects/GamePlayer.cs
@@ -15636,7 +15636,7 @@ namespace DOL.GS
 		public static GamePlayer CreateDummy() 
 		{
 			var player = new GamePlayer();
-			player.m_characterClass = new DefaultCharacterClass();
+			player.m_characterClass = new CharacterClassBase();
 			player.m_dbCharacter = new DOLCharacters();
 			return player; 
 		}
@@ -15676,7 +15676,7 @@ namespace DOL.GS
 			m_customDialogCallback = null;
 			m_sitting = false;
 			m_isWireframe = false;
-			m_characterClass = new DefaultCharacterClass();
+			m_characterClass = new CharacterClassBase();
 			m_groupIndex = 0xFF;
 
 			m_saveInDB = true;

--- a/GameServer/gameobjects/PlayerRace.cs
+++ b/GameServer/gameobjects/PlayerRace.cs
@@ -62,6 +62,17 @@ namespace DOL.GS.Realm
 			{ eRace.Graoch, new PlayerRace(eRace.Graoch, eRealm.Hibernia, eDAoCExpansion.LabyrinthOfTheMinotaur, eLivingModel.MinotaurMaleHib, eLivingModel.None) } ,
 		};
 
+		/// <summary>
+		/// Try to retrieve a PlayerRace based on eRace
+		/// </summary>
+		/// <param name="key"></param>
+		/// <param name="playerRace"></param>
+		/// <returns></returns>
+		public static bool TryGetRace(eRace key, out PlayerRace playerRace)
+		{
+			return races.TryGetValue(key, out playerRace);
+		}
+
 		public eLivingModel GetModel(eGender gender)
         {
 			if (gender == eGender.Male) return MaleModel;

--- a/GameServer/gameutils/ScriptMgr.cs
+++ b/GameServer/gameutils/ScriptMgr.cs
@@ -686,6 +686,7 @@ namespace DOL.GS
 		/// <returns>ClassSpec that was found or null if not found</returns>
 		public static ICharacterClass FindCharacterClass(int id)
 		{
+			CharacterClassBase.LoadClassOverrideDictionary();
 			foreach (Assembly asm in GameServerScripts)
 			{
 				foreach (Type type in asm.GetTypes())

--- a/GameServer/gameutils/ScriptMgr.cs
+++ b/GameServer/gameutils/ScriptMgr.cs
@@ -686,7 +686,6 @@ namespace DOL.GS
 		/// <returns>ClassSpec that was found or null if not found</returns>
 		public static ICharacterClass FindCharacterClass(int id)
 		{
-			CharacterClassBase.LoadClassOverrideDictionary();
 			foreach (Assembly asm in GameServerScripts)
 			{
 				foreach (Type type in asm.GetTypes())
@@ -703,7 +702,9 @@ namespace DOL.GS
 						{
 							if (attrib.ID == id)
 							{
-								return (ICharacterClass)Activator.CreateInstance(type);
+								var charClass = (ICharacterClass)Activator.CreateInstance(type);
+								charClass.LoadClassOverride((eCharacterClass)id);
+								return charClass;
 							}
 						}
 					}

--- a/GameServer/gameutils/SkillBase.cs
+++ b/GameServer/gameutils/SkillBase.cs
@@ -132,6 +132,7 @@ namespace DOL.GS
 					// Need Spell, SpellLines, Abilities Loaded (including RealmAbilities...) !
 					LoadSpecializations();
 					LoadClassSpecializations();
+					CharacterClassBase.LoadClassOverrideDictionary();
 					LoadAbilityHandlers();
 					LoadSkillHandlers();
 					m_loaded = true;

--- a/GameServer/keeps/Gameobjects/Guards/Archer.cs
+++ b/GameServer/keeps/Gameobjects/Guards/Archer.cs
@@ -19,7 +19,7 @@ namespace DOL.GS.Keeps
 			if (ModelRealm == eRealm.Albion) return new ClassScout();
 			else if (ModelRealm == eRealm.Midgard) return new ClassHunter();
 			else if (ModelRealm == eRealm.Hibernia) return new ClassRanger();
-			return new DefaultCharacterClass();
+			return new CharacterClassBase();
 		}
 
 		protected override void SetBlockEvadeParryChance()

--- a/GameServer/keeps/Gameobjects/Guards/Caster.cs
+++ b/GameServer/keeps/Gameobjects/Guards/Caster.cs
@@ -78,7 +78,7 @@ namespace DOL.GS.Keeps
 			if (ModelRealm == eRealm.Albion) return new ClassWizard();
 			else if (ModelRealm == eRealm.Midgard) return new ClassRunemaster();
 			else if (ModelRealm == eRealm.Hibernia) return new ClassEldritch();
-			return new DefaultCharacterClass();
+			return new CharacterClassBase();
 		}
 
 		protected override KeepGuardBrain GetBrain() => new CasterBrain();

--- a/GameServer/keeps/Gameobjects/Guards/Fighter.cs
+++ b/GameServer/keeps/Gameobjects/Guards/Fighter.cs
@@ -11,7 +11,7 @@ namespace DOL.GS.Keeps
 			if (ModelRealm == eRealm.Albion) return new ClassArmsman();
 			else if (ModelRealm == eRealm.Midgard) return new ClassWarrior();
 			else if (ModelRealm == eRealm.Hibernia) return new ClassHero();
-			return new DefaultCharacterClass();
+			return new CharacterClassBase();
 		}
 
 		protected override void SetBlockEvadeParryChance()

--- a/GameServer/keeps/Gameobjects/Guards/GameKeepGuard.cs
+++ b/GameServer/keeps/Gameobjects/Guards/GameKeepGuard.cs
@@ -1215,7 +1215,7 @@ namespace DOL.GS.Keeps
 
 		protected virtual ICharacterClass GetClass()
         {
-			return new DefaultCharacterClass();
+			return new CharacterClassBase();
 		}
 
 		protected virtual void SetModel()

--- a/GameServer/keeps/Gameobjects/Guards/Healer.cs
+++ b/GameServer/keeps/Gameobjects/Guards/Healer.cs
@@ -12,7 +12,7 @@ namespace DOL.GS.Keeps
 			if (ModelRealm == eRealm.Albion) return new ClassCleric();
 			else if (ModelRealm == eRealm.Midgard) return new ClassHealer();
 			else if (ModelRealm == eRealm.Hibernia) return new ClassDruid();
-			return new DefaultCharacterClass();
+			return new CharacterClassBase();
 		}
 
 		protected override void SetBlockEvadeParryChance()

--- a/GameServer/keeps/Gameobjects/Guards/Lord.cs
+++ b/GameServer/keeps/Gameobjects/Guards/Lord.cs
@@ -339,7 +339,7 @@ namespace DOL.GS.Keeps
 			if (ModelRealm == eRealm.Albion) return new ClassArmsman();
 			else if (ModelRealm == eRealm.Midgard) return new ClassWarrior();
 			else if (ModelRealm == eRealm.Hibernia) return new ClassHero();
-			return new DefaultCharacterClass();
+			return new CharacterClassBase();
 		}
 
 		protected override void SetBlockEvadeParryChance()

--- a/GameServer/keeps/Gameobjects/Guards/MissionMaster.cs
+++ b/GameServer/keeps/Gameobjects/Guards/MissionMaster.cs
@@ -264,7 +264,7 @@ namespace DOL.GS.Keeps
 			if (ModelRealm == eRealm.Albion) return new ClassArmsman();
 			else if (ModelRealm == eRealm.Midgard) return new ClassWarrior();
 			else if (ModelRealm == eRealm.Hibernia) return new ClassHero();
-			return new DefaultCharacterClass();
+			return new CharacterClassBase();
 		}
 
 		protected override void SetBlockEvadeParryChance()

--- a/GameServer/keeps/Gameobjects/Guards/Stealther.cs
+++ b/GameServer/keeps/Gameobjects/Guards/Stealther.cs
@@ -16,7 +16,7 @@ namespace DOL.GS.Keeps
 			if (ModelRealm == eRealm.Albion) return new ClassInfiltrator();
 			else if (ModelRealm == eRealm.Midgard) return new ClassShadowblade();
 			else if (ModelRealm == eRealm.Hibernia) return new ClassNightshade();
-			return new DefaultCharacterClass();
+			return new CharacterClassBase();
 		}
 
 		protected override void SetBlockEvadeParryChance()

--- a/GameServer/playerclasses/albion/ClassArmsman.cs
+++ b/GameServer/playerclasses/albion/ClassArmsman.cs
@@ -40,8 +40,6 @@ namespace DOL.GS.PlayerClass
 			m_tertiaryStat = eStat.DEX;
 			m_autotrainableSkills = DefaultAutoTrainableSkills;
 			m_eligibleRaces = DefaultEligibleRaces;
-
-			LoadClassOverride(eCharacterClass.Armsman);
 		}
 
 		public override bool HasAdvancedFromBaseClass()

--- a/GameServer/playerclasses/albion/ClassArmsman.cs
+++ b/GameServer/playerclasses/albion/ClassArmsman.cs
@@ -24,7 +24,11 @@ namespace DOL.GS.PlayerClass
 	[CharacterClass((int)eCharacterClass.Armsman, "Armsman", "Fighter", "Armswoman")]
 	public class ClassArmsman : ClassFighter
 	{
-		private static readonly string[] AutotrainableSkills = new[] { Specs.Slash, Specs.Thrust };
+		private static readonly List<string> DefaultAutoTrainableSkills = new() { Specs.Slash, Specs.Thrust };
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new()
+		{
+			PlayerRace.Korazh, PlayerRace.Avalonian, PlayerRace.Briton, PlayerRace.HalfOgre, PlayerRace.Highlander, PlayerRace.Inconnu, PlayerRace.Saracen,
+		};
 
 		public ClassArmsman()
 			: base()
@@ -34,22 +38,15 @@ namespace DOL.GS.PlayerClass
 			m_primaryStat = eStat.STR;
 			m_secondaryStat = eStat.CON;
 			m_tertiaryStat = eStat.DEX;
-			m_baseHP = 880;
-		}
+			m_autotrainableSkills = DefaultAutoTrainableSkills;
+			m_eligibleRaces = DefaultEligibleRaces;
 
-		public override IList<string> GetAutotrainableSkills()
-		{
-			return AutotrainableSkills;
+			LoadClassOverride(eCharacterClass.Armsman);
 		}
 
 		public override bool HasAdvancedFromBaseClass()
 		{
 			return true;
 		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			 PlayerRace.Korazh, PlayerRace.Avalonian, PlayerRace.Briton, PlayerRace.HalfOgre, PlayerRace.Highlander, PlayerRace.Inconnu, PlayerRace.Saracen,
-		};
 	}
 }

--- a/GameServer/playerclasses/albion/ClassCabalist.cs
+++ b/GameServer/playerclasses/albion/ClassCabalist.cs
@@ -37,8 +37,6 @@ namespace DOL.GS.PlayerClass
 			m_secondaryStat = eStat.DEX;
 			m_tertiaryStat = eStat.QUI;
 			m_eligibleRaces = DefaultEligibleRaces;
-
-			LoadClassOverride(eCharacterClass.Cabalist);
 		}
 
 		public override bool HasAdvancedFromBaseClass()

--- a/GameServer/playerclasses/albion/ClassCabalist.cs
+++ b/GameServer/playerclasses/albion/ClassCabalist.cs
@@ -24,26 +24,26 @@ namespace DOL.GS.PlayerClass
 	[CharacterClass((int)eCharacterClass.Cabalist, "Cabalist", "Mage")]
 	public class ClassCabalist : ClassMage
 	{
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new List<PlayerRace>()
+		{
+			PlayerRace.Avalonian, PlayerRace.Briton, PlayerRace.HalfOgre, PlayerRace.Inconnu, PlayerRace.Saracen,
+		};
+
 		public ClassCabalist()
 			: base()
 		{
 			m_profession = "PlayerClass.Profession.GuildofShadows";
-			m_specializationMultiplier = 10;
 			m_primaryStat = eStat.INT;
 			m_secondaryStat = eStat.DEX;
 			m_tertiaryStat = eStat.QUI;
-			m_manaStat = eStat.INT;
+			m_eligibleRaces = DefaultEligibleRaces;
+
+			LoadClassOverride(eCharacterClass.Cabalist);
 		}
 
 		public override bool HasAdvancedFromBaseClass()
 		{
 			return true;
 		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			 PlayerRace.Avalonian, PlayerRace.Briton, PlayerRace.HalfOgre, PlayerRace.Inconnu, PlayerRace.Saracen,
-		};
-
 	}
 }

--- a/GameServer/playerclasses/albion/ClassCleric.cs
+++ b/GameServer/playerclasses/albion/ClassCleric.cs
@@ -24,26 +24,27 @@ namespace DOL.GS.PlayerClass
 	[CharacterClass((int)eCharacterClass.Cleric, "Cleric", "Acolyte")]
 	public class ClassCleric : ClassAcolyte
 	{
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new List<PlayerRace>()
+		{
+			PlayerRace.Avalonian, PlayerRace.Briton, PlayerRace.Highlander,
+		};
+
 		public ClassCleric()
 			: base()
 		{
 			m_profession = "PlayerClass.Profession.ChurchofAlbion";
-			m_specializationMultiplier = 10;
 			m_primaryStat = eStat.PIE;
 			m_secondaryStat = eStat.CON;
 			m_tertiaryStat = eStat.STR;
 			m_manaStat = eStat.PIE;
-			m_baseHP = 720;
+			m_eligibleRaces = DefaultEligibleRaces;
+
+			LoadClassOverride(eCharacterClass.Cleric);
 		}
 
 		public override bool HasAdvancedFromBaseClass()
 		{
 			return true;
 		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			 PlayerRace.Avalonian, PlayerRace.Briton, PlayerRace.Highlander,
-		};
 	}
 }

--- a/GameServer/playerclasses/albion/ClassCleric.cs
+++ b/GameServer/playerclasses/albion/ClassCleric.cs
@@ -38,8 +38,6 @@ namespace DOL.GS.PlayerClass
 			m_tertiaryStat = eStat.STR;
 			m_manaStat = eStat.PIE;
 			m_eligibleRaces = DefaultEligibleRaces;
-
-			LoadClassOverride(eCharacterClass.Cleric);
 		}
 
 		public override bool HasAdvancedFromBaseClass()

--- a/GameServer/playerclasses/albion/ClassFriar.cs
+++ b/GameServer/playerclasses/albion/ClassFriar.cs
@@ -16,7 +16,6 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  *
  */
-
 using DOL.GS.Realm;
 using System.Collections.Generic;
 
@@ -25,6 +24,10 @@ namespace DOL.GS.PlayerClass
 	[CharacterClass((int)eCharacterClass.Friar, "Friar", "Acolyte")]
 	public class ClassFriar : ClassAcolyte
 	{
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new List<PlayerRace>()
+		{
+			PlayerRace.Avalonian, PlayerRace.Briton, PlayerRace.Highlander,
+		};
 		public ClassFriar()
 			: base()
 		{
@@ -34,18 +37,15 @@ namespace DOL.GS.PlayerClass
 			m_secondaryStat = eStat.CON;
 			m_tertiaryStat = eStat.STR;
 			m_manaStat = eStat.PIE;
-			m_wsbase = 360;
-			m_baseHP = 720;
+			m_baseWeaponSkill = 360;
+			m_eligibleRaces = DefaultEligibleRaces;
+
+			LoadClassOverride(eCharacterClass.Friar);
 		}
 
 		public override bool HasAdvancedFromBaseClass()
 		{
 			return true;
 		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			 PlayerRace.Avalonian, PlayerRace.Briton, PlayerRace.Highlander,
-		};
 	}
 }

--- a/GameServer/playerclasses/albion/ClassFriar.cs
+++ b/GameServer/playerclasses/albion/ClassFriar.cs
@@ -39,8 +39,6 @@ namespace DOL.GS.PlayerClass
 			m_manaStat = eStat.PIE;
 			m_baseWeaponSkill = 360;
 			m_eligibleRaces = DefaultEligibleRaces;
-
-			LoadClassOverride(eCharacterClass.Friar);
 		}
 
 		public override bool HasAdvancedFromBaseClass()

--- a/GameServer/playerclasses/albion/ClassHeretic.cs
+++ b/GameServer/playerclasses/albion/ClassHeretic.cs
@@ -39,8 +39,6 @@ namespace DOL.GS.PlayerClass
 			m_manaStat = eStat.PIE;
 			m_baseWeaponSkill = 360;
 			m_eligibleRaces = DefaultEligibleRaces;
-
-			LoadClassOverride(eCharacterClass.Heretic);
 		}
 
 		public override bool HasAdvancedFromBaseClass()

--- a/GameServer/playerclasses/albion/ClassHeretic.cs
+++ b/GameServer/playerclasses/albion/ClassHeretic.cs
@@ -24,6 +24,10 @@ namespace DOL.GS.PlayerClass
 	[CharacterClass((int)eCharacterClass.Heretic, "Heretic", "Acolyte")]
 	public class ClassHeretic : ClassAcolyte
 	{
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new List<PlayerRace>()
+		{
+			PlayerRace.Korazh, PlayerRace.Avalonian, PlayerRace.Briton, PlayerRace.Inconnu, PlayerRace.Saracen
+		};
 		public ClassHeretic()
 			: base()
 		{
@@ -33,18 +37,15 @@ namespace DOL.GS.PlayerClass
 			m_secondaryStat = eStat.DEX;
 			m_tertiaryStat = eStat.CON;
 			m_manaStat = eStat.PIE;
-			m_wsbase = 360;
-			m_baseHP = 720;
+			m_baseWeaponSkill = 360;
+			m_eligibleRaces = DefaultEligibleRaces;
+
+			LoadClassOverride(eCharacterClass.Heretic);
 		}
 
 		public override bool HasAdvancedFromBaseClass()
 		{
 			return true;
 		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			 PlayerRace.Korazh, PlayerRace.Avalonian, PlayerRace.Briton, PlayerRace.Inconnu,
-		};
 	}
 }

--- a/GameServer/playerclasses/albion/ClassInfiltrator.cs
+++ b/GameServer/playerclasses/albion/ClassInfiltrator.cs
@@ -40,8 +40,6 @@ namespace DOL.GS.PlayerClass
 			m_tertiaryStat = eStat.STR;
 			m_autotrainableSkills = DefaultAutoTrainableSkills;
 			m_eligibleRaces = DefaultEligibleRaces;
-
-			LoadClassOverride(eCharacterClass.Infiltrator);
 		}
 
 		public override bool CanUseLefthandedWeapon

--- a/GameServer/playerclasses/albion/ClassInfiltrator.cs
+++ b/GameServer/playerclasses/albion/ClassInfiltrator.cs
@@ -24,7 +24,11 @@ namespace DOL.GS.PlayerClass
 	[CharacterClass((int)eCharacterClass.Infiltrator, "Infiltrator", "Rogue")]
 	public class ClassInfiltrator : ClassAlbionRogue
 	{
-		private static readonly string[] AutotrainableSkills = new[] { Specs.Stealth };
+		private static readonly List<string> DefaultAutoTrainableSkills = new List<string>() { Specs.Stealth };
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new List<PlayerRace>()
+		{
+			PlayerRace.Briton, PlayerRace.Highlander, PlayerRace.Inconnu, PlayerRace.Saracen,
+		};
 
 		public ClassInfiltrator()
 			: base()
@@ -34,7 +38,10 @@ namespace DOL.GS.PlayerClass
 			m_primaryStat = eStat.DEX;
 			m_secondaryStat = eStat.QUI;
 			m_tertiaryStat = eStat.STR;
-			m_baseHP = 720;
+			m_autotrainableSkills = DefaultAutoTrainableSkills;
+			m_eligibleRaces = DefaultEligibleRaces;
+
+			LoadClassOverride(eCharacterClass.Infiltrator);
 		}
 
 		public override bool CanUseLefthandedWeapon
@@ -42,19 +49,9 @@ namespace DOL.GS.PlayerClass
 			get { return true; }
 		}
 
-		public override IList<string> GetAutotrainableSkills()
-		{
-			return AutotrainableSkills;
-		}
-
 		public override bool HasAdvancedFromBaseClass()
 		{
 			return true;
 		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			 PlayerRace.Briton, PlayerRace.Inconnu, PlayerRace.Saracen,
-		};
 	}
 }

--- a/GameServer/playerclasses/albion/ClassMaulerAlb.cs
+++ b/GameServer/playerclasses/albion/ClassMaulerAlb.cs
@@ -24,17 +24,24 @@ namespace DOL.GS.PlayerClass
 	[CharacterClass((int)eCharacterClass.MaulerAlb, "Mauler", "Fighter")]
 	public class ClassMaulerAlb : ClassFighter
 	{
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new List<PlayerRace>()
+		{
+			PlayerRace.Korazh, PlayerRace.Briton, PlayerRace.Inconnu,
+		};
+
 		public ClassMaulerAlb()
 			: base()
 		{
 			m_profession = "PlayerClass.Profession.TempleofIronFist";
 			m_specializationMultiplier = 15;
-			m_wsbase = 440;
 			m_baseHP = 600;
 			m_primaryStat = eStat.STR;
 			m_secondaryStat = eStat.CON;
 			m_tertiaryStat = eStat.QUI;
             m_manaStat = eStat.STR;
+			m_eligibleRaces = DefaultEligibleRaces;
+
+			LoadClassOverride(eCharacterClass.MaulerAlb);
 		}
 
 		public override bool CanUseLefthandedWeapon
@@ -56,11 +63,5 @@ namespace DOL.GS.PlayerClass
 		{
 			return true;
 		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			 PlayerRace.Korazh, PlayerRace.Briton, PlayerRace.Inconnu,
-		};
-
 	}
 }

--- a/GameServer/playerclasses/albion/ClassMaulerAlb.cs
+++ b/GameServer/playerclasses/albion/ClassMaulerAlb.cs
@@ -40,8 +40,6 @@ namespace DOL.GS.PlayerClass
 			m_tertiaryStat = eStat.QUI;
             m_manaStat = eStat.STR;
 			m_eligibleRaces = DefaultEligibleRaces;
-
-			LoadClassOverride(eCharacterClass.MaulerAlb);
 		}
 
 		public override bool CanUseLefthandedWeapon

--- a/GameServer/playerclasses/albion/ClassMercenary.cs
+++ b/GameServer/playerclasses/albion/ClassMercenary.cs
@@ -40,8 +40,6 @@ namespace DOL.GS.PlayerClass
 			m_tertiaryStat = eStat.CON;
 			m_autotrainableSkills = DefaultAutotrainableSkills;
 			m_eligibleRaces = DefaultEligibleRaces;
-
-			LoadClassOverride(eCharacterClass.Mercenary);
 		}
 
 		public override bool CanUseLefthandedWeapon

--- a/GameServer/playerclasses/albion/ClassMercenary.cs
+++ b/GameServer/playerclasses/albion/ClassMercenary.cs
@@ -24,7 +24,11 @@ namespace DOL.GS.PlayerClass
 	[CharacterClass((int)eCharacterClass.Mercenary, "Mercenary", "Fighter")]
 	public class ClassMercenary : ClassFighter
 	{
-		private static readonly string[] AutotrainableSkills = new[] { Specs.Slash, Specs.Thrust };
+		private static readonly List<string> DefaultAutotrainableSkills = new List<string>() { Specs.Slash, Specs.Thrust };
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new List<PlayerRace>()
+		{
+			PlayerRace.Korazh, PlayerRace.Avalonian, PlayerRace.Briton, PlayerRace.HalfOgre, PlayerRace.Highlander, PlayerRace.Inconnu, PlayerRace.Saracen,
+		};
 
 		public ClassMercenary()
 			: base()
@@ -34,7 +38,10 @@ namespace DOL.GS.PlayerClass
 			m_primaryStat = eStat.STR;
 			m_secondaryStat = eStat.DEX;
 			m_tertiaryStat = eStat.CON;
-			m_baseHP = 880;
+			m_autotrainableSkills = DefaultAutotrainableSkills;
+			m_eligibleRaces = DefaultEligibleRaces;
+
+			LoadClassOverride(eCharacterClass.Mercenary);
 		}
 
 		public override bool CanUseLefthandedWeapon
@@ -42,19 +49,9 @@ namespace DOL.GS.PlayerClass
 			get { return true; }
 		}
 
-		public override IList<string> GetAutotrainableSkills()
-		{
-			return AutotrainableSkills;
-		}
-
 		public override bool HasAdvancedFromBaseClass()
 		{
 			return true;
 		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			 PlayerRace.Korazh, PlayerRace.Avalonian, PlayerRace.Briton, PlayerRace.HalfOgre, PlayerRace.Highlander, PlayerRace.Inconnu, PlayerRace.Saracen,
-		};
 	}
 }

--- a/GameServer/playerclasses/albion/ClassMinstrel.cs
+++ b/GameServer/playerclasses/albion/ClassMinstrel.cs
@@ -43,8 +43,6 @@ namespace DOL.GS.PlayerClass
 			m_autotrainableSkills = DefaultAutotrainableSkills;
 			m_eligibleRaces = DefaultEligibleRaces;
 			m_maxPulsingSpells = 2;
-
-			LoadClassOverride(eCharacterClass.Minstrel);
 		}
 
 		public override eClassType ClassType

--- a/GameServer/playerclasses/albion/ClassMinstrel.cs
+++ b/GameServer/playerclasses/albion/ClassMinstrel.cs
@@ -24,7 +24,11 @@ namespace DOL.GS.PlayerClass
 	[CharacterClass((int)eCharacterClass.Minstrel, "Minstrel", "Rogue")]
 	public class ClassMinstrel : ClassAlbionRogue
 	{
-		private static readonly string[] AutotrainableSkills = new[] { Specs.Instruments };
+		private static readonly List<string> DefaultAutotrainableSkills = new() { Specs.Instruments };
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new()
+		{
+			 PlayerRace.Briton, PlayerRace.Highlander, PlayerRace.Saracen,
+		};
 
 		public ClassMinstrel()
 			: base()
@@ -35,8 +39,12 @@ namespace DOL.GS.PlayerClass
 			m_secondaryStat = eStat.DEX;
 			m_tertiaryStat = eStat.STR;
 			m_manaStat = eStat.CHR;
-			m_wsbase = 380;
-			m_baseHP = 720;
+			m_baseWeaponSkill = 380;
+			m_autotrainableSkills = DefaultAutotrainableSkills;
+			m_eligibleRaces = DefaultEligibleRaces;
+			m_maxPulsingSpells = 2;
+
+			LoadClassOverride(eCharacterClass.Minstrel);
 		}
 
 		public override eClassType ClassType
@@ -44,24 +52,9 @@ namespace DOL.GS.PlayerClass
 			get { return eClassType.Hybrid; }
 		}
 
-		public override IList<string> GetAutotrainableSkills()
-		{
-			return AutotrainableSkills;
-		}
-
 		public override bool HasAdvancedFromBaseClass()
 		{
 			return true;
 		}
-
-		public override ushort MaxPulsingSpells
-		{
-			get { return 2; }
-		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			 PlayerRace.Briton, PlayerRace.Highlander, PlayerRace.Saracen,
-		};
 	}
 }

--- a/GameServer/playerclasses/albion/ClassNecromancer.cs
+++ b/GameServer/playerclasses/albion/ClassNecromancer.cs
@@ -38,8 +38,6 @@ namespace DOL.GS.PlayerClass
 			m_tertiaryStat = eStat.QUI;
 			m_manaStat = eStat.INT;
 			m_eligibleRaces = DefaultEligibleRaces;
-
-			LoadClassOverride(eCharacterClass.Necromancer);
 		}
 
 		public override bool HasAdvancedFromBaseClass()

--- a/GameServer/playerclasses/albion/ClassNecromancer.cs
+++ b/GameServer/playerclasses/albion/ClassNecromancer.cs
@@ -24,25 +24,27 @@ namespace DOL.GS.PlayerClass
 	[CharacterClass((int)eCharacterClass.Necromancer, "Necromancer", "Disciple")]
 	public class ClassNecromancer : CharacterClassNecromancer
 	{
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new()
+		{
+			 PlayerRace.Briton, PlayerRace.Inconnu, PlayerRace.Saracen,
+		};
+
 		public ClassNecromancer()
 			: base()
 		{
 			m_profession = "PlayerClass.Profession.TempleofArawn";
-			m_specializationMultiplier = 10;
 			m_primaryStat = eStat.INT;
 			m_secondaryStat = eStat.DEX;
 			m_tertiaryStat = eStat.QUI;
 			m_manaStat = eStat.INT;
+			m_eligibleRaces = DefaultEligibleRaces;
+
+			LoadClassOverride(eCharacterClass.Necromancer);
 		}
 
 		public override bool HasAdvancedFromBaseClass()
 		{
 			return true;
-		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			 PlayerRace.Briton, PlayerRace.Inconnu, PlayerRace.Saracen,
-		};
+		}		
 	}
 }

--- a/GameServer/playerclasses/albion/ClassPaladin.cs
+++ b/GameServer/playerclasses/albion/ClassPaladin.cs
@@ -44,8 +44,6 @@ namespace DOL.GS.PlayerClass
 			m_autotrainableSkills = DefaultAutoTrainableSkills;
 			m_eligibleRaces = DefaultEligibleRaces;
 			m_maxPulsingSpells = 2;
-
-			LoadClassOverride(eCharacterClass.Paladin);
 		}
 
 		public override eClassType ClassType

--- a/GameServer/playerclasses/albion/ClassPaladin.cs
+++ b/GameServer/playerclasses/albion/ClassPaladin.cs
@@ -24,7 +24,11 @@ namespace DOL.GS.PlayerClass
 	[CharacterClass((int)eCharacterClass.Paladin, "Paladin", "Fighter")]
 	public class ClassPaladin : ClassFighter
 	{
-		private static readonly string[] AutotrainableSkills = new[] { Specs.Slash, Specs.Chants };
+		private static readonly List<string> DefaultAutoTrainableSkills = new(){ Specs.Slash, Specs.Chants };
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new()
+		{
+			 PlayerRace.Avalonian, PlayerRace.Briton, PlayerRace.Highlander, PlayerRace.Saracen,
+		};
 
 		public ClassPaladin()
 			: base()
@@ -35,8 +39,13 @@ namespace DOL.GS.PlayerClass
 			m_secondaryStat = eStat.PIE;
 			m_tertiaryStat = eStat.STR;
 			m_manaStat = eStat.PIE;
-			m_wsbase = 380;
+			m_baseWeaponSkill = 380;
 			m_baseHP = 760;
+			m_autotrainableSkills = DefaultAutoTrainableSkills;
+			m_eligibleRaces = DefaultEligibleRaces;
+			m_maxPulsingSpells = 2;
+
+			LoadClassOverride(eCharacterClass.Paladin);
 		}
 
 		public override eClassType ClassType
@@ -44,24 +53,9 @@ namespace DOL.GS.PlayerClass
 			get { return eClassType.Hybrid; }
 		}
 
-		public override IList<string> GetAutotrainableSkills()
-		{
-			return AutotrainableSkills;
-		}
-
 		public override bool HasAdvancedFromBaseClass()
 		{
 			return true;
 		}
-
-		public override ushort MaxPulsingSpells
-		{
-			get { return 2; }
-		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			 PlayerRace.Avalonian, PlayerRace.Briton, PlayerRace.Highlander, PlayerRace.Saracen,
-		};
 	}
 }

--- a/GameServer/playerclasses/albion/ClassReaver.cs
+++ b/GameServer/playerclasses/albion/ClassReaver.cs
@@ -24,7 +24,11 @@ namespace DOL.GS.PlayerClass
 	[CharacterClass((int)eCharacterClass.Reaver, "Reaver", "Fighter")]
 	public class ClassReaver : ClassFighter
 	{
-		private static readonly string[] AutotrainableSkills = new[] { Specs.Slash, Specs.Flexible };
+		private static readonly List<string> DefaultAutoTrainableSkills = new() { Specs.Slash, Specs.Flexible };
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new()
+		{
+			 PlayerRace.Briton, PlayerRace.Inconnu, PlayerRace.Saracen,
+		};
 
 		public ClassReaver()
 			: base()
@@ -35,8 +39,12 @@ namespace DOL.GS.PlayerClass
 			m_secondaryStat = eStat.DEX;
 			m_tertiaryStat = eStat.PIE;
 			m_manaStat = eStat.PIE;
-			m_wsbase = 380;
+			m_baseWeaponSkill = 380;
 			m_baseHP = 760;
+			m_autotrainableSkills = DefaultAutoTrainableSkills;
+			m_eligibleRaces = DefaultEligibleRaces;
+
+			LoadClassOverride(eCharacterClass.Reaver);
 		}
 
 		public override eClassType ClassType
@@ -44,19 +52,9 @@ namespace DOL.GS.PlayerClass
 			get { return eClassType.Hybrid; }
 		}
 
-		public override IList<string> GetAutotrainableSkills()
-		{
-			return AutotrainableSkills;
-		}
-
 		public override bool HasAdvancedFromBaseClass()
 		{
 			return true;
 		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			 PlayerRace.Briton, PlayerRace.Inconnu, PlayerRace.Saracen,
-		};
 	}
 }

--- a/GameServer/playerclasses/albion/ClassReaver.cs
+++ b/GameServer/playerclasses/albion/ClassReaver.cs
@@ -43,8 +43,6 @@ namespace DOL.GS.PlayerClass
 			m_baseHP = 760;
 			m_autotrainableSkills = DefaultAutoTrainableSkills;
 			m_eligibleRaces = DefaultEligibleRaces;
-
-			LoadClassOverride(eCharacterClass.Reaver);
 		}
 
 		public override eClassType ClassType

--- a/GameServer/playerclasses/albion/ClassScout.cs
+++ b/GameServer/playerclasses/albion/ClassScout.cs
@@ -41,8 +41,6 @@ namespace DOL.GS.PlayerClass
 			m_manaStat = eStat.DEX;
 			m_autotrainableSkills = DefaultAutoTrainableSkills;
 			m_eligibleRaces = DefaultEligibleRaces;
-
-			LoadClassOverride(eCharacterClass.Scout);
 		}
 
         public override eClassType ClassType

--- a/GameServer/playerclasses/albion/ClassScout.cs
+++ b/GameServer/playerclasses/albion/ClassScout.cs
@@ -24,7 +24,11 @@ namespace DOL.GS.PlayerClass
 	[CharacterClass((int)eCharacterClass.Scout, "Scout", "Rogue")]
 	public class ClassScout : ClassAlbionRogue
 	{
-		private static readonly string[] AutotrainableSkills = new[] { Specs.Archery, Specs.Longbow };
+		private static readonly List<string> DefaultAutoTrainableSkills = new() { Specs.Archery, Specs.Longbow };
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new()
+		{
+			 PlayerRace.Briton, PlayerRace.Highlander, PlayerRace.Inconnu, PlayerRace.Saracen,
+		};
 
 		public ClassScout()
 			: base()
@@ -34,19 +38,17 @@ namespace DOL.GS.PlayerClass
 			m_primaryStat = eStat.DEX;
 			m_secondaryStat = eStat.QUI;
 			m_tertiaryStat = eStat.STR;
-			m_baseHP = 720;
-            m_manaStat = eStat.DEX; 
+			m_manaStat = eStat.DEX;
+			m_autotrainableSkills = DefaultAutoTrainableSkills;
+			m_eligibleRaces = DefaultEligibleRaces;
+
+			LoadClassOverride(eCharacterClass.Scout);
 		}
 
         public override eClassType ClassType
         {
             get { return eClassType.Hybrid; }
         }
-
-        public override IList<string> GetAutotrainableSkills()
-		{
-			return AutotrainableSkills;
-		}
 
 		/// <summary>
         /// Add all spell-lines and other things that are new when this skill is trained
@@ -139,10 +141,5 @@ namespace DOL.GS.PlayerClass
 		{
 			return true;
 		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			 PlayerRace.Briton, PlayerRace.Highlander, PlayerRace.Inconnu, PlayerRace.Saracen,
-		};
 	}
 }

--- a/GameServer/playerclasses/albion/ClassSorcerer.cs
+++ b/GameServer/playerclasses/albion/ClassSorcerer.cs
@@ -24,25 +24,26 @@ namespace DOL.GS.PlayerClass
 	[CharacterClass((int)eCharacterClass.Sorcerer, "Sorcerer", "Mage", "Sorceress")]
 	public class ClassSorcerer : ClassMage
 	{
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new()
+		{
+			 PlayerRace.Avalonian, PlayerRace.Briton, PlayerRace.HalfOgre, PlayerRace.Inconnu, PlayerRace.Saracen,
+		};
+
 		public ClassSorcerer()
 			: base()
 		{
 			m_profession = "PlayerClass.Profession.Academy";
-			m_specializationMultiplier = 10;
 			m_primaryStat = eStat.INT;
 			m_secondaryStat = eStat.DEX;
 			m_tertiaryStat = eStat.QUI;
-			m_manaStat = eStat.INT;
+			m_eligibleRaces = DefaultEligibleRaces;
+
+			LoadClassOverride(eCharacterClass.Sorcerer);
 		}
 
 		public override bool HasAdvancedFromBaseClass()
 		{
 			return true;
 		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			 PlayerRace.Avalonian, PlayerRace.Briton, PlayerRace.HalfOgre, PlayerRace.Inconnu, PlayerRace.Saracen,
-		};
 	}
 }

--- a/GameServer/playerclasses/albion/ClassSorcerer.cs
+++ b/GameServer/playerclasses/albion/ClassSorcerer.cs
@@ -37,8 +37,6 @@ namespace DOL.GS.PlayerClass
 			m_secondaryStat = eStat.DEX;
 			m_tertiaryStat = eStat.QUI;
 			m_eligibleRaces = DefaultEligibleRaces;
-
-			LoadClassOverride(eCharacterClass.Sorcerer);
 		}
 
 		public override bool HasAdvancedFromBaseClass()

--- a/GameServer/playerclasses/albion/ClassTheurgist.cs
+++ b/GameServer/playerclasses/albion/ClassTheurgist.cs
@@ -38,8 +38,6 @@ namespace DOL.GS.PlayerClass
 			m_tertiaryStat = eStat.QUI;
 			m_manaStat = eStat.INT;
 			m_eligibleRaces = DefaultEligibleRaces;
-
-			LoadClassOverride(eCharacterClass.Theurgist);
 		}
 
 		public override bool HasAdvancedFromBaseClass()

--- a/GameServer/playerclasses/albion/ClassTheurgist.cs
+++ b/GameServer/playerclasses/albion/ClassTheurgist.cs
@@ -24,25 +24,27 @@ namespace DOL.GS.PlayerClass
 	[CharacterClass((int)eCharacterClass.Theurgist, "Theurgist", "Elementalist")]
 	public class ClassTheurgist : ClassElementalist
 	{
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new()
+		{
+			 PlayerRace.Avalonian, PlayerRace.Briton, PlayerRace.HalfOgre,
+		};
+
 		public ClassTheurgist()
 			: base()
 		{
 			m_profession = "PlayerClass.Profession.DefendersofAlbion";
-			m_specializationMultiplier = 10;
 			m_primaryStat = eStat.INT;
 			m_secondaryStat = eStat.DEX;
 			m_tertiaryStat = eStat.QUI;
 			m_manaStat = eStat.INT;
+			m_eligibleRaces = DefaultEligibleRaces;
+
+			LoadClassOverride(eCharacterClass.Theurgist);
 		}
 
 		public override bool HasAdvancedFromBaseClass()
 		{
 			return true;
 		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			 PlayerRace.Avalonian, PlayerRace.Briton, PlayerRace.HalfOgre,
-		};
 	}
 }

--- a/GameServer/playerclasses/albion/ClassWizard.cs
+++ b/GameServer/playerclasses/albion/ClassWizard.cs
@@ -39,8 +39,6 @@ namespace DOL.GS.PlayerClass
 			m_manaStat = eStat.INT;
 			m_baseWeaponSkill = 240; // yes, lower that for other casters for some reason
 			m_eligibleRaces = DefaultEligibleRaces;
-
-			LoadClassOverride(eCharacterClass.Wizard);
 		}
 
 		public override bool HasAdvancedFromBaseClass()

--- a/GameServer/playerclasses/albion/ClassWizard.cs
+++ b/GameServer/playerclasses/albion/ClassWizard.cs
@@ -24,26 +24,28 @@ namespace DOL.GS.PlayerClass
 	[CharacterClass((int)eCharacterClass.Wizard, "Wizard", "Elementalist")]
 	public class ClassWizard : ClassElementalist
 	{
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new()
+		{
+			 PlayerRace.Avalonian, PlayerRace.Briton, PlayerRace.HalfOgre,
+		};
+
 		public ClassWizard()
 			: base()
 		{
 			m_profession = "PlayerClass.Profession.Academy";
-			m_specializationMultiplier = 10;
 			m_primaryStat = eStat.INT;
 			m_secondaryStat = eStat.DEX;
 			m_tertiaryStat = eStat.QUI;
 			m_manaStat = eStat.INT;
-			m_wsbase = 240; // yes, lower that for other casters for some reason
+			m_baseWeaponSkill = 240; // yes, lower that for other casters for some reason
+			m_eligibleRaces = DefaultEligibleRaces;
+
+			LoadClassOverride(eCharacterClass.Wizard);
 		}
 
 		public override bool HasAdvancedFromBaseClass()
 		{
 			return true;
 		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			 PlayerRace.Avalonian, PlayerRace.Briton, PlayerRace.HalfOgre,
-		};
 	}
 }

--- a/GameServer/playerclasses/base/ClassAcolyte.cs
+++ b/GameServer/playerclasses/base/ClassAcolyte.cs
@@ -38,11 +38,6 @@ namespace DOL.GS.PlayerClass
 			m_eligibleRaces = DefaultEligibleRaces;
 		}
 
-		public override string GetTitle(GamePlayer player, int level)
-		{
-			return HasAdvancedFromBaseClass() ? base.GetTitle(player, level) : base.GetTitle(player, 0);
-		}
-
 		public override eClassType ClassType
 		{
 			get { return eClassType.Hybrid; }

--- a/GameServer/playerclasses/base/ClassAcolyte.cs
+++ b/GameServer/playerclasses/base/ClassAcolyte.cs
@@ -36,8 +36,6 @@ namespace DOL.GS.PlayerClass
 			m_baseHP = 720;
 			m_manaStat = eStat.PIE;
 			m_eligibleRaces = DefaultEligibleRaces;
-
-			LoadClassOverride(eCharacterClass.Acolyte);
 		}
 
 		public override string GetTitle(GamePlayer player, int level)

--- a/GameServer/playerclasses/base/ClassAcolyte.cs
+++ b/GameServer/playerclasses/base/ClassAcolyte.cs
@@ -24,13 +24,20 @@ namespace DOL.GS.PlayerClass
 	[CharacterClass((int)eCharacterClass.Acolyte, "Acolyte", "Acolyte")]
 	public class ClassAcolyte : CharacterClassBase
 	{
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new()
+		{
+			PlayerRace.Korazh, PlayerRace.Avalonian, PlayerRace.Briton, PlayerRace.Highlander, PlayerRace.Inconnu,
+		};
+
 		public ClassAcolyte()
 			: base()
 		{
-			m_specializationMultiplier = 10;
-			m_wsbase = 320;
+			m_baseWeaponSkill = 320;
 			m_baseHP = 720;
 			m_manaStat = eStat.PIE;
+			m_eligibleRaces = DefaultEligibleRaces;
+
+			LoadClassOverride(eCharacterClass.Acolyte);
 		}
 
 		public override string GetTitle(GamePlayer player, int level)
@@ -43,7 +50,7 @@ namespace DOL.GS.PlayerClass
 			get { return eClassType.Hybrid; }
 		}
 
-        public override GameTrainer.eChampionTrainerType ChampionTrainerType()
+		public override GameTrainer.eChampionTrainerType ChampionTrainerType()
 		{
 			return GameTrainer.eChampionTrainerType.Acolyte;
 		}
@@ -52,10 +59,5 @@ namespace DOL.GS.PlayerClass
 		{
 			return false;
 		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			PlayerRace.Korazh, PlayerRace.Avalonian, PlayerRace.Briton, PlayerRace.Highlander, PlayerRace.Inconnu,
-		};
 	}
 }

--- a/GameServer/playerclasses/base/ClassAlbionRogue.cs
+++ b/GameServer/playerclasses/base/ClassAlbionRogue.cs
@@ -37,11 +37,6 @@ namespace DOL.GS.PlayerClass
 			m_eligibleRaces = DefaultEligibleRaces;
 		}
 
-		public override string GetTitle(GamePlayer player, int level)
-		{
-			return HasAdvancedFromBaseClass() ? base.GetTitle(player, level) : base.GetTitle(player, 0);
-		}
-
 		public override eClassType ClassType
 		{
 			get { return eClassType.PureTank; }

--- a/GameServer/playerclasses/base/ClassAlbionRogue.cs
+++ b/GameServer/playerclasses/base/ClassAlbionRogue.cs
@@ -24,12 +24,19 @@ namespace DOL.GS.PlayerClass
 	[CharacterClass((int)eCharacterClass.AlbionRogue, "Rogue", "Rogue")]
 	public class ClassAlbionRogue : CharacterClassBase
 	{
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new()
+		{
+			 PlayerRace.Briton, PlayerRace.Highlander, PlayerRace.Inconnu, PlayerRace.Saracen,
+		};
+
 		public ClassAlbionRogue()
 			: base()
 		{
-			m_specializationMultiplier = 10;
-			m_wsbase = 360;
+			m_baseWeaponSkill = 360;
 			m_baseHP = 720;
+			m_eligibleRaces = DefaultEligibleRaces;
+
+			LoadClassOverride(eCharacterClass.AlbionRogue);
 		}
 
 		public override string GetTitle(GamePlayer player, int level)
@@ -51,10 +58,5 @@ namespace DOL.GS.PlayerClass
 		{
 			return false;
 		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			 PlayerRace.Briton, PlayerRace.Highlander, PlayerRace.Inconnu, PlayerRace.Saracen,
-		};
 	}
 }

--- a/GameServer/playerclasses/base/ClassAlbionRogue.cs
+++ b/GameServer/playerclasses/base/ClassAlbionRogue.cs
@@ -35,8 +35,6 @@ namespace DOL.GS.PlayerClass
 			m_baseWeaponSkill = 360;
 			m_baseHP = 720;
 			m_eligibleRaces = DefaultEligibleRaces;
-
-			LoadClassOverride(eCharacterClass.AlbionRogue);
 		}
 
 		public override string GetTitle(GamePlayer player, int level)

--- a/GameServer/playerclasses/base/ClassDisciple.cs
+++ b/GameServer/playerclasses/base/ClassDisciple.cs
@@ -38,11 +38,6 @@ namespace DOL.GS.PlayerClass
 			m_eligibleRaces = DefaultEligibleRaces;
 		}
 
-		public override string GetTitle(GamePlayer player, int level)
-		{
-			return HasAdvancedFromBaseClass() ? base.GetTitle(player, level) : base.GetTitle(player, 0);
-		}
-
 		public override eClassType ClassType
 		{
 			get { return eClassType.ListCaster; }

--- a/GameServer/playerclasses/base/ClassDisciple.cs
+++ b/GameServer/playerclasses/base/ClassDisciple.cs
@@ -24,13 +24,20 @@ namespace DOL.GS.PlayerClass
 	[CharacterClass((int)eCharacterClass.Disciple, "Disciple", "Disciple")]
 	public class ClassDisciple : CharacterClassBase
 	{
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new()
+		{
+			 PlayerRace.Briton, PlayerRace.Inconnu, PlayerRace.Saracen,
+		};
+
 		public ClassDisciple()
 			: base()
 		{
-			m_specializationMultiplier = 10;
-			m_wsbase = 280;
+			m_baseWeaponSkill = 280;
 			m_baseHP = 560;
 			m_manaStat = eStat.INT;
+			m_eligibleRaces = DefaultEligibleRaces;
+
+			LoadClassOverride(eCharacterClass.Disciple);
 		}
 
 		public override string GetTitle(GamePlayer player, int level)
@@ -51,11 +58,6 @@ namespace DOL.GS.PlayerClass
 		public override bool HasAdvancedFromBaseClass()
 		{
 			return false;
-		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			 PlayerRace.Briton, PlayerRace.Inconnu, PlayerRace.Saracen,
-		};
+		}		
 	}
 }

--- a/GameServer/playerclasses/base/ClassDisciple.cs
+++ b/GameServer/playerclasses/base/ClassDisciple.cs
@@ -36,8 +36,6 @@ namespace DOL.GS.PlayerClass
 			m_baseHP = 560;
 			m_manaStat = eStat.INT;
 			m_eligibleRaces = DefaultEligibleRaces;
-
-			LoadClassOverride(eCharacterClass.Disciple);
 		}
 
 		public override string GetTitle(GamePlayer player, int level)

--- a/GameServer/playerclasses/base/ClassElementalist.cs
+++ b/GameServer/playerclasses/base/ClassElementalist.cs
@@ -24,13 +24,20 @@ namespace DOL.GS.PlayerClass
 	[CharacterClass((int)eCharacterClass.Elementalist, "Elementalist", "Elementalist")]
 	public class ClassElementalist : CharacterClassBase
 	{
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new()
+		{
+			 PlayerRace.Avalonian, PlayerRace.Briton, PlayerRace.HalfOgre,
+		};
+
 		public ClassElementalist()
 			: base()
 		{
-			m_specializationMultiplier = 10;
-			m_wsbase = 280;
+			m_baseWeaponSkill = 280;
 			m_baseHP = 560;
 			m_manaStat = eStat.INT;
+			m_eligibleRaces = DefaultEligibleRaces;
+
+			LoadClassOverride(eCharacterClass.Elementalist);
 		}
 
 		public override string GetTitle(GamePlayer player, int level)
@@ -51,11 +58,6 @@ namespace DOL.GS.PlayerClass
 		public override bool HasAdvancedFromBaseClass()
 		{
 			return false;
-		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			 PlayerRace.Avalonian, PlayerRace.Briton, PlayerRace.HalfOgre,
-		};
+		}		
 	}
 }

--- a/GameServer/playerclasses/base/ClassElementalist.cs
+++ b/GameServer/playerclasses/base/ClassElementalist.cs
@@ -38,11 +38,6 @@ namespace DOL.GS.PlayerClass
 			m_eligibleRaces = DefaultEligibleRaces;
 		}
 
-		public override string GetTitle(GamePlayer player, int level)
-		{
-			return HasAdvancedFromBaseClass() ? base.GetTitle(player, level) : base.GetTitle(player, 0);
-		}
-
 		public override eClassType ClassType
 		{
 			get { return eClassType.ListCaster; }

--- a/GameServer/playerclasses/base/ClassElementalist.cs
+++ b/GameServer/playerclasses/base/ClassElementalist.cs
@@ -36,8 +36,6 @@ namespace DOL.GS.PlayerClass
 			m_baseHP = 560;
 			m_manaStat = eStat.INT;
 			m_eligibleRaces = DefaultEligibleRaces;
-
-			LoadClassOverride(eCharacterClass.Elementalist);
 		}
 
 		public override string GetTitle(GamePlayer player, int level)

--- a/GameServer/playerclasses/base/ClassFighter.cs
+++ b/GameServer/playerclasses/base/ClassFighter.cs
@@ -37,11 +37,6 @@ namespace DOL.GS.PlayerClass
 			m_eligibleRaces = DefaultEligibleRaces;
 		}
 
-		public override string GetTitle(GamePlayer player, int level)
-		{
-			return HasAdvancedFromBaseClass() ? base.GetTitle(player, level) : base.GetTitle(player, 0);
-		}
-
 		public override eClassType ClassType
 		{
 			get { return eClassType.PureTank; }

--- a/GameServer/playerclasses/base/ClassFighter.cs
+++ b/GameServer/playerclasses/base/ClassFighter.cs
@@ -24,12 +24,19 @@ namespace DOL.GS.PlayerClass
 	[CharacterClass((int)eCharacterClass.Fighter, "Fighter", "Fighter")]
 	public class ClassFighter : CharacterClassBase
 	{
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new()
+		{
+			 PlayerRace.Korazh, PlayerRace.Avalonian, PlayerRace.Briton, PlayerRace.HalfOgre, PlayerRace.Highlander, PlayerRace.Inconnu, PlayerRace.Saracen,
+		};
+
 		public ClassFighter()
 			: base()
 		{
-			m_specializationMultiplier = 10;
-			m_wsbase = 440;
+			m_baseWeaponSkill = 440;
 			m_baseHP = 880;
+			m_eligibleRaces = DefaultEligibleRaces;
+
+			LoadClassOverride(eCharacterClass.Fighter);
 		}
 
 		public override string GetTitle(GamePlayer player, int level)
@@ -51,10 +58,5 @@ namespace DOL.GS.PlayerClass
 		{
 			return false;
 		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			 PlayerRace.Korazh, PlayerRace.Avalonian, PlayerRace.Briton, PlayerRace.HalfOgre, PlayerRace.Highlander, PlayerRace.Inconnu, PlayerRace.Saracen,
-		};
 	}
 }

--- a/GameServer/playerclasses/base/ClassFighter.cs
+++ b/GameServer/playerclasses/base/ClassFighter.cs
@@ -35,8 +35,6 @@ namespace DOL.GS.PlayerClass
 			m_baseWeaponSkill = 440;
 			m_baseHP = 880;
 			m_eligibleRaces = DefaultEligibleRaces;
-
-			LoadClassOverride(eCharacterClass.Fighter);
 		}
 
 		public override string GetTitle(GamePlayer player, int level)

--- a/GameServer/playerclasses/base/ClassForester.cs
+++ b/GameServer/playerclasses/base/ClassForester.cs
@@ -38,11 +38,6 @@ namespace DOL.GS.PlayerClass
 			m_eligibleRaces = DefaultEligibleRaces;
 		}
 
-		public override string GetTitle(GamePlayer player, int level)
-		{
-			return HasAdvancedFromBaseClass() ? base.GetTitle(player, level) : base.GetTitle(player, 0);
-		}
-
 		public override eClassType ClassType
 		{
 			get { return eClassType.ListCaster; }

--- a/GameServer/playerclasses/base/ClassForester.cs
+++ b/GameServer/playerclasses/base/ClassForester.cs
@@ -24,13 +24,20 @@ namespace DOL.GS.PlayerClass
 	[CharacterClass((int)eCharacterClass.Forester, "Forester", "Forester")]
 	public class ClassForester : CharacterClassBase
 	{
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new()
+		{
+			 PlayerRace.Celt, PlayerRace.Firbolg, PlayerRace.Sylvan,
+		};
+
 		public ClassForester()
 			: base()
 		{
-			m_specializationMultiplier = 10;
-			m_wsbase = 280;
+			m_baseWeaponSkill = 280;
 			m_baseHP = 560;
 			m_manaStat = eStat.INT;
+			m_eligibleRaces = DefaultEligibleRaces;
+
+			LoadClassOverride(eCharacterClass.Forester);
 		}
 
 		public override string GetTitle(GamePlayer player, int level)
@@ -52,10 +59,5 @@ namespace DOL.GS.PlayerClass
 		{
 			return false;
 		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			 PlayerRace.Celt, PlayerRace.Firbolg, PlayerRace.Sylvan,
-		};
 	}
 }

--- a/GameServer/playerclasses/base/ClassForester.cs
+++ b/GameServer/playerclasses/base/ClassForester.cs
@@ -36,8 +36,6 @@ namespace DOL.GS.PlayerClass
 			m_baseHP = 560;
 			m_manaStat = eStat.INT;
 			m_eligibleRaces = DefaultEligibleRaces;
-
-			LoadClassOverride(eCharacterClass.Forester);
 		}
 
 		public override string GetTitle(GamePlayer player, int level)

--- a/GameServer/playerclasses/base/ClassGuardian.cs
+++ b/GameServer/playerclasses/base/ClassGuardian.cs
@@ -38,11 +38,6 @@ namespace DOL.GS.PlayerClass
 			m_eligibleRaces = DefaultEligibleRaces;
 		}
 
-		public override string GetTitle(GamePlayer player, int level)
-		{
-			return HasAdvancedFromBaseClass() ? base.GetTitle(player, level) : base.GetTitle(player, 0);
-		}
-
 		public override eClassType ClassType
 		{
 			get { return eClassType.PureTank; }

--- a/GameServer/playerclasses/base/ClassGuardian.cs
+++ b/GameServer/playerclasses/base/ClassGuardian.cs
@@ -24,12 +24,20 @@ namespace DOL.GS.PlayerClass
 	[CharacterClass((int)eCharacterClass.Guardian, "Guardian", "Guardian")]
 	public class ClassGuardian : CharacterClassBase
 	{
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new()
+		{
+			 PlayerRace.Celt, PlayerRace.Elf, PlayerRace.Firbolg, PlayerRace.Graoch, PlayerRace.Lurikeen, PlayerRace.Shar, PlayerRace.Sylvan,
+		};
+
+
 		public ClassGuardian()
 			: base()
 		{
-			m_specializationMultiplier = 10;
-			m_wsbase = 400;
+			m_baseWeaponSkill = 400;
 			m_baseHP = 880;
+			m_eligibleRaces = DefaultEligibleRaces;
+
+			LoadClassOverride(eCharacterClass.Guardian);
 		}
 
 		public override string GetTitle(GamePlayer player, int level)
@@ -51,10 +59,5 @@ namespace DOL.GS.PlayerClass
 		{
 			return false;
 		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			 PlayerRace.Celt, PlayerRace.Elf, PlayerRace.Firbolg, PlayerRace.Graoch, PlayerRace.Lurikeen, PlayerRace.Shar, PlayerRace.Sylvan,
-		};
 	}
 }

--- a/GameServer/playerclasses/base/ClassGuardian.cs
+++ b/GameServer/playerclasses/base/ClassGuardian.cs
@@ -36,8 +36,6 @@ namespace DOL.GS.PlayerClass
 			m_baseWeaponSkill = 400;
 			m_baseHP = 880;
 			m_eligibleRaces = DefaultEligibleRaces;
-
-			LoadClassOverride(eCharacterClass.Guardian);
 		}
 
 		public override string GetTitle(GamePlayer player, int level)

--- a/GameServer/playerclasses/base/ClassMage.cs
+++ b/GameServer/playerclasses/base/ClassMage.cs
@@ -38,11 +38,6 @@ namespace DOL.GS.PlayerClass
 			m_eligibleRaces = DefaultEligibleRaces;
 		}
 
-		public override string GetTitle(GamePlayer player, int level)
-		{
-			return HasAdvancedFromBaseClass() ? base.GetTitle(player, level) : base.GetTitle(player, 0);
-		}
-
 		public override eClassType ClassType
 		{
 			get { return eClassType.ListCaster; }

--- a/GameServer/playerclasses/base/ClassMage.cs
+++ b/GameServer/playerclasses/base/ClassMage.cs
@@ -36,8 +36,6 @@ namespace DOL.GS.PlayerClass
 			m_baseHP = 560;
 			m_manaStat = eStat.INT;
 			m_eligibleRaces = DefaultEligibleRaces;
-
-			LoadClassOverride(eCharacterClass.Mage);
 		}
 
 		public override string GetTitle(GamePlayer player, int level)

--- a/GameServer/playerclasses/base/ClassMage.cs
+++ b/GameServer/playerclasses/base/ClassMage.cs
@@ -24,13 +24,20 @@ namespace DOL.GS.PlayerClass
 	[CharacterClass((int)eCharacterClass.Mage, "Mage", "Mage")]
 	public class ClassMage : CharacterClassBase
 	{
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new()
+		{
+			 PlayerRace.Avalonian, PlayerRace.Briton, PlayerRace.HalfOgre, PlayerRace.Inconnu, PlayerRace.Saracen,
+		};
+
 		public ClassMage()
 			: base()
 		{
-			m_specializationMultiplier = 10;
-			m_wsbase = 280;
+			m_baseWeaponSkill = 280;
 			m_baseHP = 560;
 			m_manaStat = eStat.INT;
+			m_eligibleRaces = DefaultEligibleRaces;
+
+			LoadClassOverride(eCharacterClass.Mage);
 		}
 
 		public override string GetTitle(GamePlayer player, int level)
@@ -52,10 +59,5 @@ namespace DOL.GS.PlayerClass
 		{
 			return false;
 		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			 PlayerRace.Avalonian, PlayerRace.Briton, PlayerRace.HalfOgre, PlayerRace.Inconnu, PlayerRace.Saracen,
-		};
 	}
 }

--- a/GameServer/playerclasses/base/ClassMagician.cs
+++ b/GameServer/playerclasses/base/ClassMagician.cs
@@ -37,8 +37,6 @@ namespace DOL.GS.PlayerClass
 			m_baseHP = 560;
 			m_manaStat = eStat.INT;
 			m_eligibleRaces = DefaultEligibleRaces; ;
-
-			LoadClassOverride(eCharacterClass.Magician);
 		}
 
 		public override string GetTitle(GamePlayer player, int level)

--- a/GameServer/playerclasses/base/ClassMagician.cs
+++ b/GameServer/playerclasses/base/ClassMagician.cs
@@ -24,13 +24,21 @@ namespace DOL.GS.PlayerClass
 	[CharacterClass((int)eCharacterClass.Magician, "Magician", "Magician")]
 	public class ClassMagician : CharacterClassBase
 	{
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new()
+		{
+			 PlayerRace.Celt, PlayerRace.Elf, PlayerRace.Lurikeen, PlayerRace.Shar,
+		};
+
+
 		public ClassMagician()
 			: base()
 		{
-			m_specializationMultiplier = 10;
-			m_wsbase = 280;
+			m_baseWeaponSkill = 280;
 			m_baseHP = 560;
 			m_manaStat = eStat.INT;
+			m_eligibleRaces = DefaultEligibleRaces; ;
+
+			LoadClassOverride(eCharacterClass.Magician);
 		}
 
 		public override string GetTitle(GamePlayer player, int level)
@@ -52,10 +60,5 @@ namespace DOL.GS.PlayerClass
 		{
 			return false;
 		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			 PlayerRace.Celt, PlayerRace.Elf, PlayerRace.Lurikeen, PlayerRace.Shar,
-		};
 	}
 }

--- a/GameServer/playerclasses/base/ClassMagician.cs
+++ b/GameServer/playerclasses/base/ClassMagician.cs
@@ -39,11 +39,6 @@ namespace DOL.GS.PlayerClass
 			m_eligibleRaces = DefaultEligibleRaces; ;
 		}
 
-		public override string GetTitle(GamePlayer player, int level)
-		{
-			return HasAdvancedFromBaseClass() ? base.GetTitle(player, level) : base.GetTitle(player, 0);
-		}
-
 		public override eClassType ClassType
 		{
 			get { return eClassType.ListCaster; }

--- a/GameServer/playerclasses/base/ClassMidgardRogue.cs
+++ b/GameServer/playerclasses/base/ClassMidgardRogue.cs
@@ -37,11 +37,6 @@ namespace DOL.GS.PlayerClass
 			m_eligibleRaces = DefaultEligibleRaces;
 		}
 
-		public override string GetTitle(GamePlayer player, int level)
-		{
-			return HasAdvancedFromBaseClass() ? base.GetTitle(player, level) : base.GetTitle(player, 0);
-		}
-
 		public override eClassType ClassType
 		{
 			get { return eClassType.PureTank; }

--- a/GameServer/playerclasses/base/ClassMidgardRogue.cs
+++ b/GameServer/playerclasses/base/ClassMidgardRogue.cs
@@ -24,12 +24,19 @@ namespace DOL.GS.PlayerClass
 	[CharacterClass((int)eCharacterClass.MidgardRogue, "Rogue", "Rogue")]
 	public class ClassMidgardRogue : CharacterClassBase
 	{
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new()
+		{
+			 PlayerRace.Dwarf, PlayerRace.Frostalf, PlayerRace.Kobold, PlayerRace.Norseman, PlayerRace.Valkyn,
+		};
+
 		public ClassMidgardRogue()
 			: base()
 		{
-			m_specializationMultiplier = 10;
-			m_wsbase = 360; //higher than alb/hib stealthers
+			m_baseWeaponSkill = 360; //higher than alb/hib stealthers
 			m_baseHP = 720;
+			m_eligibleRaces = DefaultEligibleRaces;
+
+			LoadClassOverride(eCharacterClass.MidgardRogue);
 		}
 
 		public override string GetTitle(GamePlayer player, int level)
@@ -51,10 +58,5 @@ namespace DOL.GS.PlayerClass
 		{
 			return false;
 		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			 PlayerRace.Dwarf, PlayerRace.Frostalf, PlayerRace.Kobold, PlayerRace.Norseman, PlayerRace.Valkyn,
-		};
 	}
 }

--- a/GameServer/playerclasses/base/ClassMidgardRogue.cs
+++ b/GameServer/playerclasses/base/ClassMidgardRogue.cs
@@ -35,8 +35,6 @@ namespace DOL.GS.PlayerClass
 			m_baseWeaponSkill = 360; //higher than alb/hib stealthers
 			m_baseHP = 720;
 			m_eligibleRaces = DefaultEligibleRaces;
-
-			LoadClassOverride(eCharacterClass.MidgardRogue);
 		}
 
 		public override string GetTitle(GamePlayer player, int level)

--- a/GameServer/playerclasses/base/ClassMystic.cs
+++ b/GameServer/playerclasses/base/ClassMystic.cs
@@ -38,11 +38,6 @@ namespace DOL.GS.PlayerClass
 			m_eligibleRaces = DefaultEligibleRaces;
 		}
 
-		public override string GetTitle(GamePlayer player, int level)
-		{
-			return HasAdvancedFromBaseClass() ? base.GetTitle(player, level) : base.GetTitle(player, 0);
-		}
-
 		public override eClassType ClassType
 		{
 			get { return eClassType.ListCaster; }

--- a/GameServer/playerclasses/base/ClassMystic.cs
+++ b/GameServer/playerclasses/base/ClassMystic.cs
@@ -36,8 +36,6 @@ namespace DOL.GS.PlayerClass
 			m_baseHP = 560;
 			m_manaStat = eStat.PIE;
 			m_eligibleRaces = DefaultEligibleRaces;
-
-			LoadClassOverride(eCharacterClass.Mystic);
 		}
 
 		public override string GetTitle(GamePlayer player, int level)

--- a/GameServer/playerclasses/base/ClassMystic.cs
+++ b/GameServer/playerclasses/base/ClassMystic.cs
@@ -24,13 +24,20 @@ namespace DOL.GS.PlayerClass
 	[CharacterClass((int)eCharacterClass.Mystic, "Mystic", "Mystic")]
 	public class ClassMystic : CharacterClassBase
 	{
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new()
+		{
+			 PlayerRace.Dwarf, PlayerRace.Frostalf, PlayerRace.Kobold, PlayerRace.Norseman, PlayerRace.Troll, PlayerRace.Valkyn,
+		};
+
 		public ClassMystic()
 			: base()
 		{
-			m_specializationMultiplier = 10;
-			m_wsbase = 280;
+			m_baseWeaponSkill = 280;
 			m_baseHP = 560;
-			m_manaStat = eStat.INT;
+			m_manaStat = eStat.PIE;
+			m_eligibleRaces = DefaultEligibleRaces;
+
+			LoadClassOverride(eCharacterClass.Mystic);
 		}
 
 		public override string GetTitle(GamePlayer player, int level)
@@ -52,10 +59,5 @@ namespace DOL.GS.PlayerClass
 		{
 			return false;
 		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			 PlayerRace.Dwarf, PlayerRace.Frostalf, PlayerRace.Kobold, PlayerRace.Norseman, PlayerRace.Troll, PlayerRace.Valkyn,
-		};
 	}
 }

--- a/GameServer/playerclasses/base/ClassNaturalist.cs
+++ b/GameServer/playerclasses/base/ClassNaturalist.cs
@@ -38,11 +38,6 @@ namespace DOL.GS.PlayerClass
 			m_eligibleRaces = DefaultEligibleRaces;
 		}
 
-		public override string GetTitle(GamePlayer player, int level)
-		{
-			return HasAdvancedFromBaseClass() ? base.GetTitle(player, level) : base.GetTitle(player, 0);
-		}
-
 		public override eClassType ClassType
 		{
 			get { return eClassType.Hybrid; }

--- a/GameServer/playerclasses/base/ClassNaturalist.cs
+++ b/GameServer/playerclasses/base/ClassNaturalist.cs
@@ -36,8 +36,6 @@ namespace DOL.GS.PlayerClass
 			m_baseHP = 720;
 			m_manaStat = eStat.EMP;
 			m_eligibleRaces = DefaultEligibleRaces;
-
-			LoadClassOverride(eCharacterClass.Naturalist);
 		}
 
 		public override string GetTitle(GamePlayer player, int level)

--- a/GameServer/playerclasses/base/ClassNaturalist.cs
+++ b/GameServer/playerclasses/base/ClassNaturalist.cs
@@ -24,13 +24,20 @@ namespace DOL.GS.PlayerClass
 	[CharacterClass((int)eCharacterClass.Naturalist, "Naturalist", "Naturalist")]
 	public class ClassNaturalist : CharacterClassBase
 	{
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new()
+		{
+			 PlayerRace.Celt, PlayerRace.Firbolg, PlayerRace.Sylvan, PlayerRace.Graoch
+		};
+
 		public ClassNaturalist()
 			: base()
 		{
-			m_specializationMultiplier = 10;
-			m_wsbase = 360;
+			m_baseWeaponSkill = 360;
 			m_baseHP = 720;
 			m_manaStat = eStat.EMP;
+			m_eligibleRaces = DefaultEligibleRaces;
+
+			LoadClassOverride(eCharacterClass.Naturalist);
 		}
 
 		public override string GetTitle(GamePlayer player, int level)
@@ -52,10 +59,5 @@ namespace DOL.GS.PlayerClass
 		{
 			return false;
 		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			 PlayerRace.Celt, PlayerRace.Firbolg, PlayerRace.Sylvan, PlayerRace.Graoch
-		};
 	}
 }

--- a/GameServer/playerclasses/base/ClassSeer.cs
+++ b/GameServer/playerclasses/base/ClassSeer.cs
@@ -38,11 +38,6 @@ namespace DOL.GS.PlayerClass
 			m_eligibleRaces = DefaultEligibleRaces;
 		}
 
-		public override string GetTitle(GamePlayer player, int level)
-		{
-			return HasAdvancedFromBaseClass() ? base.GetTitle(player, level) : base.GetTitle(player, 0);
-		}
-
 		public override eClassType ClassType
 		{
 			get { return eClassType.Hybrid; }

--- a/GameServer/playerclasses/base/ClassSeer.cs
+++ b/GameServer/playerclasses/base/ClassSeer.cs
@@ -36,8 +36,6 @@ namespace DOL.GS.PlayerClass
 			m_baseHP = 720;
 			m_manaStat = eStat.PIE;
 			m_eligibleRaces = DefaultEligibleRaces;
-
-			LoadClassOverride(eCharacterClass.Seer);
 		}
 
 		public override string GetTitle(GamePlayer player, int level)

--- a/GameServer/playerclasses/base/ClassSeer.cs
+++ b/GameServer/playerclasses/base/ClassSeer.cs
@@ -24,13 +24,20 @@ namespace DOL.GS.PlayerClass
 	[CharacterClass((int)eCharacterClass.Seer, "Seer", "Seer")]
 	public class ClassSeer : CharacterClassBase
 	{
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new()
+		{
+			 PlayerRace.Dwarf, PlayerRace.Frostalf, PlayerRace.Kobold, PlayerRace.Norseman, PlayerRace.Troll,
+		};
+
 		public ClassSeer()
 			: base()
 		{
-			m_specializationMultiplier = 10;
-			m_wsbase = 360;
+			m_baseWeaponSkill = 360;
 			m_baseHP = 720;
 			m_manaStat = eStat.PIE;
+			m_eligibleRaces = DefaultEligibleRaces;
+
+			LoadClassOverride(eCharacterClass.Seer);
 		}
 
 		public override string GetTitle(GamePlayer player, int level)
@@ -52,10 +59,5 @@ namespace DOL.GS.PlayerClass
 		{
 			return false;
 		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			 PlayerRace.Dwarf, PlayerRace.Frostalf, PlayerRace.Kobold, PlayerRace.Norseman, PlayerRace.Troll,
-		};
 	}
 }

--- a/GameServer/playerclasses/base/ClassStalker.cs
+++ b/GameServer/playerclasses/base/ClassStalker.cs
@@ -37,11 +37,6 @@ namespace DOL.GS.PlayerClass
 			m_eligibleRaces = DefaultEligibleRaces;
 		}
 
-		public override string GetTitle(GamePlayer player, int level)
-		{
-			return HasAdvancedFromBaseClass() ? base.GetTitle(player, level) : base.GetTitle(player, 0);
-		}
-
 		public override eClassType ClassType
 		{
 			get { return eClassType.PureTank; }

--- a/GameServer/playerclasses/base/ClassStalker.cs
+++ b/GameServer/playerclasses/base/ClassStalker.cs
@@ -24,12 +24,19 @@ namespace DOL.GS.PlayerClass
 	[CharacterClass((int)eCharacterClass.Stalker, "Stalker", "Stalker")]
 	public class ClassStalker : CharacterClassBase
 	{
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new()
+		{
+			 PlayerRace.Celt, PlayerRace.Elf, PlayerRace.Lurikeen, PlayerRace.Shar,
+		};
+
 		public ClassStalker()
 			: base()
 		{
-			m_specializationMultiplier = 10;
-			m_wsbase = 360;
+			m_baseWeaponSkill = 360;
 			m_baseHP = 720;
+			m_eligibleRaces = DefaultEligibleRaces;
+
+			LoadClassOverride(eCharacterClass.Stalker);
 		}
 
 		public override string GetTitle(GamePlayer player, int level)
@@ -51,10 +58,5 @@ namespace DOL.GS.PlayerClass
 		{
 			return false;
 		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			 PlayerRace.Celt, PlayerRace.Elf, PlayerRace.Lurikeen, PlayerRace.Shar,
-		};
 	}
 }

--- a/GameServer/playerclasses/base/ClassStalker.cs
+++ b/GameServer/playerclasses/base/ClassStalker.cs
@@ -35,8 +35,6 @@ namespace DOL.GS.PlayerClass
 			m_baseWeaponSkill = 360;
 			m_baseHP = 720;
 			m_eligibleRaces = DefaultEligibleRaces;
-
-			LoadClassOverride(eCharacterClass.Stalker);
 		}
 
 		public override string GetTitle(GamePlayer player, int level)

--- a/GameServer/playerclasses/base/ClassViking.cs
+++ b/GameServer/playerclasses/base/ClassViking.cs
@@ -37,11 +37,6 @@ namespace DOL.GS.PlayerClass
 			m_eligibleRaces = DefaultEligibleRaces;
 		}
 
-		public override string GetTitle(GamePlayer player, int level)
-		{
-			return HasAdvancedFromBaseClass() ? base.GetTitle(player, level) : base.GetTitle(player, 0);
-		}
-
 		public override eClassType ClassType
 		{
 			get { return eClassType.PureTank; }

--- a/GameServer/playerclasses/base/ClassViking.cs
+++ b/GameServer/playerclasses/base/ClassViking.cs
@@ -24,12 +24,19 @@ namespace DOL.GS.PlayerClass
 	[CharacterClass((int)eCharacterClass.Viking, "Viking", "Viking")]
 	public class ClassViking : CharacterClassBase
 	{
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new()
+		{
+			 PlayerRace.Dwarf, PlayerRace.Frostalf, PlayerRace.Kobold, PlayerRace.Deifrang, PlayerRace.Norseman, PlayerRace.Troll, PlayerRace.Valkyn,
+		};
+
 		public ClassViking()
 			: base()
 		{
-			m_specializationMultiplier = 10;
-			m_wsbase = 440;
+			m_baseWeaponSkill = 440;
 			m_baseHP = 880;
+			m_eligibleRaces = DefaultEligibleRaces;
+
+			LoadClassOverride(eCharacterClass.Viking);
 		}
 
 		public override string GetTitle(GamePlayer player, int level)
@@ -51,10 +58,5 @@ namespace DOL.GS.PlayerClass
 		{
 			return false;
 		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			 PlayerRace.Dwarf, PlayerRace.Frostalf, PlayerRace.Kobold, PlayerRace.Deifrang, PlayerRace.Norseman, PlayerRace.Troll, PlayerRace.Valkyn,
-		};
 	}
 }

--- a/GameServer/playerclasses/base/ClassViking.cs
+++ b/GameServer/playerclasses/base/ClassViking.cs
@@ -35,8 +35,6 @@ namespace DOL.GS.PlayerClass
 			m_baseWeaponSkill = 440;
 			m_baseHP = 880;
 			m_eligibleRaces = DefaultEligibleRaces;
-
-			LoadClassOverride(eCharacterClass.Viking);
 		}
 
 		public override string GetTitle(GamePlayer player, int level)

--- a/GameServer/playerclasses/hibernia/ClassAnimist.cs
+++ b/GameServer/playerclasses/hibernia/ClassAnimist.cs
@@ -38,8 +38,6 @@ namespace DOL.GS.PlayerClass
 			m_secondaryStat = eStat.CON;
 			m_tertiaryStat = eStat.DEX;
 			m_eligibleRaces = DefaultEligibleRaces;
-
-			LoadClassOverride(eCharacterClass.Animist);
 		}
 
 		public override eClassType ClassType

--- a/GameServer/playerclasses/hibernia/ClassAnimist.cs
+++ b/GameServer/playerclasses/hibernia/ClassAnimist.cs
@@ -24,18 +24,22 @@ namespace DOL.GS.PlayerClass
 	[CharacterClass((int)eCharacterClass.Animist, "Animist", "Forester")]
 	public class ClassAnimist : CharacterClassAnimist
 	{
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new()
+		{
+			 PlayerRace.Celt, PlayerRace.Firbolg, PlayerRace.Sylvan,
+		};
+
 		public ClassAnimist()
 			: base()
 		{
 			m_specializationMultiplier = 10;
-			m_wsbase = 280;
-			m_baseHP = 560;
-			m_manaStat = eStat.INT;
-
 			m_profession = "PlayerClass.Profession.PathofAffinity";
 			m_primaryStat = eStat.INT;
 			m_secondaryStat = eStat.CON;
 			m_tertiaryStat = eStat.DEX;
+			m_eligibleRaces = DefaultEligibleRaces;
+
+			LoadClassOverride(eCharacterClass.Animist);
 		}
 
 		public override eClassType ClassType
@@ -47,10 +51,5 @@ namespace DOL.GS.PlayerClass
 		{
 			return true;
 		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			 PlayerRace.Celt, PlayerRace.Firbolg, PlayerRace.Sylvan,
-		};
 	}
 }

--- a/GameServer/playerclasses/hibernia/ClassBainshee.cs
+++ b/GameServer/playerclasses/hibernia/ClassBainshee.cs
@@ -42,8 +42,6 @@ namespace DOL.GS.PlayerClass
 			m_secondaryStat = eStat.DEX;
 			m_tertiaryStat = eStat.CON;
 			m_eligibleRaces = DefaultEligibleRaces;
-
-			LoadClassOverride(eCharacterClass.Bainshee);
 		}
 
 		public override bool HasAdvancedFromBaseClass()

--- a/GameServer/playerclasses/hibernia/ClassBainshee.cs
+++ b/GameServer/playerclasses/hibernia/ClassBainshee.cs
@@ -29,15 +29,21 @@ namespace DOL.GS.PlayerClass
 	[CharacterClass((int)eCharacterClass.Bainshee, "Bainshee", "Magician")]
 	public class ClassBainshee : ClassMagician
 	{
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new()
+		{
+			 PlayerRace.Celt, PlayerRace.Elf, PlayerRace.Lurikeen,
+		};
+
 		public ClassBainshee()
 			: base()
 		{
 			m_profession = "PlayerClass.Profession.PathofAffinity";
-			m_specializationMultiplier = 10;
 			m_primaryStat = eStat.INT;
 			m_secondaryStat = eStat.DEX;
 			m_tertiaryStat = eStat.CON;
-			m_manaStat = eStat.INT;
+			m_eligibleRaces = DefaultEligibleRaces;
+
+			LoadClassOverride(eCharacterClass.Bainshee);
 		}
 
 		public override bool HasAdvancedFromBaseClass()
@@ -172,11 +178,6 @@ namespace DOL.GS.PlayerClass
 			Player.Model = (ushort)Player.Client.Account.Characters[Player.Client.ActiveCharIndex].CreationModel;
 			
 		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			 PlayerRace.Celt, PlayerRace.Elf, PlayerRace.Lurikeen,
-		};
+		#endregion
 	}
-	#endregion
 }

--- a/GameServer/playerclasses/hibernia/ClassBard.cs
+++ b/GameServer/playerclasses/hibernia/ClassBard.cs
@@ -40,8 +40,6 @@ namespace DOL.GS.PlayerClass
 			m_manaStat = eStat.CHR;
 			m_eligibleRaces = DefaultEligibleRaces;
 			m_maxPulsingSpells = 2;
-
-			LoadClassOverride(eCharacterClass.Bard);
 		}
 
 		public override bool HasAdvancedFromBaseClass()

--- a/GameServer/playerclasses/hibernia/ClassBard.cs
+++ b/GameServer/playerclasses/hibernia/ClassBard.cs
@@ -24,6 +24,11 @@ namespace DOL.GS.PlayerClass
 	[CharacterClass((int)eCharacterClass.Bard, "Bard", "Naturalist")]
 	public class ClassBard : ClassNaturalist
 	{
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new()
+		{
+			 PlayerRace.Celt, PlayerRace.Firbolg,
+		};
+
 		public ClassBard()
 			: base()
 		{
@@ -33,22 +38,15 @@ namespace DOL.GS.PlayerClass
 			m_secondaryStat = eStat.EMP;
 			m_tertiaryStat = eStat.CON;
 			m_manaStat = eStat.CHR;
-			m_wsbase = 360;
+			m_eligibleRaces = DefaultEligibleRaces;
+			m_maxPulsingSpells = 2;
+
+			LoadClassOverride(eCharacterClass.Bard);
 		}
 
 		public override bool HasAdvancedFromBaseClass()
 		{
 			return true;
 		}
-
-		public override ushort MaxPulsingSpells
-		{
-			get { return 2; }
-		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			 PlayerRace.Celt, PlayerRace.Firbolg,
-		};
 	}
 }

--- a/GameServer/playerclasses/hibernia/ClassBlademaster.cs
+++ b/GameServer/playerclasses/hibernia/ClassBlademaster.cs
@@ -24,6 +24,11 @@ namespace DOL.GS.PlayerClass
 	[CharacterClass((int)eCharacterClass.Blademaster, "Blademaster", "Guardian")]
 	public class ClassBlademaster : ClassGuardian
 	{
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new()
+		{
+			 PlayerRace.Celt, PlayerRace.Elf, PlayerRace.Firbolg, PlayerRace.Graoch, PlayerRace.Shar,
+		};
+
 		public ClassBlademaster()
 			: base()
 		{
@@ -32,7 +37,10 @@ namespace DOL.GS.PlayerClass
 			m_primaryStat = eStat.STR;
 			m_secondaryStat = eStat.DEX;
 			m_tertiaryStat = eStat.CON;
-			m_wsbase = 440;
+			m_baseWeaponSkill = 440;
+			m_eligibleRaces = DefaultEligibleRaces;
+
+			LoadClassOverride(eCharacterClass.Blademaster);
 		}
 
 		public override bool CanUseLefthandedWeapon
@@ -44,10 +52,5 @@ namespace DOL.GS.PlayerClass
 		{
 			return true;
 		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			 PlayerRace.Celt, PlayerRace.Elf, PlayerRace.Firbolg, PlayerRace.Graoch, PlayerRace.Shar,
-		};
 	}
 }

--- a/GameServer/playerclasses/hibernia/ClassBlademaster.cs
+++ b/GameServer/playerclasses/hibernia/ClassBlademaster.cs
@@ -39,8 +39,6 @@ namespace DOL.GS.PlayerClass
 			m_tertiaryStat = eStat.CON;
 			m_baseWeaponSkill = 440;
 			m_eligibleRaces = DefaultEligibleRaces;
-
-			LoadClassOverride(eCharacterClass.Blademaster);
 		}
 
 		public override bool CanUseLefthandedWeapon

--- a/GameServer/playerclasses/hibernia/ClassChampion.cs
+++ b/GameServer/playerclasses/hibernia/ClassChampion.cs
@@ -24,6 +24,11 @@ namespace DOL.GS.PlayerClass
 	[CharacterClass((int)eCharacterClass.Champion, "Champion", "Guardian")]
 	public class ClassChampion : ClassGuardian
 	{
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new()
+		{
+			 PlayerRace.Celt, PlayerRace.Elf, PlayerRace.Graoch, PlayerRace.Lurikeen, PlayerRace.Shar,
+		};
+
 		public ClassChampion()
 			: base()
 		{
@@ -33,8 +38,11 @@ namespace DOL.GS.PlayerClass
 			m_secondaryStat = eStat.INT;
 			m_tertiaryStat = eStat.DEX;
 			m_manaStat = eStat.INT; //TODO: not sure
-			m_wsbase = 380;
+			m_baseWeaponSkill = 380;
 			m_baseHP = 760;
+			m_eligibleRaces = DefaultEligibleRaces;
+
+			LoadClassOverride(eCharacterClass.Champion);
 		}
 
 		public override eClassType ClassType
@@ -46,10 +54,5 @@ namespace DOL.GS.PlayerClass
 		{
 			return true;
 		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			 PlayerRace.Celt, PlayerRace.Elf, PlayerRace.Lurikeen, PlayerRace.Shar,
-		};
 	}
 }

--- a/GameServer/playerclasses/hibernia/ClassChampion.cs
+++ b/GameServer/playerclasses/hibernia/ClassChampion.cs
@@ -41,8 +41,6 @@ namespace DOL.GS.PlayerClass
 			m_baseWeaponSkill = 380;
 			m_baseHP = 760;
 			m_eligibleRaces = DefaultEligibleRaces;
-
-			LoadClassOverride(eCharacterClass.Champion);
 		}
 
 		public override eClassType ClassType

--- a/GameServer/playerclasses/hibernia/ClassDruid.cs
+++ b/GameServer/playerclasses/hibernia/ClassDruid.cs
@@ -39,8 +39,6 @@ namespace DOL.GS.PlayerClass
 			m_manaStat = eStat.EMP;
 			m_baseWeaponSkill = 320;
 			m_eligibleRaces = DefaultEligibleRaces;
-
-			LoadClassOverride(eCharacterClass.Druid);
 		}
 
 		public override bool HasAdvancedFromBaseClass()

--- a/GameServer/playerclasses/hibernia/ClassDruid.cs
+++ b/GameServer/playerclasses/hibernia/ClassDruid.cs
@@ -24,26 +24,28 @@ namespace DOL.GS.PlayerClass
 	[CharacterClass((int)eCharacterClass.Druid, "Druid", "Naturalist")]
 	public class ClassDruid : ClassNaturalist
 	{
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new()
+		{
+			 PlayerRace.Celt, PlayerRace.Firbolg, PlayerRace.Sylvan,
+		};
+
 		public ClassDruid()
 			: base()
 		{
 			m_profession = "PlayerClass.Profession.PathofHarmony";
-			m_specializationMultiplier = 10;
 			m_primaryStat = eStat.EMP;
 			m_secondaryStat = eStat.CON;
 			m_tertiaryStat = eStat.STR;
 			m_manaStat = eStat.EMP;
-			m_wsbase = 320;
+			m_baseWeaponSkill = 320;
+			m_eligibleRaces = DefaultEligibleRaces;
+
+			LoadClassOverride(eCharacterClass.Druid);
 		}
 
 		public override bool HasAdvancedFromBaseClass()
 		{
 			return true;
 		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			 PlayerRace.Celt, PlayerRace.Firbolg, PlayerRace.Sylvan,
-		};
 	}
 }

--- a/GameServer/playerclasses/hibernia/ClassEldritch.cs
+++ b/GameServer/playerclasses/hibernia/ClassEldritch.cs
@@ -24,25 +24,26 @@ namespace DOL.GS.PlayerClass
 	[CharacterClass((int)eCharacterClass.Eldritch, "Eldritch", "Magician")]
 	public class ClassEldritch : ClassMagician
 	{
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new()
+		{
+			 PlayerRace.Elf, PlayerRace.Lurikeen,
+		};
+
 		public ClassEldritch()
 			: base()
 		{
 			m_profession = "PlayerClass.Profession.PathofFocus";
-			m_specializationMultiplier = 10;
 			m_primaryStat = eStat.INT;
 			m_secondaryStat = eStat.DEX;
 			m_tertiaryStat = eStat.QUI;
-			m_manaStat = eStat.INT;
+			m_eligibleRaces = DefaultEligibleRaces;
+
+			LoadClassOverride(eCharacterClass.Eldritch);
 		}
 
 		public override bool HasAdvancedFromBaseClass()
 		{
 			return true;
 		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			 PlayerRace.Elf, PlayerRace.Lurikeen,
-		};
 	}
 }

--- a/GameServer/playerclasses/hibernia/ClassEldritch.cs
+++ b/GameServer/playerclasses/hibernia/ClassEldritch.cs
@@ -37,8 +37,6 @@ namespace DOL.GS.PlayerClass
 			m_secondaryStat = eStat.DEX;
 			m_tertiaryStat = eStat.QUI;
 			m_eligibleRaces = DefaultEligibleRaces;
-
-			LoadClassOverride(eCharacterClass.Eldritch);
 		}
 
 		public override bool HasAdvancedFromBaseClass()

--- a/GameServer/playerclasses/hibernia/ClassEnchanter.cs
+++ b/GameServer/playerclasses/hibernia/ClassEnchanter.cs
@@ -37,8 +37,6 @@ namespace DOL.GS.PlayerClass
 			m_secondaryStat = eStat.DEX;
 			m_tertiaryStat = eStat.QUI;
 			m_eligibleRaces = DefaultEligibleRaces;
-
-			LoadClassOverride(eCharacterClass.Enchanter);
 		}
 
 		public override bool HasAdvancedFromBaseClass()

--- a/GameServer/playerclasses/hibernia/ClassEnchanter.cs
+++ b/GameServer/playerclasses/hibernia/ClassEnchanter.cs
@@ -24,25 +24,26 @@ namespace DOL.GS.PlayerClass
 	[CharacterClass((int)eCharacterClass.Enchanter, "Enchanter", "Magician", "Enchantress")]
 	public class ClassEnchanter : ClassMagician
 	{
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new()
+		{
+			 PlayerRace.Elf, PlayerRace.Lurikeen,
+		};
+
 		public ClassEnchanter()
 			: base()
 		{
 			m_profession = "PlayerClass.Profession.PathofEssence";
-			m_specializationMultiplier = 10;
 			m_primaryStat = eStat.INT;
 			m_secondaryStat = eStat.DEX;
 			m_tertiaryStat = eStat.QUI;
-			m_manaStat = eStat.INT;
+			m_eligibleRaces = DefaultEligibleRaces;
+
+			LoadClassOverride(eCharacterClass.Enchanter);
 		}
 
 		public override bool HasAdvancedFromBaseClass()
 		{
 			return true;
 		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			 PlayerRace.Elf, PlayerRace.Lurikeen,
-		};
 	}
 }

--- a/GameServer/playerclasses/hibernia/ClassHero.cs
+++ b/GameServer/playerclasses/hibernia/ClassHero.cs
@@ -39,8 +39,6 @@ namespace DOL.GS.PlayerClass
 			m_tertiaryStat = eStat.DEX;
 			m_baseWeaponSkill = 440;
 			m_eligibleRaces = DefaultEligibleRaces;
-
-			LoadClassOverride(eCharacterClass.Hero);
 		}
 
 		public override bool HasAdvancedFromBaseClass()

--- a/GameServer/playerclasses/hibernia/ClassHero.cs
+++ b/GameServer/playerclasses/hibernia/ClassHero.cs
@@ -24,6 +24,11 @@ namespace DOL.GS.PlayerClass
 	[CharacterClass((int)eCharacterClass.Hero, "Hero", "Guardian", "Heroine")]
 	public class ClassHero : ClassGuardian
 	{
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new()
+		{
+			 PlayerRace.Celt, PlayerRace.Firbolg, PlayerRace.Graoch, PlayerRace.Lurikeen, PlayerRace.Shar, PlayerRace.Sylvan,
+		};
+
 		public ClassHero()
 			: base()
 		{
@@ -32,17 +37,15 @@ namespace DOL.GS.PlayerClass
 			m_primaryStat = eStat.STR;
 			m_secondaryStat = eStat.CON;
 			m_tertiaryStat = eStat.DEX;
-			m_wsbase = 440;
+			m_baseWeaponSkill = 440;
+			m_eligibleRaces = DefaultEligibleRaces;
+
+			LoadClassOverride(eCharacterClass.Hero);
 		}
 
 		public override bool HasAdvancedFromBaseClass()
 		{
 			return true;
 		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			 PlayerRace.Celt, PlayerRace.Firbolg, PlayerRace.Graoch, PlayerRace.Lurikeen, PlayerRace.Shar, PlayerRace.Sylvan,
-		};
 	}
 }

--- a/GameServer/playerclasses/hibernia/ClassMaulerHib.cs
+++ b/GameServer/playerclasses/hibernia/ClassMaulerHib.cs
@@ -24,17 +24,25 @@ namespace DOL.GS.PlayerClass
 	[CharacterClass((int)eCharacterClass.MaulerHib, "Mauler", "Guardian")]
 	public class ClassMaulerHib : ClassGuardian
 	{
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new()
+		{
+			 PlayerRace.Celt, PlayerRace.Graoch, PlayerRace.Lurikeen,
+		};
+
 		public ClassMaulerHib()
 			: base()
 		{
 			m_profession = "PlayerClass.Profession.TempleofIronFist";
 			m_specializationMultiplier = 15;
-			m_wsbase = 440;
+			m_baseWeaponSkill = 440;
 			m_baseHP = 600;
 			m_primaryStat = eStat.STR;
 			m_secondaryStat = eStat.CON;
 			m_tertiaryStat = eStat.QUI;
             m_manaStat = eStat.STR;
+			m_eligibleRaces = DefaultEligibleRaces;
+
+			LoadClassOverride(eCharacterClass.MaulerHib);
 		}
 
 		public override bool CanUseLefthandedWeapon
@@ -56,10 +64,5 @@ namespace DOL.GS.PlayerClass
 		{
 			return true;
 		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			 PlayerRace.Celt, PlayerRace.Graoch, PlayerRace.Lurikeen,
-		};
 	}
 }

--- a/GameServer/playerclasses/hibernia/ClassMaulerHib.cs
+++ b/GameServer/playerclasses/hibernia/ClassMaulerHib.cs
@@ -41,8 +41,6 @@ namespace DOL.GS.PlayerClass
 			m_tertiaryStat = eStat.QUI;
             m_manaStat = eStat.STR;
 			m_eligibleRaces = DefaultEligibleRaces;
-
-			LoadClassOverride(eCharacterClass.MaulerHib);
 		}
 
 		public override bool CanUseLefthandedWeapon

--- a/GameServer/playerclasses/hibernia/ClassMentalist.cs
+++ b/GameServer/playerclasses/hibernia/ClassMentalist.cs
@@ -37,8 +37,6 @@ namespace DOL.GS.PlayerClass
 			m_secondaryStat = eStat.DEX;
 			m_tertiaryStat = eStat.QUI;
 			m_eligibleRaces = DefaultEligibleRaces;
-
-			LoadClassOverride(eCharacterClass.Mentalist);
 		}
 
 		public override bool HasAdvancedFromBaseClass()

--- a/GameServer/playerclasses/hibernia/ClassMentalist.cs
+++ b/GameServer/playerclasses/hibernia/ClassMentalist.cs
@@ -24,25 +24,26 @@ namespace DOL.GS.PlayerClass
 	[CharacterClass((int)eCharacterClass.Mentalist, "Mentalist", "Magician")]
 	public class ClassMentalist : ClassMagician
 	{
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new()
+		{
+			 PlayerRace.Celt, PlayerRace.Elf, PlayerRace.Lurikeen, PlayerRace.Shar,
+		};
+
 		public ClassMentalist()
 			: base()
 		{
 			m_profession = "PlayerClass.Profession.PathofHarmony";
-			m_specializationMultiplier = 10;
 			m_primaryStat = eStat.INT;
 			m_secondaryStat = eStat.DEX;
 			m_tertiaryStat = eStat.QUI;
-			m_manaStat = eStat.INT;
+			m_eligibleRaces = DefaultEligibleRaces;
+
+			LoadClassOverride(eCharacterClass.Mentalist);
 		}
 
 		public override bool HasAdvancedFromBaseClass()
 		{
 			return true;
 		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			 PlayerRace.Celt, PlayerRace.Elf, PlayerRace.Lurikeen, PlayerRace.Shar,
-		};
 	}
 }

--- a/GameServer/playerclasses/hibernia/ClassNightshade.cs
+++ b/GameServer/playerclasses/hibernia/ClassNightshade.cs
@@ -42,8 +42,6 @@ namespace DOL.GS.PlayerClass
 			m_manaStat = eStat.DEX;
 			m_autotrainableSkills = DefaultAutoTrainableSkills;
 			m_eligibleRaces = DefaultEligibleRaces;
-
-			LoadClassOverride(eCharacterClass.Nightshade);
 		}
 
 		public override bool CanUseLefthandedWeapon

--- a/GameServer/playerclasses/hibernia/ClassNightshade.cs
+++ b/GameServer/playerclasses/hibernia/ClassNightshade.cs
@@ -24,7 +24,12 @@ namespace DOL.GS.PlayerClass
 	[CharacterClass((int)eCharacterClass.Nightshade, "Nightshade", "Stalker")]
 	public class ClassNightshade : ClassStalker
 	{
-		private static readonly string[] AutotrainableSkills = new[] { Specs.Stealth };
+		private static readonly List<string> DefaultAutoTrainableSkills = new() { Specs.Stealth };
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new()
+		{
+			 PlayerRace.Celt, PlayerRace.Elf, PlayerRace.Lurikeen,
+		};
+
 
 		public ClassNightshade()
 			: base()
@@ -35,6 +40,10 @@ namespace DOL.GS.PlayerClass
 			m_secondaryStat = eStat.QUI;
 			m_tertiaryStat = eStat.STR;
 			m_manaStat = eStat.DEX;
+			m_autotrainableSkills = DefaultAutoTrainableSkills;
+			m_eligibleRaces = DefaultEligibleRaces;
+
+			LoadClassOverride(eCharacterClass.Nightshade);
 		}
 
 		public override bool CanUseLefthandedWeapon
@@ -47,19 +56,9 @@ namespace DOL.GS.PlayerClass
 			get { return eClassType.Hybrid; }
 		}
 
-		public override IList<string> GetAutotrainableSkills()
-		{
-			return AutotrainableSkills;
-		}
-
 		public override bool HasAdvancedFromBaseClass()
 		{
 			return true;
 		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			 PlayerRace.Celt, PlayerRace.Elf, PlayerRace.Lurikeen,
-		};
 	}
 }

--- a/GameServer/playerclasses/hibernia/ClassRanger.cs
+++ b/GameServer/playerclasses/hibernia/ClassRanger.cs
@@ -24,7 +24,11 @@ namespace DOL.GS.PlayerClass
 	[CharacterClass((int)eCharacterClass.Ranger, "Ranger", "Stalker")]
 	public class ClassRanger : ClassStalker
 	{
-		private static readonly string[] AutotrainableSkills = new[] { Specs.Archery, Specs.RecurveBow };
+		private static readonly List<string> DefaultAutoTrainableSkills = new() { Specs.Archery, Specs.RecurveBow };
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new()
+		{
+			 PlayerRace.Celt, PlayerRace.Elf, PlayerRace.Lurikeen, PlayerRace.Shar, PlayerRace.Sylvan
+		};
 
 		public ClassRanger()
 			: base()
@@ -35,6 +39,10 @@ namespace DOL.GS.PlayerClass
 			m_secondaryStat = eStat.QUI;
 			m_tertiaryStat = eStat.STR;
 			m_manaStat = eStat.DEX;
+			m_autotrainableSkills = DefaultAutoTrainableSkills;
+			m_eligibleRaces = DefaultEligibleRaces;
+
+			LoadClassOverride(eCharacterClass.Ranger);
 		}
 
 		public override bool CanUseLefthandedWeapon
@@ -45,11 +53,6 @@ namespace DOL.GS.PlayerClass
 		public override eClassType ClassType
 		{
 			get { return eClassType.Hybrid; }
-		}
-
-		public override IList<string> GetAutotrainableSkills()
-		{
-			return AutotrainableSkills;
 		}
 
 		/// <summary>
@@ -143,10 +146,5 @@ namespace DOL.GS.PlayerClass
 		{
 			return true;
 		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			 PlayerRace.Celt, PlayerRace.Elf, PlayerRace.Lurikeen, PlayerRace.Shar,
-		};
 	}
 }

--- a/GameServer/playerclasses/hibernia/ClassRanger.cs
+++ b/GameServer/playerclasses/hibernia/ClassRanger.cs
@@ -41,8 +41,6 @@ namespace DOL.GS.PlayerClass
 			m_manaStat = eStat.DEX;
 			m_autotrainableSkills = DefaultAutoTrainableSkills;
 			m_eligibleRaces = DefaultEligibleRaces;
-
-			LoadClassOverride(eCharacterClass.Ranger);
 		}
 
 		public override bool CanUseLefthandedWeapon

--- a/GameServer/playerclasses/hibernia/ClassValewalker.cs
+++ b/GameServer/playerclasses/hibernia/ClassValewalker.cs
@@ -42,8 +42,6 @@ namespace DOL.GS.PlayerClass
 			m_baseWeaponSkill = 400;
 			m_baseHP = 720;
 			m_eligibleRaces = DefaultEligibleRaces;
-
-			LoadClassOverride(eCharacterClass.Valewalker);
 		}
 
 		public override bool HasAdvancedFromBaseClass()

--- a/GameServer/playerclasses/hibernia/ClassValewalker.cs
+++ b/GameServer/playerclasses/hibernia/ClassValewalker.cs
@@ -25,6 +25,11 @@ namespace DOL.GS.PlayerClass
 	[CharacterClass((int)eCharacterClass.Valewalker, "Valewalker", "Forester")]
 	public class ClassValewalker : ClassForester
 	{
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new()
+		{
+			 PlayerRace.Celt, PlayerRace.Firbolg, PlayerRace.Sylvan,
+		};
+
 		public ClassValewalker()
 			: base()
 		{
@@ -34,19 +39,17 @@ namespace DOL.GS.PlayerClass
 			m_secondaryStat = eStat.INT;
 			m_tertiaryStat = eStat.CON;
 			m_manaStat = eStat.INT;
-			m_wsbase = 400;
+			m_baseWeaponSkill = 400;
 			m_baseHP = 720;
+			m_eligibleRaces = DefaultEligibleRaces;
+
+			LoadClassOverride(eCharacterClass.Valewalker);
 		}
 
 		public override bool HasAdvancedFromBaseClass()
 		{
 			return true;
 		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			 PlayerRace.Celt, PlayerRace.Firbolg, PlayerRace.Sylvan,
-		};
 	}
 }
 

--- a/GameServer/playerclasses/hibernia/ClassVampiir.cs
+++ b/GameServer/playerclasses/hibernia/ClassVampiir.cs
@@ -43,8 +43,6 @@ namespace DOL.GS.PlayerClass
             m_baseWeaponSkill = 440;
             m_baseHP = 878;
 			m_eligibleRaces = DefaultEligibleRaces;
-
-			LoadClassOverride(eCharacterClass.Vampiir);
 		}
 
         public override eClassType ClassType

--- a/GameServer/playerclasses/hibernia/ClassVampiir.cs
+++ b/GameServer/playerclasses/hibernia/ClassVampiir.cs
@@ -24,7 +24,12 @@ namespace DOL.GS.PlayerClass
     [CharacterClass((int)eCharacterClass.Vampiir, "Vampiir", "Stalker")]
     public class ClassVampiir : ClassStalker
     {
-        public ClassVampiir()
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new()
+		{
+			 PlayerRace.Celt, PlayerRace.Lurikeen, PlayerRace.Shar,
+		};
+
+		public ClassVampiir()
             : base()
         {
             m_profession = "PlayerClass.Profession.PathofAffinity";
@@ -35,9 +40,12 @@ namespace DOL.GS.PlayerClass
             //Vampiirs do not have a mana stat
             //Special handling is need in the power pool calculator
             //m_manaStat = eStat.STR;
-            m_wsbase = 440;
+            m_baseWeaponSkill = 440;
             m_baseHP = 878;
-        }
+			m_eligibleRaces = DefaultEligibleRaces;
+
+			LoadClassOverride(eCharacterClass.Vampiir);
+		}
 
         public override eClassType ClassType
         {
@@ -48,10 +56,5 @@ namespace DOL.GS.PlayerClass
         {
             return true;
         }
-
-        public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-        {
-             PlayerRace.Celt, PlayerRace.Lurikeen, PlayerRace.Shar,
-        };
     }
 }

--- a/GameServer/playerclasses/hibernia/ClassWarden.cs
+++ b/GameServer/playerclasses/hibernia/ClassWarden.cs
@@ -24,6 +24,11 @@ namespace DOL.GS.PlayerClass
 	[CharacterClass((int)eCharacterClass.Warden, "Warden", "Naturalist")]
 	public class ClassWarden : ClassNaturalist
 	{
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new()
+		{
+			 PlayerRace.Celt, PlayerRace.Firbolg, PlayerRace.Graoch, PlayerRace.Sylvan,
+		};
+
 		public ClassWarden()
 			: base()
 		{
@@ -33,22 +38,15 @@ namespace DOL.GS.PlayerClass
 			m_secondaryStat = eStat.STR;
 			m_tertiaryStat = eStat.CON;
 			m_manaStat = eStat.EMP;
-			m_wsbase = 360;
+			m_eligibleRaces = DefaultEligibleRaces;
+			m_maxPulsingSpells = 2;
+
+			LoadClassOverride(eCharacterClass.Warden);
 		}
 
 		public override bool HasAdvancedFromBaseClass()
 		{
 			return true;
 		}
-
-		public override ushort MaxPulsingSpells
-		{
-			get { return 2; }
-		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			 PlayerRace.Celt, PlayerRace.Firbolg, PlayerRace.Graoch, PlayerRace.Sylvan,
-		};
 	}
 }

--- a/GameServer/playerclasses/hibernia/ClassWarden.cs
+++ b/GameServer/playerclasses/hibernia/ClassWarden.cs
@@ -40,8 +40,6 @@ namespace DOL.GS.PlayerClass
 			m_manaStat = eStat.EMP;
 			m_eligibleRaces = DefaultEligibleRaces;
 			m_maxPulsingSpells = 2;
-
-			LoadClassOverride(eCharacterClass.Warden);
 		}
 
 		public override bool HasAdvancedFromBaseClass()

--- a/GameServer/playerclasses/midgard/ClassBerserker.cs
+++ b/GameServer/playerclasses/midgard/ClassBerserker.cs
@@ -24,6 +24,11 @@ namespace DOL.GS.PlayerClass
 	[CharacterClass((int)eCharacterClass.Berserker, "Berserker", "Viking")]
 	public class ClassBerserker : ClassViking
 	{
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new()
+		{
+			 PlayerRace.Dwarf, PlayerRace.Deifrang, PlayerRace.Norseman, PlayerRace.Troll, PlayerRace.Valkyn,
+		};
+
 		public ClassBerserker()
 			: base()
 		{
@@ -32,7 +37,9 @@ namespace DOL.GS.PlayerClass
 			m_primaryStat = eStat.STR;
 			m_secondaryStat = eStat.DEX;
 			m_tertiaryStat = eStat.CON;
-			m_wsbase = 440;
+			m_eligibleRaces = DefaultEligibleRaces;
+
+			LoadClassOverride(eCharacterClass.Berserker);
 		}
 
 		public override bool CanUseLefthandedWeapon
@@ -44,10 +51,5 @@ namespace DOL.GS.PlayerClass
 		{
 			return true;
 		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			 PlayerRace.Dwarf, PlayerRace.Deifrang, PlayerRace.Norseman, PlayerRace.Troll, PlayerRace.Valkyn,
-		};
 	}
 }

--- a/GameServer/playerclasses/midgard/ClassBerserker.cs
+++ b/GameServer/playerclasses/midgard/ClassBerserker.cs
@@ -38,8 +38,6 @@ namespace DOL.GS.PlayerClass
 			m_secondaryStat = eStat.DEX;
 			m_tertiaryStat = eStat.CON;
 			m_eligibleRaces = DefaultEligibleRaces;
-
-			LoadClassOverride(eCharacterClass.Berserker);
 		}
 
 		public override bool CanUseLefthandedWeapon

--- a/GameServer/playerclasses/midgard/ClassBonedancer.cs
+++ b/GameServer/playerclasses/midgard/ClassBonedancer.cs
@@ -37,8 +37,6 @@ namespace DOL.GS.PlayerClass
 			m_secondaryStat = eStat.DEX;
 			m_tertiaryStat = eStat.QUI;
 			m_eligibleRaces = DefaultEligibleRaces;
-
-			LoadClassOverride(eCharacterClass.Bonedancer);
 		}
 
 		public override eClassType ClassType

--- a/GameServer/playerclasses/midgard/ClassBonedancer.cs
+++ b/GameServer/playerclasses/midgard/ClassBonedancer.cs
@@ -24,18 +24,21 @@ namespace DOL.GS.PlayerClass
 	[CharacterClass((int)eCharacterClass.Bonedancer, "Bonedancer", "Mystic")]
 	public class ClassBonedancer : CharacterClassBoneDancer
 	{
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new()
+		{
+			PlayerRace.Kobold, PlayerRace.Troll, PlayerRace.Valkyn,
+		};
+
 		public ClassBonedancer()
 			: base()
 		{
-			m_specializationMultiplier = 10;
-			m_wsbase = 280;
-			m_baseHP = 560;
-			m_manaStat = eStat.PIE;
-
 			m_profession = "PlayerClass.Profession.HouseofBodgar";
 			m_primaryStat = eStat.PIE;
 			m_secondaryStat = eStat.DEX;
 			m_tertiaryStat = eStat.QUI;
+			m_eligibleRaces = DefaultEligibleRaces;
+
+			LoadClassOverride(eCharacterClass.Bonedancer);
 		}
 
 		public override eClassType ClassType
@@ -47,10 +50,5 @@ namespace DOL.GS.PlayerClass
 		{
 			return true;
 		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			 PlayerRace.Kobold, PlayerRace.Troll, PlayerRace.Valkyn,
-		};
 	}
 }

--- a/GameServer/playerclasses/midgard/ClassHealer.cs
+++ b/GameServer/playerclasses/midgard/ClassHealer.cs
@@ -24,25 +24,26 @@ namespace DOL.GS.PlayerClass
 	[CharacterClass((int)eCharacterClass.Healer, "Healer", "Seer")]
 	public class ClassHealer : ClassSeer
 	{
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new()
+		{
+			 PlayerRace.Dwarf, PlayerRace.Frostalf, PlayerRace.Norseman,
+		};
+
 		public ClassHealer()
 			: base()
 		{
 			m_profession = "PlayerClass.Profession.HouseofEir";
-			m_specializationMultiplier = 10;
 			m_primaryStat = eStat.PIE;
 			m_secondaryStat = eStat.CON;
 			m_tertiaryStat = eStat.STR;
-			m_manaStat = eStat.PIE;
+			m_eligibleRaces = DefaultEligibleRaces;
+
+			LoadClassOverride(eCharacterClass.Healer);
 		}
 
 		public override bool HasAdvancedFromBaseClass()
 		{
 			return true;
 		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			 PlayerRace.Dwarf, PlayerRace.Frostalf, PlayerRace.Norseman,
-		};
 	}
 }

--- a/GameServer/playerclasses/midgard/ClassHealer.cs
+++ b/GameServer/playerclasses/midgard/ClassHealer.cs
@@ -37,8 +37,6 @@ namespace DOL.GS.PlayerClass
 			m_secondaryStat = eStat.CON;
 			m_tertiaryStat = eStat.STR;
 			m_eligibleRaces = DefaultEligibleRaces;
-
-			LoadClassOverride(eCharacterClass.Healer);
 		}
 
 		public override bool HasAdvancedFromBaseClass()

--- a/GameServer/playerclasses/midgard/ClassHunter.cs
+++ b/GameServer/playerclasses/midgard/ClassHunter.cs
@@ -24,7 +24,11 @@ namespace DOL.GS.PlayerClass
 	[CharacterClass((int)eCharacterClass.Hunter, "Hunter", "MidgardRogue", "Huntress")]
 	public class ClassHunter : ClassMidgardRogue
 	{
-		private static readonly string[] AutotrainableSkills = new[] { Specs.Archery, Specs.CompositeBow };
+		private static readonly List<string> DefaultAutoTrainableSkills = new() { Specs.Archery, Specs.CompositeBow };
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new()
+		{
+			 PlayerRace.Dwarf, PlayerRace.Frostalf, PlayerRace.Kobold, PlayerRace.Norseman, PlayerRace.Valkyn,
+		};
 
 		public ClassHunter()
 			: base()
@@ -34,13 +38,12 @@ namespace DOL.GS.PlayerClass
 			m_primaryStat = eStat.DEX;
 			m_secondaryStat = eStat.QUI;
 			m_tertiaryStat = eStat.STR;
-			m_wsbase = 380;
-			m_manaStat = eStat.DEX; 
-		}
+			m_baseWeaponSkill = 380;
+			m_manaStat = eStat.DEX;
+			m_autotrainableSkills = DefaultAutoTrainableSkills;
+			m_eligibleRaces = DefaultEligibleRaces;
 
-		public override IList<string> GetAutotrainableSkills()
-		{
-			return AutotrainableSkills;
+			LoadClassOverride(eCharacterClass.Hunter);
 		}
 
 		public override eClassType ClassType
@@ -139,10 +142,5 @@ namespace DOL.GS.PlayerClass
 		{
 			return true;
 		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			 PlayerRace.Dwarf, PlayerRace.Frostalf, PlayerRace.Kobold, PlayerRace.Norseman, PlayerRace.Valkyn,
-		};
 	}
 }

--- a/GameServer/playerclasses/midgard/ClassHunter.cs
+++ b/GameServer/playerclasses/midgard/ClassHunter.cs
@@ -42,8 +42,6 @@ namespace DOL.GS.PlayerClass
 			m_manaStat = eStat.DEX;
 			m_autotrainableSkills = DefaultAutoTrainableSkills;
 			m_eligibleRaces = DefaultEligibleRaces;
-
-			LoadClassOverride(eCharacterClass.Hunter);
 		}
 
 		public override eClassType ClassType

--- a/GameServer/playerclasses/midgard/ClassMaulerMid.cs
+++ b/GameServer/playerclasses/midgard/ClassMaulerMid.cs
@@ -24,17 +24,24 @@ namespace DOL.GS.PlayerClass
 	[CharacterClass((int)eCharacterClass.MaulerMid, "Mauler", "Viking")]
 	public class ClassMaulerMid : ClassViking
 	{
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new()
+		{
+			 PlayerRace.Kobold, PlayerRace.Deifrang, PlayerRace.Norseman,
+		};
+
 		public ClassMaulerMid()
 			: base()
 		{
 			m_profession = "PlayerClass.Profession.TempleofIronFist";
 			m_specializationMultiplier = 15;
-			m_wsbase = 440;
 			m_baseHP = 600;
 			m_primaryStat = eStat.STR;
 			m_secondaryStat = eStat.CON;
 			m_tertiaryStat = eStat.QUI;
             m_manaStat = eStat.STR;
+			m_eligibleRaces = DefaultEligibleRaces;
+
+			LoadClassOverride(eCharacterClass.MaulerMid);
 		}
 
 		public override bool CanUseLefthandedWeapon
@@ -56,10 +63,5 @@ namespace DOL.GS.PlayerClass
 		{
 			return true;
 		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			 PlayerRace.Kobold, PlayerRace.Deifrang, PlayerRace.Norseman,
-		};
 	}
 }

--- a/GameServer/playerclasses/midgard/ClassMaulerMid.cs
+++ b/GameServer/playerclasses/midgard/ClassMaulerMid.cs
@@ -40,8 +40,6 @@ namespace DOL.GS.PlayerClass
 			m_tertiaryStat = eStat.QUI;
             m_manaStat = eStat.STR;
 			m_eligibleRaces = DefaultEligibleRaces;
-
-			LoadClassOverride(eCharacterClass.MaulerMid);
 		}
 
 		public override bool CanUseLefthandedWeapon

--- a/GameServer/playerclasses/midgard/ClassRunemaster.cs
+++ b/GameServer/playerclasses/midgard/ClassRunemaster.cs
@@ -24,25 +24,26 @@ namespace DOL.GS.PlayerClass
 	[CharacterClass((int)eCharacterClass.Runemaster, "Runemaster", "Mystic")]
 	public class ClassRunemaster : ClassMystic
 	{
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new()
+		{
+			 PlayerRace.Dwarf, PlayerRace.Frostalf, PlayerRace.Kobold, PlayerRace.Norseman,
+		};
+
 		public ClassRunemaster()
 			: base()
 		{
 			m_profession = "PlayerClass.Profession.HouseofOdin";
-			m_specializationMultiplier = 10;
 			m_primaryStat = eStat.PIE;
 			m_secondaryStat = eStat.DEX;
 			m_tertiaryStat = eStat.QUI;
-			m_manaStat = eStat.PIE;
+			m_eligibleRaces = DefaultEligibleRaces;
+
+			LoadClassOverride(eCharacterClass.Runemaster);
 		}
 
 		public override bool HasAdvancedFromBaseClass()
 		{
 			return true;
 		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			 PlayerRace.Dwarf, PlayerRace.Frostalf, PlayerRace.Kobold, PlayerRace.Norseman,
-		};
 	}
 }

--- a/GameServer/playerclasses/midgard/ClassRunemaster.cs
+++ b/GameServer/playerclasses/midgard/ClassRunemaster.cs
@@ -37,8 +37,6 @@ namespace DOL.GS.PlayerClass
 			m_secondaryStat = eStat.DEX;
 			m_tertiaryStat = eStat.QUI;
 			m_eligibleRaces = DefaultEligibleRaces;
-
-			LoadClassOverride(eCharacterClass.Runemaster);
 		}
 
 		public override bool HasAdvancedFromBaseClass()

--- a/GameServer/playerclasses/midgard/ClassSavage.cs
+++ b/GameServer/playerclasses/midgard/ClassSavage.cs
@@ -40,8 +40,6 @@ namespace DOL.GS.PlayerClass
 			m_tertiaryStat = eStat.STR;
 			m_baseWeaponSkill = 400;
 			m_eligibleRaces = DefaultEligibleRaces;
-
-			LoadClassOverride(eCharacterClass.Savage);
 		}
 
 		public override bool CanUseLefthandedWeapon

--- a/GameServer/playerclasses/midgard/ClassSavage.cs
+++ b/GameServer/playerclasses/midgard/ClassSavage.cs
@@ -24,6 +24,11 @@ namespace DOL.GS.PlayerClass
 	[CharacterClassAttribute((int)eCharacterClass.Savage, "Savage", "Viking")]
 	public class ClassSavage : ClassViking
 	{
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new()
+		{
+			 PlayerRace.Dwarf, PlayerRace.Kobold, PlayerRace.Norseman, PlayerRace.Troll, PlayerRace.Valkyn,
+		};
+
 
 		public ClassSavage()
 			: base()
@@ -33,7 +38,10 @@ namespace DOL.GS.PlayerClass
 			m_primaryStat = eStat.DEX;
 			m_secondaryStat = eStat.QUI;
 			m_tertiaryStat = eStat.STR;
-			m_wsbase = 400;
+			m_baseWeaponSkill = 400;
+			m_eligibleRaces = DefaultEligibleRaces;
+
+			LoadClassOverride(eCharacterClass.Savage);
 		}
 
 		public override bool CanUseLefthandedWeapon
@@ -45,10 +53,5 @@ namespace DOL.GS.PlayerClass
 		{
 			return true;
 		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			 PlayerRace.Dwarf, PlayerRace.Kobold, PlayerRace.Norseman, PlayerRace.Troll, PlayerRace.Valkyn,
-		};
 	}
 }

--- a/GameServer/playerclasses/midgard/ClassShadowblade.cs
+++ b/GameServer/playerclasses/midgard/ClassShadowblade.cs
@@ -24,7 +24,11 @@ namespace DOL.GS.PlayerClass
 	[CharacterClass((int)eCharacterClass.Shadowblade, "Shadowblade", "MidgardRogue")]
 	public class ClassShadowblade : ClassMidgardRogue
 	{
-		private static readonly string[] AutotrainableSkills = new[] { Specs.Stealth };
+		private static readonly List<string> DefaultAutoTrainableSkills = new() { Specs.Stealth };
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new()
+		{
+			 PlayerRace.Dwarf, PlayerRace.Frostalf, PlayerRace.Kobold, PlayerRace.Norseman, PlayerRace.Valkyn,
+		};
 
 		public ClassShadowblade()
 			: base()
@@ -35,6 +39,10 @@ namespace DOL.GS.PlayerClass
 			m_secondaryStat = eStat.QUI;
 			m_tertiaryStat = eStat.STR;
 			m_baseHP = 760;
+			m_autotrainableSkills = DefaultAutoTrainableSkills;
+			m_eligibleRaces = DefaultEligibleRaces;
+
+			LoadClassOverride(eCharacterClass.Shadowblade);
 		}
 
 		/// <summary>
@@ -45,19 +53,9 @@ namespace DOL.GS.PlayerClass
 			get { return true; }
 		}
 
-		public override IList<string> GetAutotrainableSkills()
-		{
-			return AutotrainableSkills;
-		}
-
 		public override bool HasAdvancedFromBaseClass()
 		{
 			return true;
 		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			 PlayerRace.Frostalf, PlayerRace.Kobold, PlayerRace.Norseman, PlayerRace.Valkyn,
-		};
 	}
 }

--- a/GameServer/playerclasses/midgard/ClassShadowblade.cs
+++ b/GameServer/playerclasses/midgard/ClassShadowblade.cs
@@ -41,8 +41,6 @@ namespace DOL.GS.PlayerClass
 			m_baseHP = 760;
 			m_autotrainableSkills = DefaultAutoTrainableSkills;
 			m_eligibleRaces = DefaultEligibleRaces;
-
-			LoadClassOverride(eCharacterClass.Shadowblade);
 		}
 
 		/// <summary>

--- a/GameServer/playerclasses/midgard/ClassShaman.cs
+++ b/GameServer/playerclasses/midgard/ClassShaman.cs
@@ -24,25 +24,26 @@ namespace DOL.GS.PlayerClass
 	[CharacterClass((int)eCharacterClass.Shaman, "Shaman", "Seer")]
 	public class ClassShaman : ClassSeer
 	{
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new()
+		{
+			 PlayerRace.Dwarf, PlayerRace.Frostalf, PlayerRace.Kobold, PlayerRace.Troll,
+		};
+
 		public ClassShaman()
 			: base()
 		{
 			m_profession = "PlayerClass.Profession.HouseofYmir";
-			m_specializationMultiplier = 10;
 			m_primaryStat = eStat.PIE;
 			m_secondaryStat = eStat.CON;
 			m_tertiaryStat = eStat.STR;
-			m_manaStat = eStat.PIE;
+			m_eligibleRaces = DefaultEligibleRaces;
+
+			LoadClassOverride(eCharacterClass.Shaman);
 		}
 
 		public override bool HasAdvancedFromBaseClass()
 		{
 			return true;
 		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			 PlayerRace.Dwarf, PlayerRace.Frostalf, PlayerRace.Kobold, PlayerRace.Troll,
-		};
 	}
 }

--- a/GameServer/playerclasses/midgard/ClassShaman.cs
+++ b/GameServer/playerclasses/midgard/ClassShaman.cs
@@ -37,8 +37,6 @@ namespace DOL.GS.PlayerClass
 			m_secondaryStat = eStat.CON;
 			m_tertiaryStat = eStat.STR;
 			m_eligibleRaces = DefaultEligibleRaces;
-
-			LoadClassOverride(eCharacterClass.Shaman);
 		}
 
 		public override bool HasAdvancedFromBaseClass()

--- a/GameServer/playerclasses/midgard/ClassSkald.cs
+++ b/GameServer/playerclasses/midgard/ClassSkald.cs
@@ -24,6 +24,11 @@ namespace DOL.GS.PlayerClass
 	[CharacterClass((int)eCharacterClass.Skald, "Skald", "Viking")]
 	public class ClassSkald : ClassViking
 	{
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new()
+		{
+			 PlayerRace.Dwarf, PlayerRace.Kobold, PlayerRace.Norseman, PlayerRace.Troll,
+		};
+
 		public ClassSkald()
 			: base()
 		{
@@ -33,8 +38,12 @@ namespace DOL.GS.PlayerClass
 			m_secondaryStat = eStat.STR;
 			m_tertiaryStat = eStat.CON;
 			m_manaStat = eStat.CHR;
-			m_wsbase = 380;
+			m_baseWeaponSkill = 380;
 			m_baseHP = 760;
+			m_eligibleRaces = DefaultEligibleRaces;
+			m_maxPulsingSpells = 2;
+
+			LoadClassOverride(eCharacterClass.Skald);
 		}
 
 		public override eClassType ClassType
@@ -46,15 +55,5 @@ namespace DOL.GS.PlayerClass
 		{
 			return true;
 		}
-
-		public override ushort MaxPulsingSpells
-		{
-			get { return 2; }
-		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			 PlayerRace.Dwarf, PlayerRace.Kobold, PlayerRace.Norseman, PlayerRace.Troll,
-		};
 	}
 }

--- a/GameServer/playerclasses/midgard/ClassSkald.cs
+++ b/GameServer/playerclasses/midgard/ClassSkald.cs
@@ -42,8 +42,6 @@ namespace DOL.GS.PlayerClass
 			m_baseHP = 760;
 			m_eligibleRaces = DefaultEligibleRaces;
 			m_maxPulsingSpells = 2;
-
-			LoadClassOverride(eCharacterClass.Skald);
 		}
 
 		public override eClassType ClassType

--- a/GameServer/playerclasses/midgard/ClassSpiritmaster.cs
+++ b/GameServer/playerclasses/midgard/ClassSpiritmaster.cs
@@ -37,8 +37,6 @@ namespace DOL.GS.PlayerClass
 			m_secondaryStat = eStat.DEX;
 			m_tertiaryStat = eStat.QUI;
 			m_eligibleRaces = DefaultEligibleRaces;
-
-			LoadClassOverride(eCharacterClass.Spiritmaster);
 		}
 
 		public override bool HasAdvancedFromBaseClass()

--- a/GameServer/playerclasses/midgard/ClassSpiritmaster.cs
+++ b/GameServer/playerclasses/midgard/ClassSpiritmaster.cs
@@ -24,25 +24,26 @@ namespace DOL.GS.PlayerClass
 	[CharacterClass((int)eCharacterClass.Spiritmaster, "Spiritmaster", "Mystic")]
 	public class ClassSpiritmaster : ClassMystic
 	{
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new()
+		{
+			 PlayerRace.Frostalf, PlayerRace.Kobold, PlayerRace.Norseman,
+		};
+
 		public ClassSpiritmaster()
 			: base()
 		{
 			m_profession = "PlayerClass.Profession.HouseofHel";
-			m_specializationMultiplier = 10;
 			m_primaryStat = eStat.PIE;
 			m_secondaryStat = eStat.DEX;
 			m_tertiaryStat = eStat.QUI;
-			m_manaStat = eStat.PIE;
+			m_eligibleRaces = DefaultEligibleRaces;
+
+			LoadClassOverride(eCharacterClass.Spiritmaster);
 		}
 
 		public override bool HasAdvancedFromBaseClass()
 		{
 			return true;
 		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			 PlayerRace.Frostalf, PlayerRace.Kobold, PlayerRace.Norseman,
-		};
 	}
 }

--- a/GameServer/playerclasses/midgard/ClassThane.cs
+++ b/GameServer/playerclasses/midgard/ClassThane.cs
@@ -24,6 +24,11 @@ namespace DOL.GS.PlayerClass
 	[CharacterClass((int)eCharacterClass.Thane, "Thane", "Viking")]
 	public class ClassThane : ClassViking
 	{
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new()
+		{
+			 PlayerRace.Dwarf, PlayerRace.Frostalf, PlayerRace.Deifrang, PlayerRace.Norseman, PlayerRace.Troll,
+		};
+
 		public ClassThane()
 			: base()
 		{
@@ -33,8 +38,11 @@ namespace DOL.GS.PlayerClass
 			m_secondaryStat = eStat.PIE;
 			m_tertiaryStat = eStat.CON;
 			m_manaStat = eStat.PIE;
-			m_wsbase = 360;
+			m_baseWeaponSkill = 360;
 			m_baseHP = 720;
+			m_eligibleRaces = DefaultEligibleRaces;
+
+			LoadClassOverride(eCharacterClass.Thane);
 		}
 
 		public override eClassType ClassType
@@ -46,10 +54,5 @@ namespace DOL.GS.PlayerClass
 		{
 			return true;
 		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			 PlayerRace.Dwarf, PlayerRace.Frostalf, PlayerRace.Deifrang, PlayerRace.Norseman, PlayerRace.Troll,
-		};
 	}
 }

--- a/GameServer/playerclasses/midgard/ClassThane.cs
+++ b/GameServer/playerclasses/midgard/ClassThane.cs
@@ -41,8 +41,6 @@ namespace DOL.GS.PlayerClass
 			m_baseWeaponSkill = 360;
 			m_baseHP = 720;
 			m_eligibleRaces = DefaultEligibleRaces;
-
-			LoadClassOverride(eCharacterClass.Thane);
 		}
 
 		public override eClassType ClassType

--- a/GameServer/playerclasses/midgard/ClassValkyrie.cs
+++ b/GameServer/playerclasses/midgard/ClassValkyrie.cs
@@ -41,8 +41,6 @@ namespace DOL.GS.PlayerClass
 			m_baseWeaponSkill = 360;
 			m_baseHP = 720;
 			m_eligibleRaces = DefaultEligibleRaces;
-
-			LoadClassOverride(eCharacterClass.Valkyrie);
 		}
 
 		public override eClassType ClassType

--- a/GameServer/playerclasses/midgard/ClassValkyrie.cs
+++ b/GameServer/playerclasses/midgard/ClassValkyrie.cs
@@ -24,6 +24,11 @@ namespace DOL.GS.PlayerClass
 	[CharacterClass((int)eCharacterClass.Valkyrie, "Valkyrie", "Viking")]
 	public class ClassValkyrie : ClassViking
 	{
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new()
+		{
+			 PlayerRace.Dwarf, PlayerRace.Frostalf, PlayerRace.Norseman, PlayerRace.Valkyn
+		};
+
 		public ClassValkyrie()
 			: base()
 		{
@@ -33,8 +38,11 @@ namespace DOL.GS.PlayerClass
 			m_secondaryStat = eStat.STR;
 			m_tertiaryStat = eStat.DEX;
 			m_manaStat = eStat.PIE;
-			m_wsbase = 360;
+			m_baseWeaponSkill = 360;
 			m_baseHP = 720;
+			m_eligibleRaces = DefaultEligibleRaces;
+
+			LoadClassOverride(eCharacterClass.Valkyrie);
 		}
 
 		public override eClassType ClassType
@@ -46,10 +54,5 @@ namespace DOL.GS.PlayerClass
 		{
 			return true;
 		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			 PlayerRace.Dwarf, PlayerRace.Frostalf, PlayerRace.Norseman,
-		};
 	}
 }

--- a/GameServer/playerclasses/midgard/ClassWarlock.cs
+++ b/GameServer/playerclasses/midgard/ClassWarlock.cs
@@ -37,8 +37,6 @@ namespace DOL.GS.PlayerClass
 			m_secondaryStat = eStat.CON;
 			m_tertiaryStat = eStat.DEX;
 			m_eligibleRaces = DefaultEligibleRaces;
-
-			LoadClassOverride(eCharacterClass.Warlock);
 		}
 
 		public override bool HasAdvancedFromBaseClass()

--- a/GameServer/playerclasses/midgard/ClassWarlock.cs
+++ b/GameServer/playerclasses/midgard/ClassWarlock.cs
@@ -24,15 +24,21 @@ namespace DOL.GS.PlayerClass
 	[CharacterClass((int)eCharacterClass.Warlock, "Warlock", "Mystic")]
 	public class ClassWarlock : ClassMystic
 	{
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new()
+		{
+			 PlayerRace.Frostalf, PlayerRace.Kobold, PlayerRace.Norseman,
+		};
+
 		public ClassWarlock()
 			: base()
 		{
 			m_profession = "PlayerClass.Profession.HouseofHel";
-			m_specializationMultiplier = 10;
 			m_primaryStat = eStat.PIE;
 			m_secondaryStat = eStat.CON;
 			m_tertiaryStat = eStat.DEX;
-			m_manaStat = eStat.PIE;
+			m_eligibleRaces = DefaultEligibleRaces;
+
+			LoadClassOverride(eCharacterClass.Warlock);
 		}
 
 		public override bool HasAdvancedFromBaseClass()
@@ -76,10 +82,5 @@ namespace DOL.GS.PlayerClass
 
 			return true;
 		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			 PlayerRace.Frostalf, PlayerRace.Kobold, PlayerRace.Norseman,
-		};
 	}
 }

--- a/GameServer/playerclasses/midgard/ClassWarrior.cs
+++ b/GameServer/playerclasses/midgard/ClassWarrior.cs
@@ -41,8 +41,6 @@ namespace DOL.GS.PlayerClass
 			m_baseWeaponSkill = 460;
 			m_autotrainableSkills = DefaultAutoTrainableSkills;
 			m_eligibleRaces = DefaultEligibleRaces;
-
-			LoadClassOverride(eCharacterClass.Warrior);
 		}
 
 		public override bool HasAdvancedFromBaseClass()

--- a/GameServer/playerclasses/midgard/ClassWarrior.cs
+++ b/GameServer/playerclasses/midgard/ClassWarrior.cs
@@ -24,7 +24,11 @@ namespace DOL.GS.PlayerClass
 	[CharacterClass((int)eCharacterClass.Warrior, "Warrior", "Viking")]
 	public class ClassWarrior : ClassViking
 	{
-		private static readonly string[] AutotrainableSkills = new[] { Specs.Axe, Specs.Hammer, Specs.Sword };
+		private static readonly List<string> DefaultAutoTrainableSkills = new() { Specs.Axe, Specs.Hammer, Specs.Sword };
+		private static readonly List<PlayerRace> DefaultEligibleRaces = new()
+		{
+			 PlayerRace.Dwarf, PlayerRace.Kobold, PlayerRace.Deifrang, PlayerRace.Norseman, PlayerRace.Troll, PlayerRace.Valkyn,
+		};
 
 		public ClassWarrior()
 			: base()
@@ -34,22 +38,16 @@ namespace DOL.GS.PlayerClass
 			m_primaryStat = eStat.STR;
 			m_secondaryStat = eStat.CON;
 			m_tertiaryStat = eStat.DEX;
-			m_wsbase = 460;
-		}
+			m_baseWeaponSkill = 460;
+			m_autotrainableSkills = DefaultAutoTrainableSkills;
+			m_eligibleRaces = DefaultEligibleRaces;
 
-		public override IList<string> GetAutotrainableSkills()
-		{
-			return AutotrainableSkills;
+			LoadClassOverride(eCharacterClass.Warrior);
 		}
 
 		public override bool HasAdvancedFromBaseClass()
 		{
 			return true;
 		}
-
-		public override List<PlayerRace> EligibleRaces => new List<PlayerRace>()
-		{
-			 PlayerRace.Dwarf, PlayerRace.Kobold, PlayerRace.Deifrang, PlayerRace.Norseman, PlayerRace.Troll, PlayerRace.Valkyn,
-		};
 	}
 }

--- a/GameServer/spells/SpellHandler.cs
+++ b/GameServer/spells/SpellHandler.cs
@@ -343,7 +343,7 @@ namespace DOL.GS.Spells
 			// will prevent us from knowing which spell is the oldest and should be canceled - we can go ahead and simply
 			// cancel the last spell in the list (which will result in inconsistent behavior) or change the code that adds
 			// spells to ConcentrationEffects so that it enforces predictable ordering.
-			if (pulsingSpells.Count > 1)
+			if (pulsingSpells.Count > 1 && (player == null || pulsingSpells.Count >= player.CharacterClass.MaxPulsingSpells))
 			{
 				pulsingSpells[pulsingSpells.Count - 1].Cancel(false);
 			}

--- a/Tests/UnitTests/FakeGameObjects.cs
+++ b/Tests/UnitTests/FakeGameObjects.cs
@@ -8,7 +8,7 @@ namespace DOL.UnitTests.Gameserver
 {
     public class FakePlayer : GamePlayer
     {
-        public ICharacterClass fakeCharacterClass = new DefaultCharacterClass();
+        public ICharacterClass fakeCharacterClass = new CharacterClassBase();
         public int modifiedSpecLevel;
         public int modifiedIntelligence;
         public int modifiedToHitBonus;

--- a/Tests/UnitTests/GameObject/UT_GamePlayer.cs
+++ b/Tests/UnitTests/GameObject/UT_GamePlayer.cs
@@ -6,6 +6,12 @@ namespace DOL.UnitTests.Gameserver
     [TestFixture]
     class UT_GamePlayer
     {
+        [OneTimeSetUp]
+        public void LoadCalculators()
+        {
+            GameLiving.LoadCalculators();
+        }
+
         [Test]
         public void Constitution_Level50PlayerWith100ConstBaseBuff_Return62()
         {

--- a/Tests/UnitTests/UT_HereticFocusSpells.cs
+++ b/Tests/UnitTests/UT_HereticFocusSpells.cs
@@ -126,7 +126,7 @@ namespace DOL.UnitTests.Gameserver
         private FakePlayer NewL50Player()
         {
             var player = new FakePlayer();
-            player.fakeCharacterClass = new DefaultCharacterClass();
+            player.fakeCharacterClass = new CharacterClassBase();
             player.Level = 50;
             return player;
         }

--- a/Tests/UnitTests/UT_SpellHandler.cs
+++ b/Tests/UnitTests/UT_SpellHandler.cs
@@ -507,7 +507,7 @@ namespace DOL.UnitTests.Gameserver
 
             public FakePlayerSpy() : base()
             {
-                fakeCharacterClass = new DefaultCharacterClass();
+                fakeCharacterClass = new CharacterClassBase();
                 fakeRegion.fakeElapsedTime = 0;
             }
 


### PR DESCRIPTION
Adds CharacterClassOverride table, which can be used to override the following class properties:
Spec multiplier
Base HP
Base weaponskill, both melee and ranged
Max pulsing spells
Auto trainable skills
Eligible race/class combos

Everything but ClassID is optional, so only properties you wish to override need to be entered.

DB entries are stored in a static dictionary, which is pulled from after inherited constructors have set hardcoded defaults.

A lot of classes had redundant hardcoded properties, which were already set to the same value by classes they inherit from.  I removed most of those to allow base classes to be modified via the DB rather than using multiple rows to alter the inherited classes.  As an example, Classid 0 can be used to set max pulsing spells to 2 for all classes, though the handful of classes that already have it set to 2 will still take precedence, or the Mystic ClassID could be used to change spec multiplier for all Midgard cloth casters.

A few other eccentricities had to be addressed:
Max pulsing spells was only being checked > 1, which hard capped max pulsing spells at 2.  That has been resolved, so classes set to run more than 2 pulsing spells at once are able to do so.
Adding static methods required removing CharacterClassBase being abstract.  This made DefaultCharacterClass redundant.