### PR TITLE
Create a GameInventoryItem when interacting with a GameInventoryObject

### DIFF
--- a/GameServer/gameobjects/GameInventoryObject.cs
+++ b/GameServer/gameobjects/GameInventoryObject.cs
@@ -169,7 +169,7 @@ namespace DOL.GS
 				// if there is an item in the objects target slot then move it to the players inventory
 				if (inventory.ContainsKey((int)toClientSlot))
 				{
-					InventoryItem toItem = inventory[(int)toClientSlot];
+					InventoryItem toItem = GameInventoryItem.Create(inventory[(int)toClientSlot]);
 					thisObject.OnRemoveItem(player, toItem);
 					player.Inventory.AddTradeItem(fromClientSlot, toItem);
 				}


### PR DESCRIPTION
Every item added to the player's inventory needs to be a `GameInventoryItem` type. There exists a condition in `GameInventoryObject`s which allow to exchange two items from a vault, during which the item received loses its type and uses InventoryItem instead.
A player could exploit this behaviour to prevent items from losing condition (for example). Indeed once turned into bare `InventoryItem`s [this code](https://github.com/Dawn-of-Light/DOLSharp/blob/master/GameServer/gameobjects/GameInventoryItem.cs#L285) is no longer called.
Note there are probably other places in the code where we are pushing an `InventoryItem` instead of a `GameInventoryItem` and we forget to `GameInventoryItem.Create`.

This begs some questions:
1. Why do the interface `IGameInventory` and all derivatives not accept an `IGameInventoryItem` instead of a generic `InventoryItem` object. This would effectively add a compile-time check that all items added to a player's inventory (and even a living's inventory - that would not hurt actually) are of the right type.
I had a quick look in the code and actually this change would be large but wouldn't be too difficult because most of the code is articulated around `GameInventoryItem` anyway already.

2. What was the initial reason we splitted `InventoryItem` into `GameInventoryItem` historically? I imagine the first is the database record, and the second is the logical record and it makes sense to have a separation of their concerns.

3. Why does the `GameInventoryItem` inherit from `InventoryItem`? Most of the time this forces a copy of the `InventoryItem` object into the `GameInventoryItem`, while it would probably (?) be simpler to keep a private reference to an `InventoryItem` inside the `GameInventoryItem` and not inherit from it (composition over inheritance).