### PR TITLE
Fix AddToAggroList() LOS Checks

### DIFF
--- a/GameServer/ai/brain/BD Pets/BDHealerBrain.cs
+++ b/GameServer/ai/brain/BD Pets/BDHealerBrain.cs
@@ -37,11 +37,6 @@ namespace DOL.AI.Brain
 	public class BDHealerBrain : BDPetBrain
 	{
 		/// <summary>
-		/// Defines a logger for this class.
-		/// </summary>
-		private static readonly ILog log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
-
-		/// <summary>
 		/// Constructs new controlled npc brain
 		/// </summary>
 		/// <param name="owner"></param>
@@ -214,7 +209,7 @@ namespace DOL.AI.Brain
 		/// </summary>
 		/// <param name="living"></param>
 		/// <param name="aggroamount"></param>
-		public override void AddToAggroList(GameLiving living, int aggroamount) { }
+		public override void AddToAggroList(GameLiving living, int aggroamount, bool CheckLOS = false) { }
 
 		public override void  RemoveFromAggroList(GameLiving living) { }
 

--- a/GameServer/ai/brain/ControlledNpcBrain.cs
+++ b/GameServer/ai/brain/ControlledNpcBrain.cs
@@ -935,7 +935,7 @@ namespace DOL.AI.Brain
 		/// </summary>
 		/// <param name="living"></param>
 		/// <param name="aggroamount"></param>
-		public override void AddToAggroList(GameLiving living, int aggroamount)
+		public override void AddToAggroList(GameLiving living, int aggroamount, bool CheckLOS = false)
 		{
             GameNPC npc_owner = GetNPCOwner();
             if (npc_owner == null || !(npc_owner.Brain is StandardMobBrain))

--- a/GameServer/ai/brain/Guards/KeepGuardBrain.cs
+++ b/GameServer/ai/brain/Guards/KeepGuardBrain.cs
@@ -10,16 +10,12 @@ namespace DOL.AI.Brain
 	/// </summary>
 	public class KeepGuardBrain : StandardMobBrain
 	{
-		/// <summary>
-		/// Defines a logger for this class.
-		/// </summary>
-		private static readonly ILog log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
-
-		public GameKeepGuard guard;
-		/// <summary>
-		/// Constructor for the Brain setting default values
-		/// </summary>
-		public KeepGuardBrain()
+        public GameKeepGuard guard;
+        protected override bool IsKeepGuard => true;
+        /// <summary>
+        /// Constructor for the Brain setting default values
+        /// </summary>
+        public KeepGuardBrain()
 			: base()
 		{
 			AggroLevel = 90;
@@ -55,8 +51,8 @@ namespace DOL.AI.Brain
 
 			if ((guard is GuardArcher || guard is GuardStaticArcher || guard is GuardLord))
 			{
-				// Drop aggro and disengage if the target is out of range.
-				if (Body.IsAttacking && Body.TargetObject is GameLiving living && Body.IsWithinRadius(Body.TargetObject, AggroRange, false) == false)
+                // Drop aggro and disengage if the target is out of range.
+                if (Body.IsAttacking && Body.TargetObject is GameLiving living && Body.IsWithinRadius(Body.TargetObject, AggroRange, false) == false)
 				{
 					Body.StopAttack();
 					RemoveFromAggroList(living);
@@ -72,8 +68,8 @@ namespace DOL.AI.Brain
 			//if we are not doing an action, let us see if we should move somewhere
 			if (guard.CurrentSpellHandler == null && !guard.IsMoving && !guard.AttackState && !guard.InCombat)
 			{
-				// Tolakram - always clear the aggro list so if this is done by mistake the list will correctly re-fill on next think
-				ClearAggroList();
+                // Tolakram - always clear the aggro list so if this is done by mistake the list will correctly re-fill on next think
+                ClearAggroList();
 
 				if (guard.Coordinate.DistanceTo(guard.SpawnPosition, ignoreZ: true) > 50)
 				{
@@ -83,19 +79,18 @@ namespace DOL.AI.Brain
 			//Eden - Portal Keeps Guards max distance
             if (guard.Level > 200 && guard.Coordinate.DistanceTo(guard.SpawnPosition) > 2000)
 			{
-				ClearAggroList();
+                ClearAggroList();
 				guard.WalkToSpawn();
 			}
             else if (guard.InCombat == false && guard.Coordinate.DistanceTo(guard.SpawnPosition) > 6000)
 			{
-				ClearAggroList();
 				guard.WalkToSpawn();
 			}
 
 			// We want guards to check aggro even when they are returning home, which StandardMobBrain does not, so add checks here
 			if (guard.CurrentSpellHandler == null && !guard.AttackState && !guard.InCombat)
 			{
-				CheckPlayerAggro();
+                CheckPlayerAggro();
 				CheckNPCAggro();
 
 				if (HasAggro && Body.IsReturningHome)
@@ -134,7 +129,7 @@ namespace DOL.AI.Brain
 						Body.Say("Want to attack player " + player.Name);
 					}
 
-					AddToAggroList(player, 1);
+					AddToAggroList(player, 1, true);
 					return;
 				}
 			}
@@ -171,7 +166,7 @@ namespace DOL.AI.Brain
 						Body.Say("Want to attack player " + player.Name + " pet " + npc.Name);
 					}
 
-					AddToAggroList(npc, 1);
+					AddToAggroList(npc, 1, true);
 					return;
 				}
 			}
@@ -189,11 +184,6 @@ namespace DOL.AI.Brain
 			if (GameServer.KeepManager.IsEnemy(Body as GameKeepGuard, checkPlayer, true))
 				return AggroLevel;
 			return 0;
-		}
-		
-		public override bool AggroLOS
-		{
-			get { return true; }
 		}
 	}
 }

--- a/GameServer/ai/brain/Guards/Lord.cs
+++ b/GameServer/ai/brain/Guards/Lord.cs
@@ -9,9 +9,10 @@ namespace DOL.AI.Brain
 	/// </summary>
 	public class LordBrain : KeepGuardBrain
 	{
-		public LordBrain() : base()
+        public LordBrain() : base()
 		{
-		}
+			AggroRange = 750;
+        }
 
 		public override void Think()
 		{
@@ -55,20 +56,19 @@ namespace DOL.AI.Brain
 					int iGuardsResponding = 0;
 
 					foreach (GameKeepGuard guard in lord.Component.Keep.Guards.Values)
-						if (guard != null && guard.IsAlive && guard.IsAvailable)
+						if (guard != null)
 							if (guard.AssistLord(lord))
 								iGuardsResponding++;
 
-					string sMessage = $"{lord.Name} bellows for assistance ";
+					string sMessage = $"for assistance ";
 					if (iGuardsResponding == 0)
 						sMessage += "but no guards respond!";
 					else
 						sMessage += $"and {iGuardsResponding} guards respond!";
 
 					foreach (GamePlayer player in lord.GetPlayersInRadius(WorldMgr.VISIBILITY_DISTANCE, true))
-						if (player != null)
-							ChatUtil.SendErrorMessage(player, sMessage);
-				}
+                        player?.YellReceive(Body, sMessage);
+                }
 			}
 			else
 				base.BringFriends(trigger);

--- a/GameServer/ai/brain/IOldAggressiveBrain.cs
+++ b/GameServer/ai/brain/IOldAggressiveBrain.cs
@@ -21,7 +21,8 @@ namespace DOL.AI.Brain
 		/// </summary>
 		/// <param name="living"></param>
 		/// <param name="aggroamount"></param>
-		void AddToAggroList(GameLiving living, int aggroamount);
+		/// <param name="CheckLOS"></param>
+		void AddToAggroList(GameLiving living, int aggroamount, bool CheckLOS = false);
 
 		/// <summary>
 		/// Get current amount of aggro on aggrotable

--- a/GameServer/ai/brain/RoundsBrain.cs
+++ b/GameServer/ai/brain/RoundsBrain.cs
@@ -48,7 +48,7 @@ namespace DOL.AI.Brain
 		/// </summary>
 		/// <param name="living"></param>
 		/// <param name="aggroamount"></param>
-		public override void AddToAggroList(GameLiving living, int aggroamount)
+		public override void AddToAggroList(GameLiving living, int aggroamount, bool CheckLOS = false)
 		{
 			//save current position in path go to here and reload path point
 			//insert path in pathpoint
@@ -57,7 +57,7 @@ namespace DOL.AI.Brain
 			temporaryPathPoint.Prev = Body.CurrentWayPoint.Prev;
 			Body.CurrentWayPoint = temporaryPathPoint;
 			//this path point will be not available after the following point because no link to itself
-			base.AddToAggroList(living, aggroamount);
+			base.AddToAggroList(living, aggroamount, CheckLOS);
 		}
 
 		/// <summary>

--- a/GameServer/keeps/Gameobjects/Guards/GameKeepGuard.cs
+++ b/GameServer/keeps/Gameobjects/Guards/GameKeepGuard.cs
@@ -147,6 +147,8 @@ namespace DOL.GS.Keeps
 		/// <returns>Whether or not we are responding</returns>
 		public virtual bool AssistLord(GuardLord lord)
 		{
+			if (!IsAlive || !IsAvailable || MaxSpeedBase <= 0)
+				return false;
 			Follow(lord, GameNPC.STICKMINIMUMRANGE, int.MaxValue);
 			return true;
 		}

--- a/GameServer/serverproperty/ServerProperties.cs
+++ b/GameServer/serverproperty/ServerProperties.cs
@@ -653,10 +653,16 @@ namespace DOL.GS.ServerProperties
 		[ServerProperty("world", "always_check_los", "Perform a LoS check before aggroing. This can involve a huge lag, handle with care!", false)]
 		public static bool ALWAYS_CHECK_LOS;
 
-		/// <summary>
-		/// Perform checklos on client with each mob
-		/// </summary>
-		[ServerProperty("world", "check_los_during_cast", "Perform a LOS check during a spell cast.", true)]
+        /// <summary>
+        /// Perform checklos on client with each mob
+        /// </summary>
+        [ServerProperty("world", "always_check_los_keep_guard", "Perform a LoS check before keep guards aggro. This can involve a huge lag, handle with care!", false)]
+        public static bool ALWAYS_CHECK_LOS_KEEP_GUARD;
+
+        /// <summary>
+        /// Perform checklos on client with each mob
+        /// </summary>
+        [ServerProperty("world", "check_los_during_cast", "Perform a LOS check during a spell cast.", true)]
 		public static bool CHECK_LOS_DURING_CAST;
 
 		/// <summary>


### PR DESCRIPTION
I noticed PvE keep lords calling BringFriends() and bringing all the keep guards to them before a hostile player was anywhere near them, because keep guards are hardcoded twice over to never check LOS in AddToAggroList().  That appears to cause other problems down the line with keep guard specific code needed to stop them from spamming LOS checks in StartAttack() when they try to attack players who shouldn't be in their aggro tables in the first place.  I've tried to remedy that by adding a server property to enable keep guard LOS in AddToAggroList, which is disabled by default to maintain existing functionality.

In exploring that, I discovered that StandardMobBrain.AddAggroToList()'s LOS check is flawed.  The LOS request is sent to the client, a callback is set up, but the result for all LOS checks are stored in a single local property so only the most recent LOS result is stored, and that property is checked before the callbacks have had time to run.  Each Think() cycle calls CheckNPCAggro() and CheckPlayerAggro(), which make decisions based on the previous cycle's most recent LOS check result, which is then applied to all NPCs and players within aggrorange whether they're in LOS or not.  It's possible the previous LOS check is from a target that is no longer in LOS or even in aggro range.  I expect there are a lot of weird intermittent initial aggro issues stemming from this.

So I've split up AddAggroToList() in a manner akin to StartAttack() and ContinueStartAttack().  If no LOS check is done, AddAggroToList() calls ContinueAddAggroToList(), and behaviour shouldn't change.  If a LOS check is done and there is LOS, CheckAggroLOS() will call ContinueAddAggroToList() and AttackMostWanted() to get the mob to attack immediately instead of waiting for the next Think() cycle.  CheckAggroLOS() doesn't get the aggro amount passed to it, so a list is used to store the pending aggro amounts based on ObjectID.  I've tried to streamline that as much as possible to prevent a race condition in which AddToAggroList() is adding items to the list faster than CheckAggroLOS() is removing them.

There are more issues with keep guards that I need to look into, but I want to make sure the StandardMobBrain LOS checks are correct before I get too far into that.

I expect we're going to want to change a few things before merging this.  I don't have a lot of experience with callbacks and thread safety, so there may be potential issues I've overlooked, or a better way to get aggro amounts into CheckAggroLOS().