### PR TITLE
Allow NPC Protect Effect

### DIFF
--- a/GameServer/ai/brain/ControlledNpcBrain.cs
+++ b/GameServer/ai/brain/ControlledNpcBrain.cs
@@ -464,7 +464,7 @@ namespace DOL.AI.Brain
 						case Abilities.Protect:
 							{
 								if (GetPlayerOwner() is GamePlayer player)
-									new ProtectEffect().Start(player);
+									new ProtectEffect().Start(Body, player);
 								break;
 							}
 						case Abilities.ChargeAbility:

--- a/GameServer/ai/brain/StandardMobBrain.cs
+++ b/GameServer/ai/brain/StandardMobBrain.cs
@@ -523,9 +523,9 @@ namespace DOL.AI.Brain
 					if (protectAmount > 0)
 					{
 						aggroamount -= protectAmount;
-						protect.ProtectSource.Out.SendMessage(LanguageMgr.GetTranslation(protect.ProtectSource.Client.Account.Language, "AI.Brain.StandardMobBrain.YouProtDist", player.GetName(0, false),
-						                                                                 Body.GetName(0, false, protect.ProtectSource.Client.Account.Language, Body)), eChatType.CT_System, eChatLoc.CL_SystemWindow);
-						//player.Out.SendMessage("You are protected by " + protect.ProtectSource.GetName(0, false) + " from " + Body.GetName(0, false) + ".", eChatType.CT_System, eChatLoc.CL_SystemWindow);
+						if (protect.ProtectSource is GamePlayer playerSource)
+							playerSource.Out.SendMessage(LanguageMgr.GetTranslation(playerSource.Client.Account.Language, "AI.Brain.StandardMobBrain.YouProtDist", player.GetName(0, false),
+								Body.GetName(0, false, playerSource.Client.Account.Language, Body)), eChatType.CT_System, eChatLoc.CL_SystemWindow);
 
 						lock ((m_aggroTable as ICollection).SyncRoot)
 						{


### PR DESCRIPTION
A while back, I gave custom pets the protect ability to apply to their owners, but it never worked properly as ProtectEffect assumed both the source and target of protect effects were players.  This remedies that by allowing the effect to be applied by and on GameLivings.

The ability handler already limits players to applying the effect to other players in their group, so vanilla behaviour hasn't changed, and the only other possible application currently is custom pets protecting their owners.  That said, I tried to future proof it so that other contexts are possible.  Somebody could create a group vs group fight between NPCs, and have tank NPCs protect healing NPCs, for example.

While I was there, I cleaned up the code and addressed compiler warnings and recommendations.